### PR TITLE
ci: Add PR previews with Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,6 @@
+[build]
+  command = "hugo --gc --minify && npx -y pagefind --site public"
+  publish = "public"
+
+[build.environment]
+  HUGO_VERSION = "0.145.0"


### PR DESCRIPTION
## Description

This PR adds the foundation for PR previews using Netlify. Netlify is a cloud computing company that offers fast & easy deployment of pages. The free plan is sufficient, no credit card is required and as far as I know, pull request previews don't even count for the limit.

Using the provided configuration, a preview is built for each opened PR automatically. 
An example can be seen here, where I tested the functionality: https://github.com/MoritzWeber0/fipguide.github.io/pull/1#issuecomment-2839887790 
This avoids cases like "It works on my machine" and also makes reviews easier. You don't to set up the local environment every time for small changes, instead you can just check the result.

The only disadvantage is that someone with permissions in this repository has to create a Netlify account and link it to the GitHub repository.

It's not required to configure anything else than a page name, the whole configuration is part of the small file `netlify.toml`.

It's just an idea to improve the workflow for non-tech people since they can see the result without setting up the development environment. But I can also understand if you don't want to implement it.

A similar behavior is also possible with an implementation in GitHub Pages, I can have a look at it if wanted. Something like: https://github.com/marketplace/actions/deploy-pr-preview