### PR TITLE
fix: Search overflows on large screens

### DIFF
--- a/assets/sass/stage.scss
+++ b/assets/sass/stage.scss
@@ -17,6 +17,7 @@
 #search {
     position: absolute;
     width: 80%;
+    max-width: 1056px; // 1320*0.8
     height: 6rem;
     left: 50%;
     transform: translate(-50%);
@@ -25,6 +26,7 @@
 
     @include media-breakpoint-up(md) {
         width: 60%;
+        max-width: 792px; // 1320*0.6
     }
 
     .pagefind-ui__search-input,


### PR DESCRIPTION

## Description

The search overflowed the picture on larger screens. This should fix it.

Before:
![image](https://github.com/user-attachments/assets/e0684fb3-73a3-4d0a-922a-4e1bed05a575)

After:
![image](https://github.com/user-attachments/assets/92086c9a-68d7-4ace-9965-c3de32af73b1)

It's probably better to set the max-width on a parent element and let the search + picture inherit from it, but for some reason it didn't properly work when I tried it.