### PR TITLE
feat: Auto-fetch "last updated" from Git history

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,6 @@
 ## Checklist
 <!-- Check fields with: [x] / Abhaken von Punkten: [x] -->
 
-- [ ] Changed the date in updatet content pages <!-- Auf Inhaltsseiten wurde das Bearbeitungsdatum angepasst -->
 - [ ] Check the License of new pictures (non-commercial use without attribution) <!-- Die Lizenz neuer Bilder geprüft (nicht-kommerzielle Nutzung ohne Namensnennung) -->
 
 The content was modified in the following languages: <!-- Der Inhalt wurde für die folgenden Sprachen angepasst -->

--- a/archetypes/country.de.md
+++ b/archetypes/country.de.md
@@ -1,5 +1,4 @@
 ---
-date: '{{ .Date }}'
 draft: <true/false>
 title: '<Name des Landes in Deutsch>'
 country: '<Name des Landes auf Englisch>'

--- a/archetypes/country.en.md
+++ b/archetypes/country.en.md
@@ -1,5 +1,4 @@
 ---
-date: '{{ .Date }}'
 draft: <true/false>
 title: '<Name of the country in English>'
 country: '<Name of the country in English>'

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,5 +1,4 @@
 ---
-date: '{{ .Date }}'
 draft: true
 title: '{{ replace .File.ContentBaseName "-" " " | title }}'
 ---

--- a/archetypes/operator.de.md
+++ b/archetypes/operator.de.md
@@ -1,5 +1,4 @@
 ---
-date: '{{ .Date }}'
 draft: <true/false>
 title: '<Abkürzung der Bahngesellschaft>'
 country:

--- a/archetypes/operator.en.md
+++ b/archetypes/operator.en.md
@@ -1,5 +1,4 @@
 ---
-date: '{{ .Date }}'
 draft: <true/false>
 title: '<Abbreviation of the Railway Company>'
 country:

--- a/assets/sass/content.scss
+++ b/assets/sass/content.scss
@@ -2,6 +2,10 @@
     font-size: 1.3rem;
 }
 
+.updateDate > .material-symbols-rounded {
+    font-size: 1.5rem
+}
+
 code {
     font-size: inherit;
     font-weight: 700;

--- a/content/country/belgium/index.de.md
+++ b/content/country/belgium/index.de.md
@@ -1,5 +1,4 @@
 ---
-date: "2024-10-17"
 draft: false
 title: "Belgien"
 description: "Informationen über die FIP-Bedingungen für Belgien und für welche Betreiber Vergünstigungen genutzt werden können."

--- a/content/country/belgium/index.en.md
+++ b/content/country/belgium/index.en.md
@@ -1,5 +1,4 @@
 ---
-date: "2024-10-17"
 draft: false
 title: "Belgium"
 description: "Find out about the FIP conditions for Belgium and for which operators you can benefit from discounts."

--- a/content/country/netherlands/index.de.md
+++ b/content/country/netherlands/index.de.md
@@ -1,5 +1,4 @@
 ---
-date: "2024-10-17"
 draft: false
 title: "Niederlande"
 description: "Informationen über die FIP-Bedingungen für die Niederlande und für welche Betreiber Vergünstigungen genutzt werden können."

--- a/content/country/netherlands/index.en.md
+++ b/content/country/netherlands/index.en.md
@@ -1,5 +1,4 @@
 ---
-date: "2024-10-17"
 draft: false
 title: "Netherlands"
 description: "Find out about the FIP conditions for the nederlands and for which operators you can benefit from discounts."

--- a/content/country/slovakia/index.de.md
+++ b/content/country/slovakia/index.de.md
@@ -1,5 +1,4 @@
 ---
-date: "2024-10-17"
 draft: false
 title: "Slowakei"
 description: "Informationen über die FIP-Bedingungen für die Slowakei und für welche Betreiber Vergünstigungen genutzt werden können."

--- a/content/country/slovakia/index.en.md
+++ b/content/country/slovakia/index.en.md
@@ -1,5 +1,4 @@
 ---
-date: "2024-10-17"
 draft: false
 title: "Slovakia"
 description: "Find out about the FIP conditions for slovakia and for which operators you can benefit from discounts."

--- a/content/generalInformation.de.md
+++ b/content/generalInformation.de.md
@@ -1,5 +1,4 @@
 ---
-date: "2025-05-01"
 title: "Übergreifende Infos"
 description: "Informationen über die allgemeinen Hinweise zu FIP und wie FIP in Anspruch genommen werden kann."
 ---

--- a/content/generalInformation.en.md
+++ b/content/generalInformation.en.md
@@ -1,5 +1,4 @@
 ---
-date: "2025-05-01"
 title: "General Information"
 description: "Find out about the general information on FIP and how you can use FIP."
 ---

--- a/content/operator/eurostar/index.de.md
+++ b/content/operator/eurostar/index.de.md
@@ -1,5 +1,4 @@
 ---
-date: "2025-05-01"
 draft: false
 title: "Eurostar"
 description: "Informationen über die FIP-Bedingungen bei Eurostar."

--- a/content/operator/eurostar/index.en.md
+++ b/content/operator/eurostar/index.en.md
@@ -1,5 +1,4 @@
 ---
-date: "2025-05-01"
 draft: false
 title: "Eurostar"
 description: "Information about FIP conditions for Eurostar."

--- a/content/operator/ns/index.de.md
+++ b/content/operator/ns/index.de.md
@@ -1,5 +1,4 @@
 ---
-date: "2024-10-17"
 draft: false
 title: "NS"
 description: "Informationen über die FIP-Bedingungen bei NS."

--- a/content/operator/ns/index.en.md
+++ b/content/operator/ns/index.en.md
@@ -1,5 +1,4 @@
 ---
-date: "2024-10-17"
 draft: false
 title: "NS"
 description: "Find out about the FIP conditions at NS."

--- a/content/operator/sncb/index.de.md
+++ b/content/operator/sncb/index.de.md
@@ -1,5 +1,4 @@
 ---
-date: "2025-03-25"
 draft: false
 title: "SNCB"
 description: "Informationen über die FIP-Bedingungen bei SNCB."

--- a/content/operator/sncb/index.en.md
+++ b/content/operator/sncb/index.en.md
@@ -1,5 +1,4 @@
 ---
-date: "2025-02-15"
 draft: false
 title: "SNCB"
 description: "Find out about the FIP conditions at SNCB."

--- a/content/operator/zsr/index.de.md
+++ b/content/operator/zsr/index.de.md
@@ -1,5 +1,4 @@
 ---
-date: "2025-04-13"
 draft: false
 title: "ZSR / ZSSK"
 description: "Informationen über die FIP-Bedingungen bei ZSR / ZSSK."

--- a/content/operator/zsr/index.en.md
+++ b/content/operator/zsr/index.en.md
@@ -1,5 +1,4 @@
 ---
-date: "2025-04-13"
 draft: false
 title: "ZSR / ZSSK"
 description: "Find out about the FIP conditions at ZSR / ZSSK."

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,6 +2,7 @@ baseURL: 'https://www.fipguide.org/'
 title: 'FIP Guide'
 
 enableRobotsTXT: true
+enableGitInfo: true
 
 defaultContentLanguage: "en"
 defaultContentLanguageInSubdir: true

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,2 +1,2 @@
-<span class="material-symbols-rounded" aria-hidden="true">{{ . }}</span>
+<span data-pagefind-ignore="all" class="material-symbols-rounded" aria-hidden="true">{{ . }}</span>
 {{- /* Needed, otherwise links break: https://github.com/fipguide/fipguide.github.io/issues/116 */ -}}

--- a/layouts/partials/updateDate.html
+++ b/layouts/partials/updateDate.html
@@ -2,10 +2,26 @@
 {{ $dateHuman := .Date | time.Format ":date_long" }}
 
 {{ if .Date }}
-<div class="updateDate">
+<div class="updateDate" data-pagefind-ignore="all">
   {{ if ne .Type "news" }}
   <span>{{ T "updateDate"}}:</span>
   {{ end }}
   <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
 </div>
+{{ else if .GitInfo }}
+  {{ $dateMachine := .GitInfo.AuthorDate | time.Format "2006-01-02T15:04:05-07:00" }}
+  {{ $dateHuman := .GitInfo.AuthorDate | time.Format ":date_long" }}
+  {{ $href := print .Site.Params.gitHubUrl "/commits/" .GitInfo.Hash "/content" .Path "/index." .Language ".md" }}
+  <a
+    href="{{ $href }}"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="updateDate"
+    aria-label="Open the commit history of the page"
+    data-pagefind-ignore="all"
+  >
+    {{ T "updateDate"}}:
+    <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
+    {{- partial "icon" "arrow_outward" -}}
+  </a>
 {{ end }}


### PR DESCRIPTION
## Description

It's not longer needed to provide the "date" attribute in the page metadata. If it's not provided, the information will be auto-fetched from Git.
Related to #95

The disadvantage with the auto-updated date is that also minor changes like updated grammar, spelling etc. will also update the "last updated" field.