### PR TITLE
feat: Report issues on pages directly from sidemenu

### DIFF
--- a/assets/sass/fonts.scss
+++ b/assets/sass/fonts.scss
@@ -66,6 +66,7 @@
   font-weight: 400;
   src: url(@fontsource/material-symbols-rounded/files/material-symbols-rounded-latin-400-normal.woff2) format('woff2'), url(@fontsource/material-symbols-rounded/files/material-symbols-rounded-latin-400-normal.woff) format('woff');
   unicode-range: U+0000-00FF,U+0131,U+0152-0153,U+02BB-02BC,U+02C6,U+02DA,U+02DC,U+0304,U+0308,U+0329,U+2000-206F,U+2074,U+20AC,U+2122,U+2191,U+2193,U+2212,U+2215,U+FEFF,U+FFFD;
+  font-display: block; // Do not display icons until font is fully loaded
 }
 
 body {
@@ -79,7 +80,7 @@ body {
   font-weight: normal;
   font-style: normal;
   display: inline-block;
-  font-size: 20px;
+  font-size: 2rem;
   line-height: 1;
   text-transform: none;
   letter-spacing: normal;
@@ -88,4 +89,6 @@ body {
   direction: ltr;
   vertical-align: text-bottom;
   text-decoration: none;
+  width: 1em;
+  height: 1em;
 }

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -36,6 +36,14 @@ markup:
   tableOfContents:
     startLevel: 2
     endLevel: 2
+  goldmark:
+    renderer:
+      # https://gohugo.io/configuration/markup/#rendererunsafe
+      # Safe rendering does omit some styles to prevent XSS,
+      # but since our content is in our control,
+      # we can disable safe rendering.
+      unsafe: true
+
 
 cascade:
   toc: true # enable toc for all pages
@@ -44,3 +52,4 @@ cascade:
 
 params:
   githubDevUrl: 'https://github.dev/fipguide/fipguide.github.io/'
+  gitHubUrl: 'https://github.com/fipguide/fipguide.github.io'

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -23,6 +23,7 @@ toc_name: Inhalt
 _operator__nearby: Angrenzende Betreiber
 toc-backlink: Zurück zu
 editPage: Seite bearbeiten
+reportError: Melde ein Fehler
 anchorLink:
   copy: Link zu diesem Abschnitt kopieren
   copied: Link wurde in die Zwischenablage kopiert

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -23,6 +23,7 @@ toc_name: Contents
 _operator__nearby: Neighboring Operators
 toc-backlink: Back to
 editPage: Edit page
+reportError: Report an error
 anchorLink:
   copy: Copy link to this section
   copied: Link has been copied to the clipboard

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,6 +1,6 @@
 {{- $url := .Destination -}}
 {{- if strings.HasPrefix $url "http" -}}
-<a href="{{ $url }}" target="_blank" rel="noopener noreferrer"><span>{{ .Text }}</span>{{ partial "icon" "arrow_outward" }}</a>
+{{ partial "link" . }}
 {{- else -}}
 <a href="{{ $url }}">{{ .Text }}</a>
 {{- end -}}

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,1 +1,2 @@
 <span class="material-symbols-rounded" aria-hidden="true">{{ . }}</span>
+{{- /* Needed, otherwise links break: https://github.com/fipguide/fipguide.github.io/issues/116 */ -}}

--- a/layouts/partials/link.html
+++ b/layouts/partials/link.html
@@ -1,0 +1,2 @@
+<a href="{{ .Destination }}" target="_blank" rel="noopener noreferrer">{{ .Text }}{{- partial "icon" "arrow_outward" -}}</a>
+{{- /* Needed, otherwise links break: https://github.com/fipguide/fipguide.github.io/issues/116 */ -}}

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -60,9 +60,29 @@
             </ul>
         {{ end }}
         <hr>
-        <a href="{{ .Site.Params.githubDevUrl }}blob/main/content{{ .Path }}/index.{{ .Language }}.md" target="_blank" rel="noopener noreferrer">
-            {{ partial "icon" "edit_square" }}
-            {{ T "editPage"}}
-        </a>
+        {{ partial "link"
+            (dict
+                "Destination" (print .Site.Params.githubDevUrl "blob/main/content" .Path "/index." .Language ".md")
+                "Text" ((print (partial "icon" "edit_square" ) (T "editPage")) | .Page.RenderString)
+            )
+        }}
+        {{ if eq .Page.Type "operator" }}
+            {{ $operator := replace .Path (printf "/%s/" .Page.Type) "" }}
+            {{ partial "link"
+                (dict
+                    "Destination" (print .Site.Params.gitHubUrl "/issues/new?title=Issue+with+operator+" .LinkTitle "&labels=content,operator::" $operator)
+                    "Text" ((print (partial "icon" "bug_report" ) (T "reportError")) | .Page.RenderString)
+                )
+            }}
+        {{ end }}
+        {{ if eq .Page.Type "country" }}
+            {{ $country := replace .Path (printf "/%s/" .Page.Type) "" }}
+            {{ partial "link"
+                (dict
+                    "Destination" (print .Site.Params.gitHubUrl "/issues/new?title=Issue+with+country+" .LinkTitle "&labels=content,country::" $country)
+                    "Text" ((print (partial "icon" "bug_report" ) (T "reportError")) | .Page.RenderString)
+                )
+            }}
+        {{ end }}
     </div>
 </aside>


### PR DESCRIPTION
## Description

Add a link to report issues directly in the sidemenu. Corresponding labels are auto-added to the report.

Depends on https://github.com/fipguide/fipguide.github.io/pull/96. Do not merge before https://github.com/fipguide/fipguide.github.io/pull/96 is merged!

The content was modified in the following languages: <!-- Der Inhalt wurde für die folgenden Sprachen angepasst -->
- [x] English
- [x] German
