### PR TITLE
fix: Specify baseURL for netlify deployments

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
-  command = "hugo --gc --minify && npx -y pagefind --site public"
+  command = "hugo --gc --minify -b $DEPLOY_PRIME_URL && npx -y pagefind --site public"
   publish = "public"
 
 [build.environment]


### PR DESCRIPTION
Some links didn't work without the base url.