### PR TITLE
fix: Use correct plural of operator

### DIFF
--- a/archetypes/country.en.md
+++ b/archetypes/country.en.md
@@ -11,7 +11,7 @@ country: '<Name of the country in English>'
 A short summary text that should answer the following questions in this order:
 - Which FIP tickets (FIP 50/FIP free travel tickets) are recognized in the country and by which railway operator?
 - What are the special features of using FIP with the respective railway operator? (Add link to the railway operator)
-- Which railway operator do not recognize FIP tickets and how can you identify these operator in the connection information?
+- Which railway operators do not recognize FIP tickets and how can you identify these operators in the connection information?
 >
 
 ## Insteresting
@@ -33,5 +33,5 @@ A short section about the general train situation in the country. The following 
 The rating criteria are still under development
 >
 
-## Operator without FIP
-- <Operator without FIP>
+## Operators without FIP
+- <Operators without FIP>

--- a/content/country/belgium/index.en.md
+++ b/content/country/belgium/index.en.md
@@ -22,6 +22,6 @@ Belgium has an extensive and dense rail network. Unlike other countries, there i
 
 Still pending
 
-## Operator without FIP
+## Operators without FIP
 
 - European Sleeper

--- a/content/country/slovakia/index.en.md
+++ b/content/country/slovakia/index.en.md
@@ -12,7 +12,7 @@ Slovakia can be easily traveled by train with both FIP 50 and FIP vouchers. Incl
 spoločnosť Slovensko), for which the FIP tickets of ŽSR are valid. 
 Particular attention should be paid to reservation conditions on long-distance trains as well as extended regulations for the free transport of children.
 
-Also operating in Slovakia are the operator LeoExpress and RegioJet, which cannot be used with FIP tickets. These are abbreviated in the connection information with `LE` and `RJ` (not to be confused with `RJ` for RailJet). In case of doubt, the operator can be clarified via the respective provider's website or via [Bahn.de](https://www.bahn.de).
+Also operating in Slovakia are the operators LeoExpress and RegioJet, which cannot be used with FIP tickets. These are abbreviated in the connection information with `LE` and `RJ` (not to be confused with `RJ` for RailJet). In case of doubt, the operator can be clarified via the respective provider's website or via [Bahn.de](https://www.bahn.de).
 
 ## Insteresting
 
@@ -22,6 +22,6 @@ Slovakia has a dense rail network, which mainly consists of two main routes. One
 
 Overall, Slovakia has a good infrastructure and most journeys are operated by ZSSK. This makes it possible to travel a large part of the country with FIP tickets. However, the FIP experience is somewhat marred by reservation requirements (always in 1st class, in 2nd class on Intercity trains) as well as rather poor information systems and often not good scheduling on the branch lines.
 
-## Operator without FIP
+## Operators without FIP
 
 - RegioJet

--- a/content/privacy.en.md
+++ b/content/privacy.en.md
@@ -46,7 +46,7 @@ Your data will only be transferred to external parties in connection with contra
 
 Personal data will be transferred or disclosed by us to the following designated third parties:
 
-* Various service providers or partner operator that support us in order processing, customer information, advertising, and the provision of services, IT service providers, and technical processors (processors according to Art. 28 GDPR). These operator are obliged to comply with all data protection regulations. Strict data protection regulations apply to order data processing, in particular, these operator may only use the data to fulfill their tasks on our behalf. We are responsible for compliance with data protection regulations by these operator and have concluded corresponding order processing agreements with the service providers
+* Various service providers or partner operators that support us in order processing, customer information, advertising, and the provision of services, IT service providers, and technical processors (processors according to Art. 28 GDPR). These operators are obliged to comply with all data protection regulations. Strict data protection regulations apply to order data processing, in particular, these operators may only use the data to fulfill their tasks on our behalf. We are responsible for compliance with data protection regulations by these operators and have concluded corresponding order processing agreements with the service providers
 * To our tax advisor to fulfill our tax obligations
 
 ## Your Rights

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -16,7 +16,7 @@ highlight-important: Important Information
 highlight-inofficial: Unofficial Information
 highlight-tip: Personal Tip
 news-headline: What's new?
-_operator__list_title: Operator supporting FIP
+_operator__list_title: Operators supporting FIP
 _country__list_title: Countries
 _news__list_title: News
 updateDate: Last updated


### PR DESCRIPTION
Instead of operator, use operators as plural form.