### PR TITLE
fix: Reduce margins for anchors

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -172,7 +172,7 @@ img {
     content: "";
     display: block;
     width: 100%;
-    margin: 1rem 0;
+    margin: 2rem 0;
     background-image: url("/intersector.svg");
     background-position: center;
     background-repeat: no-repeat;

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -172,7 +172,7 @@ img {
     content: "";
     display: block;
     width: 100%;
-    margin: 3.2rem 0;
+    margin: 1rem 0;
     background-image: url("/intersector.svg");
     background-position: center;
     background-repeat: no-repeat;


### PR DESCRIPTION
## Description

This is just a proposal because in my opinion the margins of the anchors / dividers are too large. But it's an personal opinion, so happy to hear other voices :) 

Before: 
![image](https://github.com/user-attachments/assets/9fce9fe2-972f-4f60-85c8-e5febaee3b37)

After: 
![image](https://github.com/user-attachments/assets/733ae8cd-113f-479a-8619-42db2ccc5b47)