### PR TITLE
feat: Add new snippet shortcut and note to incomplete pages

### DIFF
--- a/content/country/netherlands/index.de.md
+++ b/content/country/netherlands/index.de.md
@@ -6,6 +6,8 @@ description: "Informationen über die FIP-Bedingungen für die Niederlande und f
 country: "netherlands"
 ---
 
+{{< snippet wip >}}
+
 ## FIP Nutzung
 
 ## Wissenswertes

--- a/content/country/netherlands/index.en.md
+++ b/content/country/netherlands/index.en.md
@@ -6,6 +6,8 @@ description: "Find out about the FIP conditions for the nederlands and for which
 country: "netherlands"
 ---
 
+{{< snippet wip >}}
+
 ## FIP Information
 
 ## Insteresting

--- a/content/snippets/wip.de.md
+++ b/content/snippets/wip.de.md
@@ -1,0 +1,4 @@
+<!-- This placeholder is needed, otherwise huge recognizes the file as JSON -->
+{{< highlight >}}
+An dieser Seite wird noch gearbeitet und Inhalte können unvollständig sein. Wir freuen uns, wenn du zur Verbesserung dieser Seite beträgst. [Mehr Information auf GitHub](https://github.com/fipguide/fipguide.github.io/wiki/Deutsch).
+{{< /highlight >}}

--- a/content/snippets/wip.en.md
+++ b/content/snippets/wip.en.md
@@ -1,0 +1,4 @@
+<!-- This placeholder is needed, otherwise huge recognizes the file as JSON -->
+{{< highlight >}}
+This page is still under construction and content may be incomplete. We would be happy if you contribute to improve this page. [More information on GitHub](https://github.com/fipguide/fipguide.github.io/wiki/English).
+{{< /highlight >}}

--- a/layouts/shortcodes/snippet.html
+++ b/layouts/shortcodes/snippet.html
@@ -1,0 +1,1 @@
+{{- print "snippets/" (.Get 0) "." .Page.Language.Lang ".md" | readFile | .Page.RenderString -}}


### PR DESCRIPTION
This adds a new shortcut called snippet. It can be used to include reusable markdown content. 

In this PR, a new snippet "wip" (work in progress) was added. To do so, two new files "content/snippets/wip.en.md" and "content/snippets/wip.de.md" were added. To include the snippet, just use the shortcut "snipped" like: 

```
{{< snippet wip >}}
```

The specific "wip" snippet informs about an incomplete page. It has been applied to the (so far) empty Netherlands page.