### PR TITLE
fix/missing-i11n-key

### DIFF
--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -16,6 +16,7 @@ highlight-important: Wichtige Information
 highlight-inofficial: Inoffizielle Information
 highlight-tip: Persönlicher Tipp
 news-headline: Was gibt's Neues?
+_operator__list_title: Betreiber mit FIP
 updateDate: Zuletzt aktualisiert
 related: Verwandte Seiten
 toc_name: Inhalt

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -16,6 +16,7 @@ highlight-important: Important Information
 highlight-inofficial: Unofficial Information
 highlight-tip: Personal Tip
 news-headline: What's new?
+_operator__list_title: Operators supporting FIP
 updateDate: Last updated
 related: Related Pages
 toc_name: Contents


### PR DESCRIPTION
=> added missing _operator__list_title key in i11n

## Description
_operator__list_title was accidentally removed in https://github.com/fipguide/fipguide.github.io/pull/92.

## Checklist
<!-- Check fields with: [x] / Abhaken von Punkten: [x] -->

- [ ] Changed the date in updatet content pages <!-- Auf Inhaltsseiten wurde das Bearbeitungsdatum angepasst -->
- [ ] Check the License of new pictures (non-commercial use without attribution) <!-- Die Lizenz neuer Bilder geprüft (nicht-kommerzielle Nutzung ohne Namensnennung) -->

The content was modified in the following languages: <!-- Der Inhalt wurde für die folgenden Sprachen angepasst -->
- [ ] English
- [ ] German
