### PR TITLE
fix: #79 footnodes in shortcodes

### DIFF
--- a/archetypes/operator.de.md
+++ b/archetypes/operator.de.md
@@ -40,7 +40,7 @@ Sind Reservierungen möglich und wo besteht eine Reservierungspflicht?
 >
 
 <Für jede Zugkategorie kann ein eigene Abschnitt nach dem folgenden Prinzip eingefügt werden:>
-{{< expander "<Name (Abkürzung)><hinzufügen von ⚠️ für Reservierungspflicht und 1️⃣ für Reservierungspflicht in der 1. Klasse>" <expander-gruppe> >}}
+{{% expander "<Name (Abkürzung)><hinzufügen von ⚠️ für Reservierungspflicht und 1️⃣ für Reservierungspflicht in der 1. Klasse>" <expander-gruppe> %}}
 **Beschreibung:**
 <Beschreibung der Kategorie>
 **Reservierung möglich:** <ja/nein> \
@@ -49,7 +49,7 @@ Sind Reservierungen möglich und wo besteht eine Reservierungspflicht?
 <Preis 2. Klasse> (2. Klasse) \
 <Preis 1. Klasse> (1. Klasse)
 <gibt es keine Festpreise, dann einen groben Preis "ab" angeben>
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ticket- und Reservierungskauf
 
@@ -103,12 +103,12 @@ Können im Zug noch Fahrkarten mit FIP Rabatt gekauft werden, wenn ja wie und gi
 
 ### Grenzpunkte
 
-{{< expander "Grenzpunkte" >}}
+{{% expander "Grenzpunkte" %}}
 | Bahngesellschaft | Grenzpunkte                                                         |
 | ---------------- | ------------------------------------------------------------------- |
 | <Abkürzung der angrenzenden Bahngesellschaft>              | <Grenzpunkte>             |
 
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ermäßigungen
 

--- a/archetypes/operator.en.md
+++ b/archetypes/operator.en.md
@@ -40,7 +40,7 @@ Are reservations possible and where is there a reservation requirement?
 >
 
 <For each train category, a separate section can be added according to the following principle:>
-{{< expander "<Name (Abbreviation)><add ⚠️ for reservation requirement and 1️⃣ for reservation requirement in 1st class>" <expander-group>>}}
+{{% expander "<Name (Abbreviation)><add ⚠️ for reservation requirement and 1️⃣ for reservation requirement in 1st class>" <expander-group> %}}
 **Description:** \
 <Description of the category>
 **Reservation possible:** <yes/no> \
@@ -49,7 +49,7 @@ Are reservations possible and where is there a reservation requirement?
 <Price 2nd class> (2nd class) \
 <Price 1st class> (1st class) \
 <if there are no fixed prices, then provide an approximate price "from">
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ticket and Reservation Purchase
 
@@ -101,12 +101,12 @@ Can tickets with FIP discount still be purchased on the train, if so how and is 
 
 ### Border Points
 
-{{< expander "Border Points" >}}
+{{% expander "Border Points" %}}
 | Railway Company | Border Points                                                         |
 | ---------------- | ------------------------------------------------------------------- |
 | <Abbreviation of the neighboring railway company>              | <Border Points>             |
 
-{{< /expander >}}
+{{% /expander %}}
 
 ## Discounts
 

--- a/content/operator/dsb/index.de.md
+++ b/content/operator/dsb/index.de.md
@@ -23,7 +23,7 @@ FIP Freifahrtscheine und FIP 50 Tickets sind auf Verbindungen der DSB gültig. B
 Innerhalb von Dänemark sind Reservierungen möglich, aber nicht verpflichtend. Bei den grenzüberschreitenden Reisen von und nach Deutschland sind die EC-Züge Hamburg - Kopenhagen im Normalfall im Sommer reservierungspflichtig.
 
 
-{{< expander "InterCityLyn (ICL)" category>}}
+{{% expander "InterCityLyn (ICL)" category %}}
 **Beschreibung:** \
 InterCityLyn-Züge sind die schnellsten Züge der DSB. Sie verkehren mit bis zu 180 km/h mit wenigen Halten auf den Hauptstrecken durch das Land. So verbinden sie beispielsweise Aalborg, Aarhus und Kopenhagen miteiander. \
 **Reservierung möglich:** ja \
@@ -31,9 +31,9 @@ InterCityLyn-Züge sind die schnellsten Züge der DSB. Sie verkehren mit bis zu 
 **Kosten für Reservierung:** 🟢 \
 30 kr (2. Klasse) \
 30 kr (1. Klasse)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "InterCity (IC)" category>}}
+{{% expander "InterCity (IC)" category%}}
 **Beschreibung:** \
 InterCity-Züge sind ähnlich wie die ICL-Züge, halten jedoch öfter und sind langsamer. Sie verkehren auch grenzüberschreitend ins deutsche Flensburg. \
 **Reservierung möglich:** ja \
@@ -41,9 +41,9 @@ InterCity-Züge sind ähnlich wie die ICL-Züge, halten jedoch öfter und sind l
 **Kosten für Reservierung:** 🟢 \
 30 kr (2. Klasse) \
 30 kr (1. Klasse)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "EuroCity (EC)" category>}}
+{{% expander "EuroCity (EC)" category%}}
 **Beschreibung:** \
 EuroCity-Züge verkehren grenzüberschreitend auf der Strecke zwischen Hamburg und Kopenhagen, die aktuell u. a. über Padborg, Kolding und Odense fahren. Sie verkehren Stand 2025 mit ehemaligen IC-Wagen der Deutschen Bahn. Eine Reservierung ist bei einer grenzüberschreitenden Fahrt empfehlenswert, in der Hauptsaison (Sommer) meist auch verpflichtend. \
 **Reservierung möglich:** ja \
@@ -53,22 +53,22 @@ EuroCity-Züge verkehren grenzüberschreitend auf der Strecke zwischen Hamburg u
 |-----------------------------|-----------|-----------|
 | Innerhalb Dänemarks         | 30 kr    | 30 kr    |
 | Grenzüberschreitende Strecken | 5,20 € | 6,50 € |
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Regionalzug (R) ℹ️" >}}
+{{% expander "Regionalzug (R) ℹ️" %}}
 **Beschreibung:** \
 Regional-Züge stellen den Nahverkehr zwischen verschiedenen Orten sicher. Sie halten außerhalb des S-Bahn-Netzes in Kopenhagen an allen Stationen und sind daher eher langsam. \
 ℹ️ Auch Züge von anderen Anbietern werden als "R" angezeigt, daher unbedingt vorher schauen, ob der Betreiber des Zuges die DSB ist. \
 **Reservierung möglich:** nein \
 **Reservierungspflicht:** nein
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "S-tog (S)" >}}
+{{% expander "S-tog (S)" %}}
 **Beschreibung:** \
 Die S-Bahn Kopenhagen wird ebenfalls von der DSB betrieben und kann daher auch mit FIP-Fahrkarten genutzt werden. Sie verkehrt im dichten Takt mit Halt an allen Stationen und ist mit S-Bahn-Systemen in anderen Ländern gut zu vergleichen. \
 **Reservierung möglich:** nein \
 **Reservierungspflicht:** nein
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ticket- und Reservierungskauf
 ### Online
@@ -107,12 +107,12 @@ Von Deutschland aus kann der durchgängige EC Hamburg - Kopenhagen genutzt werde
 Aus Schweden kann entweder aus Malmö über den Öresund gefahren oder von Helsingborg aus die Fähre nach Helsingør genutzt werden. Da in Schweden keine FIP-Ermäßigungen gelten müssen und die Öresund-Strecke zudem von Øresundståg bedient wird, müssen hier auf der kompletten Strecke Malmö - Kopenhagen Normalpreistickets gekauft werden.
 
 ### Grenzpunkte
-{{< expander "Grenzpunkte" >}}
+{{% expander "Grenzpunkte" %}}
 | Bahngesellschaft | Grenzpunkte                                                                 |
 |------------------|----------------------------------------------------------------------------|
 | DB               | Flensburg (Gr), Puttgarden (über Rødby Faerge), Tønder, Warnemünde (über Gedser) |
 | SJ               | Helsingborg (über Helsingør)                                              |
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ermäßigungen
 Kinder unter 5 Jahren reisen kostenlos. Kinder unter 16 Jahren erhalten 50% Rabatt auf den Erwachsenen-Tarif.[^1]
@@ -129,14 +129,14 @@ FIP-Angebote sind nicht gültig in Øresundståg-Zügen von Københavns Hovedban
 FIP 50 Tickets können nicht zwischen Bahnhöfen im Großraum Kopenhagen oder im Raum Aarhus-Grenaa ausgestellt werden. Nur Fahrten über diese Regionen hinaus sind möglich. FIP Freifahrtsscheine sind hingegen auch bei Fahrten nur innerhalb dieser Regionen gültig.
 
 ### Nutzung von Fähren
-{{< highlight inofficial >}}
+{{% highlight inofficial %}}
 Angeblich sind FIP 50 Tickets gültig auf Fähren von Scandlines in Verbindung mit einer Zugreise durch Dänemark. Jedoch konnte dies bisher nicht von uns bestätigt werden. [^1]
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Erfahrungen
-{{< highlight tip >}}
+{{% highlight tip %}}
 Die DSB bietet einen zuverlässigen und komfortablen Service. Die 1. Klasse lohnt sich für FIP-Fahrten in Dänemark besonders, da hier jederzeit Tee, Kaffee, Wasser und Snacks zuschlagsfrei zur Verfügung stehen und morgens auch oft ein kleines Frühstück serviert wird. Zudem erlaubt sie Zugang zur DSB Lounge in Kopenhagen, Odense und Aarhus. Außerdem besteht die Möglichkeit am Bahnhof bei 7/11 ein kostenloses Getränk (Kaffee, Tee, Wasser) zu bekommen. [^2]
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Quellen
 [^1]: [Rail Delivery Group](https://www.raildeliverygroup.com/rst/europe-and-fip.html#Tips)

--- a/content/operator/dsb/index.en.md
+++ b/content/operator/dsb/index.en.md
@@ -22,7 +22,7 @@ FIP Coupons and FIP 50 Tickets are valid on DSB connections. For cross-border jo
 ## Train Categories and Reservations
 Within Denmark, reservations are possible but not mandatory. For cross-border journeys to and from Germany, the EC trains Hamburg - Copenhagen are usually reservation-required during the summer.
 
-{{< expander "InterCityLyn (ICL)" category>}}
+{{% expander "InterCityLyn (ICL)" category%}}
 **Description:** \
 InterCityLyn trains are the fastest trains of DSB. They operate at speeds of up to 180 km/h with few stops on the main routes across the country, connecting cities like Aalborg, Aarhus, and Copenhagen. \
 **Reservation possible:** yes \
@@ -30,9 +30,9 @@ InterCityLyn trains are the fastest trains of DSB. They operate at speeds of up 
 **Reservation cost:** 🟢 \
 30 kr (2nd class) \
 30 kr (1st class)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "InterCity (IC)" category>}}
+{{% expander "InterCity (IC)" category%}}
 **Description:** \
 InterCity trains are similar to ICL trains but stop more frequently and are slower. They also operate cross-border to Flensburg, Germany. \
 **Reservation possible:** yes \
@@ -40,9 +40,9 @@ InterCity trains are similar to ICL trains but stop more frequently and are slow
 **Reservation cost:** 🟢 \
 30 kr (2nd class) \
 30 kr (1st class)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "EuroCity (EC)" category>}}
+{{% expander "EuroCity (EC)" category%}}
 **Description:** \
 EuroCity trains operate cross-border on the route between Hamburg and Copenhagen, currently via Padborg, Kolding, and Odense. As of 2025, they use former IC coaches of Deutsche Bahn. A reservation is recommended for cross-border journeys and usually mandatory during the peak season (summer). \
 **Reservation possible:** yes \
@@ -52,22 +52,22 @@ EuroCity trains operate cross-border on the route between Hamburg and Copenhagen
 |-----------------------------|-----------|-----------|
 | Within Denmark              | 30 kr    | 30 kr    |
 | Cross-border routes         | 5.20 €   | 6.50 €   |
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Regional Train (R) ℹ️" >}}
+{{% expander "Regional Train (R) ℹ️" %}}
 **Description:** \
 Regional trains provide local connections between various locations. Outside the S-train network in Copenhagen, they stop at all stations and are therefore slower. \
 ℹ️ Trains from other operators are also displayed as "R," so always check beforehand if the operator is DSB. \
 **Reservation possible:** no \
 **Reservation mandatory:** no
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "S-tog (S)" >}}
+{{% expander "S-tog (S)" %}}
 **Description:** \
 The Copenhagen S-train is also operated by DSB and can therefore be used with FIP tickets. It operates at frequent intervals, stopping at all stations, and is comparable to S-train systems in other countries. \
 **Reservation possible:** no \
 **Reservation mandatory:** no
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ticket and Reservation Purchase
 ### Online
@@ -106,12 +106,12 @@ From Germany, the direct EC Hamburg - Copenhagen can be used, operating multiple
 From Sweden, travel is possible either via Malmö over the Øresund or via Helsingborg using the ferry to Helsingør. Since FIP discounts do not apply in Sweden and the Øresund route is operated by Øresundståg, regular tickets must be purchased for the entire Malmö - Copenhagen route.
 
 ### Border Points
-{{< expander "Border Points" >}}
+{{% expander "Border Points" %}}
 | Railway Company | Border Points                                                               |
 |------------------|----------------------------------------------------------------------------|
 | DB               | Flensburg (Gr), Puttgarden (via Rødby Faerge), Tønder, Warnemünde (via Gedser) |
 | SJ               | Helsingborg (via Helsingør)
-{{< /expander >}}
+{{% /expander %}}
 
 ## Discounts
 Children under 5 years travel for free. Children under 16 years receive a 50% discount on the adult fare.[^1]
@@ -128,14 +128,14 @@ FIP facilities are not valid on Øresundståg services from Københavns Hovedban
 FIP 50 Tickets cannot be issued for trips between stations within the Copenhagen metropolitan area or the Aarhus-Grenaa region. Only trips beyond these regions are possible. FIP Coupons, however, are valid for trips within these regions.
 
 ### Use of Ferries
-{{< highlight inofficial >}}
+{{% highlight inofficial %}}
 Allegedly, FIP 50 Tickets are valid on Scandlines ferries in connection with a train journey through Denmark. However, this has not yet been confirmed by us. [^1]
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Experiences
-{{< highlight tip >}}
+{{% highlight tip %}}
 DSB offers reliable and comfortable service. The 1st class is particularly worthwhile for FIP journeys in Denmark, as it provides complimentary tea, coffee, water, and snacks at all times, and often a small breakfast in the morning. It also grants access to the DSB Lounge in Copenhagen, Odense, and Aarhus. Additionally, a free drink (coffee, tea, water) can be obtained at 7/11 at the station. [^2]
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Sources
 [^1]: [Rail Delivery Group](https://www.raildeliverygroup.com/rst/europe-and-fip.html#Tips)

--- a/content/operator/eurostar/index.de.md
+++ b/content/operator/eurostar/index.de.md
@@ -27,11 +27,11 @@ Der Erwerb von vergünstigten FIP Globalpreistickets zum Festpreis ist möglich.
 ## Zugkategorien und Reservierungen
 
 
-{{< highlight important >}}
+{{% highlight important %}}
 Alle Züge sind reservierungspflichtig und ein zuggebundenes Ticket muss vor Abfahrt zum FIP Globalpreis gekauft werden.
-{{< /highlight >}}
+{{% /highlight %}}
 
-{{< expander "Eurostar (Blue): London - Paris / Brüssel / Amsterdam ⚠️" category >}}
+{{% expander "Eurostar (Blue): London - Paris / Brüssel / Amsterdam ⚠️" category %}}
 **Beschreibung:** \
 Hochgeschwindigkeitszug zwischen Großbritannien und Europa \
 **Reservierung möglich:** ja \
@@ -42,9 +42,9 @@ Hochgeschwindigkeitszug zwischen Großbritannien und Europa \
 | London - Paris / Brüssel | 39 € / 34,50 £ | 60 € / 52,50 £ |
 | London - Amsterdam / Rotterdam | ? € / 44,50 £ | ? € / 62 £ |
 | Brüssel - Amsterdam / Rotterdam  | ? € / 15,50 £ | ? € / 30,50 £ |
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Eurostar (Red): Paris - Amsterdam / Brüssel / Köln / Dortmund ⚠️" category >}}
+{{% expander "Eurostar (Red): Paris - Amsterdam / Brüssel / Köln / Dortmund ⚠️" category %}}
 **Beschreibung:** \
 Hochgeschwindigkeitszug zwischen Belgien, Deutschland, Frankreich und den Niederlanden \
 **Reservierung möglich:** ja \
@@ -55,22 +55,22 @@ Hochgeschwindigkeitszug zwischen Belgien, Deutschland, Frankreich und den Nieder
 | Fahrt in einem Land | Kein FIP | Kein FIP |
 | Fahrt zwischen 2 Ländern | 18 € | 35 € |
 | Fahrt zwischen 3 Ländern | 20 € | 40 € |
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Eurostar Snow: Amsterdam / Brüssel - Französische Alpen ⛔⚠️" category >}}
+{{% expander "Eurostar Snow: Amsterdam / Brüssel - Französische Alpen ⛔⚠️" category %}}
 **Beschreibung:** \
 Hochgeschwindigkeitszug von Amsterdam und Brüssel in die Französischen Alpen. \
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
 **FIP Globalpreis:** ⛔
-{{< /expander >}}
+{{% /expander %}}
 
 Die Eurostar Kategorie Standard entspricht der 2. Klasse. Die Kategorie Plus entspricht der 1. Klasse und kann nur mit einem FIP Ausweis 1. Klasse gebucht werden.
 Für die Eurostar Kategorie Premiere sind keine FIP Vergünstigungen erhältlich.
 
-{{< highlight tip >}}
+{{% highlight tip %}}
 Bei der Buchung kann teilweise in Pfund oder Euro bezahlt werden. In der Regel sind die Euro-Preise jedoch günstiger.
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Ticket- und Reservierungskauf
 
@@ -119,21 +119,21 @@ Kinder bis einschließlich 3 Jahre reisen kostenfrei, jedoch ohne garantierten S
 
 ### Ticketkontingente
 
-{{< highlight tip >}}
+{{% highlight tip %}}
 Alle FIP-Tarife unterliegen einer Kontingentierung, weshalb eine frühzeitige Buchung zu empfehlen ist.
-{{< /highlight >}}
+{{% /highlight %}}
 
 Für Eurostar-Züge, die freitags, samstags und sonntags zwischen 17.30 Uhr und 19.00 Uhr abfahren, besteht das FIP-Angebot (1. Klasse und 2. Klasse) nicht. [^2]
 
 ### Anschlüsse - HOTNAT
 
-{{< highlight tip >}}
+{{% highlight tip %}}
 Für den Eurostar ist der Kauf von durchgehenden Fahrkarten nicht möglich. Zur Anschlusssicherung beim Umstieg kann jedoch [HOTNAT (Hop on the next available train)](https://www.railteam.eu/de/am-i-eligible-for-hotnat/) genutzt werden.
 
 Wenn beim Umstieg zwischen zwei Hochgeschwindigkeitszügen durch Verspätung oder Ausfall der Anschluss verpasst wird, kann auf den nächsten verfügbaren Zug des gleichen Betreibers ausgewichen werden. Dazu kann am Service Schalter vor Ort die Umbuchung auf den nächsten Zug erfolgen.
 
 HOTNAT gilt nur für den Umstieg von Hochgeschwindigkeitszügen von Railteam Mitgliedern (DB, Eurostar, NS, SBB, SNCB, SNCF, ÖBB) und an den Bahnhöfen Paris, Brüssel, Köln, München, Basel und Zürich. Die Inanspruchnahme ist von der Auslastung der Züge abhängig.
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Quellen
 

--- a/content/operator/eurostar/index.en.md
+++ b/content/operator/eurostar/index.en.md
@@ -26,11 +26,11 @@ The purchase of discounted FIP Global Fare tickets at a fixed rate is possible. 
 
 ## Train Categories and Reservations
 
-{{< highlight important >}}
+{{% highlight important %}}
 All trains require reservations, and a train-specific ticket must be purchased at the FIP Global Fare before departure.
-{{< /highlight >}}
+{{% /highlight %}}
 
-{{< expander "Eurostar (Blue): London - Paris / Brussels / Amsterdam ⚠️" category >}}
+{{% expander "Eurostar (Blue): London - Paris / Brussels / Amsterdam ⚠️" category %}}
 **Description:** \
 High-speed train between Great Britain and Europe \
 **Reservation possible:** yes \
@@ -41,9 +41,9 @@ High-speed train between Great Britain and Europe \
 | London - Paris / Brussels | 39 € / 34.50 £ | 60 € / 52.50 £ |
 | London - Amsterdam / Rotterdam | ? € / 44.50 £ | ? € / 62 £ |
 | Brussels - Amsterdam / Rotterdam  | ? € / 15.50 £ | ? € / 30.50 £ |
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Eurostar (Red): Paris - Amsterdam / Brussels / Cologne / Dortmund ⚠️" category >}}
+{{% expander "Eurostar (Red): Paris - Amsterdam / Brussels / Cologne / Dortmund ⚠️" category %}}
 **Description:** \
 High-speed train between Belgium, Germany, France, and the Netherlands \
 **Reservation possible:** yes \
@@ -54,22 +54,22 @@ High-speed train between Belgium, Germany, France, and the Netherlands \
 | Travel within one country | No FIP | No FIP |
 | Travel between 2 countries | 18 € | 35 € |
 | Travel between 3 countries | 20 € | 40 € |
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Eurostar Snow: Amsterdam / Brussels - French Alps ⛔⚠️" category >}}
+{{% expander "Eurostar Snow: Amsterdam / Brussels - French Alps ⛔⚠️" category %}}
 **Description:** \
 High-speed train from Amsterdam and Brussels to the French Alps. \
 **Reservation possible:** yes \
 **Reservation required:** ⚠️ yes \
 **FIP Global Fare:** ⛔
-{{< /expander >}}
+{{% /expander %}}
 
 The Eurostar Standard category corresponds to 2nd class. The Plus category corresponds to 1st class and can only be booked with a 1st class FIP card.
 FIP discounts are not available for the Eurostar Premiere category.
 
-{{< highlight tip >}}
+{{% highlight tip %}}
 When booking, payment can sometimes be made in pounds or euros. Generally, euro prices are cheaper.
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Ticket and Reservation Purchase
 
@@ -122,21 +122,21 @@ Children up to and including 3 years old travel free of charge but without a gua
 
 ### Ticket Quotas
 
-{{< highlight tip >}}
+{{% highlight tip %}}
 All FIP fares are subject to quotas, so early booking is recommended.
-{{< /highlight >}}
+{{% /highlight %}}
 
 For Eurostar trains departing on Fridays, Saturdays, and Sundays between 5:30 PM and 7:00 PM, the FIP offer (1st Class and 2nd Class) is not available. [^2]
 
 ### Connections - HOTNAT
 
-{{< highlight tip >}}
+{{% highlight tip %}}
 Through tickets cannot be purchased for Eurostar. However, to ensure connections during transfers, [HOTNAT (Hop on the next available train)](https://www.railteam.eu/de/am-i-eligible-for-hotnat/) can be used.
 
 If a connection is missed due to delays or cancellations when transferring between two high-speed trains, the next available train of the same operator can be taken. Rebooking to the next train can be done at the service counter on-site.
 
 HOTNAT is only valid for transfers between high-speed trains of Railteam members (DB, Eurostar, NS, SBB, SNCB, SNCF, ÖBB) and at the stations Paris, Brussels, Cologne, Munich, Basel, and Zurich. Usage depends on train availability.
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Sources
 

--- a/content/operator/sncb/index.de.md
+++ b/content/operator/sncb/index.de.md
@@ -27,7 +27,7 @@ FIP Freifahrtscheine und FIP 50 Tickets sind auf Verbindungen der SNCB gültig. 
 
 Innerhalb Belgiens ist bei der SNCB keine Reservierung erforderlich und in vielen Zügen auch nicht möglich. Beim grenzüberschreitenden ICE nach Deutschland ist eine Reservierung möglich und war beispielsweise im Sommer 2024 auch verpflichtend (nur bei grenzüberschreitenden Reisen).
 
-{{< expander "InterCity Express (ICE)" category >}}
+{{% expander "InterCity Express (ICE)" category %}}
 **Beschreibung:** \
 Hochgeschwindigkeitszüge der Deutschen Bahn, die in Belgien von der SNCB übernommen werden. Sie verkehren zwischen Brüssel (Midi) und Deutschland (Köln / Frankfurt am Main), können jedoch auch innerhalb Belgiens zwischen Bruxelles Midi und Liège-Guillemins mit FIP Fahrscheinen ohne Aufschlag genutzt werden. \
 **Reservierung möglich:** ja \
@@ -35,55 +35,55 @@ Hochgeschwindigkeitszüge der Deutschen Bahn, die in Belgien von der SNCB übern
 **Kosten für Reservierung:** 🟡
 5,20 € (2. Klasse) \
 6,50 € (1. Klasse)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "InterCity (IC)" category >}}
+{{% expander "InterCity (IC)" category %}}
 **Beschreibung:** \
 Anders als in anderen Ländern keine wirklichen Fernzüge, sondern eher schnelle Regionalzüge mit wenigen Halten. \
 **Reservierung möglich:** nein \
 **Reservierungspflicht:** nein \
 **Kosten für Reservierung:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Train local oder Lokale trein (L)" category >}}
+{{% expander "Train local oder Lokale trein (L)" category %}}
 **Beschreibung:** \
 Regionalbahnen mit Halt an meist allen Stationen, in den Verbindungsauskünften oft auch einfach als "R" für Regionalzug zu finden. \
 **Reservierung möglich:** nein \
 **Reservierungspflicht:** nein \
 **Kosten für Reservierung:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Train S oder S-Trein (S)" category >}}
+{{% expander "Train S oder S-Trein (S)" category %}}
 **Beschreibung:** \
 Eine S-Bahn in den Großräumen Antwerpen, Brüssel, Charleroi, Gent oder Lüttich. Sie verbinden die großen Städte mit den Vororten und halten meist überall. Anders als in anderen Ländern zeichnen sich die S-Bahnen hier nicht durch dichtere Takte als bei anderen Zugkategorien aus. In der Verbindungsauskunft werden auch diese manchmal als "R" für Regionalzug zusammengefasst. \
 **Reservierung möglich:** nein \
 **Reservierungspflicht:** nein \
 **Kosten für Reservierung:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Train d’heure de pointe oder Piekuurtrein (P)" category >}}
+{{% expander "Train d’heure de pointe oder Piekuurtrein (P)" category %}}
 **Beschreibung:** \
 Zusätzliche Züge zu den Hauptverkehrszeiten montags bis freitags morgens sowie am späten Nachmittag, in den Verbindungsauskünften oft auch einfach als "R" für Regionalzug zu finden. \
 **Reservierung möglich:** nein \
 **Reservierungspflicht:** nein \
 **Kosten für Reservierung:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Express (E/EXP/EXTRA)" category >}}
+{{% expander "Express (E/EXP/EXTRA)" category %}}
 **Beschreibung:** \
 Zusätzliche Züge bei hohem Verkehrsaufkommen, vor allem in den Sommermonaten zur belgischen Küste. \
 **Reservierung möglich:** nein \
 **Reservierungspflicht:** nein \
 **Kosten für Reservierung:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Tourist (T)" category >}}
+{{% expander "Tourist (T)" category %}}
 **Beschreibung:** \
 Zusätzliche Züge zu bestimmten touristischen Zielen, oft auch einfach als "R" für Regionalzug zu finden. \
 **Reservierung möglich:** nein \
 **Reservierungspflicht:** nein \
 **Kosten für Reservierung:** -
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ticket- und Reservierungskauf
 
@@ -132,19 +132,19 @@ Von Luxemburg aus können grenzüberschreitende SNCB-Züge nach Lüttich oder Br
 
 ### Deutschland
 
-Von Deutschland aus kann der grenzüberschreitende ICE von Frankfurt / Köln / Aachen aus genutzt werden, um ins Netz der SNCB zu kommen. Auch ein Regionalzug der SNCB verkehrt zwischen Aachen und Lüttich. In beiden Fällen wird zusätzlich ein Ticket für den deutschen Abschnitt der DB benötigt. Mit dem Eurostar (ehemals Thalys) kann ebenfalls von Deutschland aus das Netz der SNCB erreicht werden. Hier wird ein spezielles FIP-Ticket von Eurostar auf dem kompletten Abschnitt (auch innerhalb von Belgien) benötigt. ([siehe Eurostar]({{< ref "/operator/eurostar" >}} "Eurostar"))
+Von Deutschland aus kann der grenzüberschreitende ICE von Frankfurt / Köln / Aachen aus genutzt werden, um ins Netz der SNCB zu kommen. Auch ein Regionalzug der SNCB verkehrt zwischen Aachen und Lüttich. In beiden Fällen wird zusätzlich ein Ticket für den deutschen Abschnitt der DB benötigt. Mit dem Eurostar (ehemals Thalys) kann ebenfalls von Deutschland aus das Netz der SNCB erreicht werden. Hier wird ein spezielles FIP-Ticket von Eurostar auf dem kompletten Abschnitt (auch innerhalb von Belgien) benötigt. ([siehe Eurostar]({{% ref "/operator/eurostar" %}} "Eurostar"))
 
 ### Niederlande
 
-Von den Niederlanden aus können grenzüberschreitende Regionalzüge (dazu gehört hier auch der IC) genutzt werden, dafür wird ein zusätzliches FIP-Ticket der NS benötigt. Mit dem Eurostar (ehemals Thalys) kann ebenfalls von den Niederlanden aus das Netz der SNCB erreicht werden. Hier wird ein spezielles FIP-Ticket von Eurostar auf dem kompletten Abschnitt (auch innerhalb von Belgien) benötigt. ([siehe Eurostar]({{< ref "/operator/eurostar" >}} "Eurostar"))
+Von den Niederlanden aus können grenzüberschreitende Regionalzüge (dazu gehört hier auch der IC) genutzt werden, dafür wird ein zusätzliches FIP-Ticket der NS benötigt. Mit dem Eurostar (ehemals Thalys) kann ebenfalls von den Niederlanden aus das Netz der SNCB erreicht werden. Hier wird ein spezielles FIP-Ticket von Eurostar auf dem kompletten Abschnitt (auch innerhalb von Belgien) benötigt. ([siehe Eurostar]({{% ref "/operator/eurostar" %}} "Eurostar"))
 
 ### Frankreich
 
-Von Frankreich aus können grenzüberschreitende Regionalzüge genutzt werden, dafür wird ein zusätzliches FIP-Ticket für den französischen Abschnitt benötigt. Bei den internationalen TGV-Zügen gibt es einen Globalpreis, FIP Freifahrtscheine haben hier keine Gültigkeit, sie werden nicht von der SNCB betrieben. Mit dem Eurostar (ehemals Thalys) kann ebenfalls von Frankreich aus das Netz der SNCB erreicht werden. Hier wird ein spezielles FIP-Ticket von Eurostar auf dem kompletten Abschnitt (auch innerhalb von Belgien) benötigt. ([siehe Eurostar]({{< ref "/operator/eurostar" >}} "Eurostar"))
+Von Frankreich aus können grenzüberschreitende Regionalzüge genutzt werden, dafür wird ein zusätzliches FIP-Ticket für den französischen Abschnitt benötigt. Bei den internationalen TGV-Zügen gibt es einen Globalpreis, FIP Freifahrtscheine haben hier keine Gültigkeit, sie werden nicht von der SNCB betrieben. Mit dem Eurostar (ehemals Thalys) kann ebenfalls von Frankreich aus das Netz der SNCB erreicht werden. Hier wird ein spezielles FIP-Ticket von Eurostar auf dem kompletten Abschnitt (auch innerhalb von Belgien) benötigt. ([siehe Eurostar]({{% ref "/operator/eurostar" %}} "Eurostar"))
 
 ### Grenzpunkte
 
-{{< expander "Grenzpunkte" >}}
+{{% expander "Grenzpunkte" %}}
 | Bahngesellschaft | Grenzpunkte                                                         |
 | ---------------- | ------------------------------------------------------------------- |
 | CFL              | Athus, Gouvy (fr), Sterpenich (fr)                                  |
@@ -155,7 +155,7 @@ Von Frankreich aus können grenzüberschreitende Regionalzüge genutzt werden, d
 | THI              | Antwerpen, Bruxelles, Liège                                         |
 
 
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ermäßigungen
 
@@ -169,9 +169,9 @@ Auf Verbindungen von und zum Flughafen Brüssel Zaventem muss für den FIP Freif
 
 ## Erfahrungen
 
-{{< highlight inofficial >}}
+{{% highlight inofficial %}}
 Die 1. Klasse in den Zügen der SNCB / NMBS wird oft auch mit 2. Klasse Tickets benutzt. Auch ist die 1. Klasse meist nicht viel komfortabler als die 2. Klasse. Anders als in anderen Ländern lohnt sich daher ein Kauf von 1. Klasse Tickets, um hier mehr Platz und Ruhe zu haben, nur bedingt.
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Quellen
 

--- a/content/operator/sncb/index.en.md
+++ b/content/operator/sncb/index.en.md
@@ -27,7 +27,7 @@ FIP Coupons and FIP 50 tickets are valid on SNCB connections. For cross-border t
 
 Within Belgium, no reservation is required for SNCB and in many trains, it is not possible. For the cross-border ICE to Germany, a reservation is possible and was mandatory in summer 2024 (only for cross-border journeys).
 
-{{< expander "InterCity Express (ICE)" category >}}
+{{% expander "InterCity Express (ICE)" category %}}
 **Description:** \
 High-speed trains of Deutsche Bahn, operated by SNCB in Belgium. They run between Brussels (Midi) and Germany (Cologne / Frankfurt am Main), but can also be used with FIP tickets without surcharge within Belgium between Brussels Midi and Liège-Guillemins. \
 **Reservation possible:** yes \
@@ -35,55 +35,55 @@ High-speed trains of Deutsche Bahn, operated by SNCB in Belgium. They run betwee
 **Cost of reservation:** 🟡
 5.20 € (2nd class) \
 6.50 € (1st class)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "InterCity (IC)" category >}}
+{{% expander "InterCity (IC)" category %}}
 **Description:** \
 Unlike in other countries, these are not real long-distance trains, but rather fast regional trains with few stops. \
 **Reservation possible:** no \
 **Reservation required:** no \
 **Cost of reservation:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Train local or Lokale trein (L)" category >}}
+{{% expander "Train local or Lokale trein (L)" category %}}
 **Description:** \
 Regional trains stopping at most stations, often simply referred to as "R" for regional train in connection information. \
 **Reservation possible:** no \
 **Reservation required:** no \
 **Cost of reservation:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Train S or S-Trein (S)" category >}}
+{{% expander "Train S or S-Trein (S)" category %}}
 **Description:** \
 A suburban train in the metropolitan areas of Antwerp, Brussels, Charleroi, Ghent, or Liège. They connect the major cities with the suburbs and usually stop everywhere. Unlike in other countries, the S-trains here do not have denser schedules than other train categories. In the connection information, these are sometimes also summarized as "R" for regional train. \
 **Reservation possible:** no \
 **Reservation required:** no \
 **Cost of reservation:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Train d’heure de pointe or Piekuurtrein (P)" category >}}
+{{% expander "Train d’heure de pointe or Piekuurtrein (P)" category %}}
 **Description:** \
 Additional trains during peak hours from Monday to Friday mornings and late afternoons, often simply referred to as "R" for regional train in connection information. \
 **Reservation possible:** no \
 **Reservation required:** no \
 **Cost of reservation:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Express (E/EXP/EXTRA)" category >}}
+{{% expander "Express (E/EXP/EXTRA)" category %}}
 **Description:** \
 Additional trains during high traffic periods, especially in the summer months to the Belgian coast. \
 **Reservation possible:** no \
 **Reservation required:** no \
 **Cost of reservation:** -
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Tourist (T)" category >}}
+{{% expander "Tourist (T)" category %}}
 **Description:** \
 Additional trains to certain tourist destinations, often simply referred to as "R" for regional train. \
 **Reservation possible:** no \
 **Reservation required:** no \
 **Cost of reservation:** -
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ticket and Reservation Purchase
 
@@ -133,19 +133,19 @@ From Luxembourg, cross-border SNCB trains to Liège or Brussels can be used. In 
 
 ### Germany
 
-From Germany, the cross-border ICE from Frankfurt / Cologne / Aachen can be used to enter the SNCB network. A regional train of SNCB also runs between Aachen and Liège. In both cases, an additional ticket for the German section of DB is required. The Eurostar (formerly Thalys) can also be used from Germany to reach the SNCB network. Here, a special FIP ticket from Eurostar is required for the entire section (including within Belgium) .([see Eurostar]({{< ref "/operator/eurostar" >}} "Eurostar"))
+From Germany, the cross-border ICE from Frankfurt / Cologne / Aachen can be used to enter the SNCB network. A regional train of SNCB also runs between Aachen and Liège. In both cases, an additional ticket for the German section of DB is required. The Eurostar (formerly Thalys) can also be used from Germany to reach the SNCB network. Here, a special FIP ticket from Eurostar is required for the entire section (including within Belgium) .([see Eurostar]({{% ref "/operator/eurostar" %}} "Eurostar"))
 
 ### Netherlands
 
-From the Netherlands, cross-border regional trains (including IC here) can be used, requiring an additional FIP ticket for NS. The Eurostar (formerly Thalys) can also be used from the Netherlands to reach the SNCB network. Here, a special FIP ticket from Eurostar is required for the entire section (including within Belgium) .([see Eurostar]({{< ref "/operator/eurostar" >}} "Eurostar"))
+From the Netherlands, cross-border regional trains (including IC here) can be used, requiring an additional FIP ticket for NS. The Eurostar (formerly Thalys) can also be used from the Netherlands to reach the SNCB network. Here, a special FIP ticket from Eurostar is required for the entire section (including within Belgium) .([see Eurostar]({{% ref "/operator/eurostar" %}} "Eurostar"))
 
 ### France
 
-From France, cross-border regional trains can be used, requiring an additional FIP ticket for the French section. For international TGV trains, there is a global price, and FIP free travel passes are not valid as they are not operated by SNCB. The Eurostar (formerly Thalys) can also be used from France to reach the SNCB network. Here, a special FIP ticket from Eurostar is required for the entire section (including within Belgium) .([see Eurostar]({{< ref "/operator/eurostar" >}} "Eurostar"))
+From France, cross-border regional trains can be used, requiring an additional FIP ticket for the French section. For international TGV trains, there is a global price, and FIP free travel passes are not valid as they are not operated by SNCB. The Eurostar (formerly Thalys) can also be used from France to reach the SNCB network. Here, a special FIP ticket from Eurostar is required for the entire section (including within Belgium) .([see Eurostar]({{% ref "/operator/eurostar" %}} "Eurostar"))
 
 ### Border Points
 
-{{< expander "Border Points" >}}
+{{% expander "Border Points" %}}
 | Railway operator | Border Points                                                         |
 | ---------------- | ------------------------------------------------------------------- |
 | CFL              | Athus, Gouvy (fr), Sterpenich (fr)                                  |
@@ -155,7 +155,7 @@ From France, cross-border regional trains can be used, requiring an additional F
 | SNCF             | Blandain (fr), Givet (fr), Jeumont (fr), Quévy (fr), Tourcoing (fr) |
 | THI              | Antwerpen, Bruxelles, Liège                                         |
 
-{{< /expander >}}
+{{% /expander %}}
 
 ## Discounts
 
@@ -169,9 +169,9 @@ For connections to and from Brussels Zaventem Airport, a surcharge must be paid 
 
 ## Experiences
 
-{{< highlight inofficial >}}
+{{% highlight inofficial %}}
 The first class in SNCB / NMBS trains is often used with second class tickets. Also, the 1st class is usually not much more comfortable than the second class. Unlike in other countries, buying first class tickets to have more space and quiet is only worthwhile to a limited extent.
-{{< /highlight >}}
+{{% /highlight %}}
 
 ## Sources
 

--- a/content/operator/zsr/index.de.md
+++ b/content/operator/zsr/index.de.md
@@ -28,16 +28,16 @@ FIP Freifahrtscheine und FIP 50 Tickets sind auf Verbindungen der ZSSK mit der E
 
 Reservierungspflicht für SC- und IC-Züge. Andere ZSSK Züge erfordern nur eine Reservierung in der 1. Klasse. [^2]
 
-{{< expander "SuperCity (SC) ⚠️" category >}}
+{{% expander "SuperCity (SC) ⚠️" category %}}
 **Beschreibung:** \
 Schnelle Neigetechnik-Züge (Pendolino), die zwischen Prag (Tschechien) und Košice, mit wenigen Halten verkehren. \
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
 **Kosten für Reservierung:** 🔴 Ab 7 € \
 Abhängig von Strecke und Auslastung (inkl. Aufschlag für Zugkategorie)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "InterCity (IC) ⚠️" category >}}
+{{% expander "InterCity (IC) ⚠️" category %}}
 **Beschreibung:** \
 *Zur Zeit ist der Betrieb der Intercity-Zügen aus wirtschaftlichen Gründen eingestellt. Die Züge werden durch EX-Züge ersetzt.* \
 Grenzüberschreitende Fernzüge, die eigenwirtschaftlich von der ZSSK und CD erbracht werden und meist zwischen Prag und Bratislava/Zilina mit wenigen Halten und schneller Durchschnittsgeschwindigkeit verkehren. \
@@ -45,9 +45,9 @@ Grenzüberschreitende Fernzüge, die eigenwirtschaftlich von der ZSSK und CD erb
 **Reservierungspflicht:** ⚠️ ja \
 **Kosten für Reservierung:** 🔴 Ab 7 € \
 Abhängig von Strecke und Auslastung (inkl. Aufschlag für Zugkategorie)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "EuroCity (EC) / RailJet (RJ) ⚠️1️⃣" category >}}
+{{% expander "EuroCity (EC) / RailJet (RJ) ⚠️1️⃣" category %}}
 **Beschreibung:** \
 Grenzüberschreitende Züge zwischen der Slowakei und Tschechien, Österreich oder Ungarn. Sie verkehren oft mit wenigen Halten und im Vergleich relativ hoher Durchschnittsgeschwindigkeit. Die RJ-Züge sind RailJet-Züge der Österreichischen Bundesbahn, die auf slowakischem Abschnitt auch mit ZSSK-Freifahrtscheinen genutzt werden können. \
 *RJ ist gleichzeitig auch die Abkürzung für RegioJet, dort gelten keinerlei FIP-Farscheine.* \
@@ -56,19 +56,19 @@ Grenzüberschreitende Züge zwischen der Slowakei und Tschechien, Österreich od
 **Kosten für Reservierung:** 🟢 \
 1 € (2. Klasse) \
 2 € (1. Klasse)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "EuroNight (EN) ⚠️" category >}}
+{{% expander "EuroNight (EN) ⚠️" category %}}
 **Beschreibung:** \
  EN sind internationale Nachtzüge, bei denen Reservierungspflicht besteht und die Möglichkeit einen Aufpreis für Liege- oder Schlafwagen zu zahlen. Sonst sind sie ähnlich wie die EC. \
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ja \
 **Kosten für Reservierung:** 🔴 \
 Abhängig von Strecke und Auslastung sowie Wagenkategorie (inkl. Aufschlag für Zugkategorie)
-{{< /expander >}}
+{{% /expander %}}
 
 
-{{< expander "Express (Ex) ⚠️1️⃣" category >}}
+{{% expander "Express (Ex) ⚠️1️⃣" category %}}
 **Beschreibung:** \
 Eine Art Interregio mit weniger Halten als ein Regionalzug, aber mehr als beispielsweise den IC. Oft haben sie auch ein Bordrestaurant und fahren mit komfortablen Lok-Wagen-Zügen. \
 **Reservierung möglich:** ja \
@@ -76,9 +76,9 @@ Eine Art Interregio mit weniger Halten als ein Regionalzug, aber mehr als beispi
 **Kosten für Reservierung:** 🟢  \
 1 € (2. Klasse) \
 2 € (1. Klasse)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Rychlik (R) ⚠️1️⃣" category >}}
+{{% expander "Rychlik (R) ⚠️1️⃣" category %}}
 **Beschreibung:** \
 Schnelle Regionalzüge mit Halten an den wichtigsten Bahnhöfen in der Region, eine Art Regionalexpress mit sehr unterschiedlichem Wagenmaterial. \
 **Reservierung möglich:** ja \
@@ -86,9 +86,9 @@ Schnelle Regionalzüge mit Halten an den wichtigsten Bahnhöfen in der Region, e
 **Kosten für Reservierung:** 🟢 \
 1 € (2. Klasse) \
 2 € (1. Klasse)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Osobní vlak (Os) ⚠️1️⃣" category >}}
+{{% expander "Osobní vlak (Os) ⚠️1️⃣" category %}}
 **Beschreibung:** \
 Standard-Regionalzüge, die meist überall halten (es gibt jedoch Ausnahmen). Gerade auf Nebenstrecken verkehren sie oft mit veralteten Wagenmaterial. Teilweise werden sie auch als S-Bahnen vermarktet, ohne jedoch wirklich in einem S-Bahn-Takt zu fahren. \
 **Reservierung möglich:** ja \
@@ -96,7 +96,7 @@ Standard-Regionalzüge, die meist überall halten (es gibt jedoch Ausnahmen). Ge
 **Kosten für Reservierung:** 🟢 \
 1 € (2. Klasse) \
 2 € (1. Klasse)
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ticket- und Reservierungskauf
 
@@ -147,7 +147,7 @@ Von Košice aus fahren grenzüberschreitende Regionalzüge nach Chop und Mukache
 
 ### Grenzpunkte
 
-{{< expander "Grenzpunkte" >}}
+{{% expander "Grenzpunkte" %}}
 | Bahngesellschaft | Grenzpunkte                                                                                                 |
 | ---------------- | ----------------------------------------------------------------------------------------------------------- |
 | ČD               | Čadca (Gr), Hodonin (Gr), Horní Lideč (Gr), Kúty (Gr), Myjava (Gr), Nemšová (Gr), Skalica na Slovensku (Gr) |
@@ -157,7 +157,7 @@ Von Košice aus fahren grenzüberschreitende Regionalzüge nach Chop und Mukache
 | PKP              | Lupkow (Gr), Plaveč (Gr), Skalité (Gr)                                                                      |
 | UZ               | Čierna nad Tisou (Gr)                                                                                       |
 
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ermäßigungen
 

--- a/content/operator/zsr/index.en.md
+++ b/content/operator/zsr/index.en.md
@@ -28,16 +28,16 @@ FIP Coupons and FIP 50 tickets are valid on ZSSK connections with the restrictio
 
 Reservation required for SC and IC trains. Other ZSSK trains only require a reservation in 1st class.  [^2]
 
-{{< expander "SuperCity (SC) ⚠️" category >}}
+{{% expander "SuperCity (SC) ⚠️" category %}}
 **Description:** \
 Fast tilting trains (Pendolino) running between Prague (Czech Republic) and Košice, with few stops. \
 **Reservation possible:** yes \
 **Reservation required:** ⚠️ yes \
 **Cost of reservation:** 🔴 From 7 € \
 Depending on route and occupancy (including surcharge for train category)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "InterCity (IC) ⚠️" category >}}
+{{% expander "InterCity (IC) ⚠️" category %}}
 **Description:** \
 *Currently, the operation of InterCity trains has been suspended for economic reasons. The trains are being replaced by EX trains.* \
 Cross-border long-distance trains operated commercially by ZSSK and CD, usually running between Prague and Bratislava/Zilina with few stops and high average speed. \
@@ -45,9 +45,9 @@ Cross-border long-distance trains operated commercially by ZSSK and CD, usually 
 **Reservation required:** ⚠️ yes \
 **Cost of reservation:** 🔴 From 7 € \
 Depending on route and occupancy (including surcharge for train category)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "EuroCity (EC) / RailJet (RJ) ⚠️1️⃣" category >}}
+{{% expander "EuroCity (EC) / RailJet (RJ) ⚠️1️⃣" category %}}
 **Description:** \
 Cross-border trains between Slovakia and the Czech Republic, Austria, or Hungary. They often run with few stops and relatively high average speed. RJ trains are RailJet trains of the Austrian Federal Railways, which can also be used with ZSSK Coupons on the Slovak section. \
 *RJ is also the abbreviation for RegioJet, where no FIP tickets are valid.* \
@@ -56,18 +56,18 @@ Cross-border trains between Slovakia and the Czech Republic, Austria, or Hungary
 **Cost of reservation:** 🟢 \
 1 € (2nd class) \
 2 € (1st class)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "EuroNight (EN) ⚠️" category >}}
+{{% expander "EuroNight (EN) ⚠️" category %}}
 **Description:** \
 EN are international night trains that require reservations and offer the option to pay a surcharge for couchette or sleeper cars. Otherwise, they are similar to EC trains. \
 **Reservation possible:** yes \
 **Reservation required:** ⚠️ yes \
 **Cost of reservation:** 🔴 \
 Depending on route and occupancy as well as car category (including surcharge for train category)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Express (Ex) ⚠️1️⃣" category >}}
+{{% expander "Express (Ex) ⚠️1️⃣" category %}}
 **Description:** \
 A type of interregional train with fewer stops than a regional train but more than, for example, IC trains. They often have a dining car and run with comfortable locomotive-hauled trains. \
 **Reservation possible:** yes \
@@ -75,9 +75,9 @@ A type of interregional train with fewer stops than a regional train but more th
 **Cost of reservation:** 🟢 \
 1 € (2nd class) \
 2 € (1st class)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Rychlik (R) ⚠️1️⃣" category >}}
+{{% expander "Rychlik (R) ⚠️1️⃣" category %}}
 **Description:** \
 Fast regional trains stopping at the main stations in the region, a type of regional express with very varied rolling stock. \
 **Reservation possible:** yes \
@@ -85,9 +85,9 @@ Fast regional trains stopping at the main stations in the region, a type of regi
 **Cost of reservation:** 🟢 \
 1 € (2nd class) \
 2 € (1st class)
-{{< /expander >}}
+{{% /expander %}}
 
-{{< expander "Osobní vlak (Os) ⚠️1️⃣" category>}}
+{{% expander "Osobní vlak (Os) ⚠️1️⃣" category%}}
 **Description:** \
 Standard regional trains that usually stop everywhere (there are exceptions). Especially on branch lines, they often run with outdated rolling stock. They are sometimes marketed as S-Bahn trains, but without really running on an S-Bahn schedule. \
 **Reservation possible:** yes \
@@ -95,7 +95,7 @@ Standard regional trains that usually stop everywhere (there are exceptions). Es
 **Cost of reservation:** 🟢 \
 1 € (2nd class) \
 2 € (1st class)
-{{< /expander >}}
+{{% /expander %}}
 
 ## Ticket and reservation purchase
 
@@ -146,7 +146,7 @@ From Košice, cross-border regional trains run to Chop and Mukacheve. Since FIP 
 
 ### Border Points
 
-{{< expander "Border points" >}}
+{{% expander "Border points" %}}
 | Railway operator | Border Points                                                                                                 |
 | --------------- | ------------------------------------------------------------------------------------------------------------- |
 | ČD              | Čadca (Gr), Hodonin (Gr), Horní Lideč (Gr), Kúty (Gr), Myjava (Gr), Nemšová (Gr), Skalica na Slovensku (Gr)   |
@@ -156,7 +156,7 @@ From Košice, cross-border regional trains run to Chop and Mukacheve. Since FIP 
 | PKP             | Lupkow (Gr), Plaveč (Gr), Skalité (Gr)                                                                        |
 | UZ              | Čierna nad Tisou (Gr)                                                                                         |
 
-{{< /expander >}}
+{{% /expander %}}
 
 ## Discounts
 

--- a/content/snippets/wip.de.md
+++ b/content/snippets/wip.de.md
@@ -1,4 +1,4 @@
 <!-- This placeholder is needed, otherwise huge recognizes the file as JSON -->
-{{< highlight >}}
+{{% highlight %}}
 An dieser Seite wird noch gearbeitet und Inhalte können unvollständig sein. Wir freuen uns, wenn du zur Verbesserung dieser Seite beträgst. [Mehr Information auf GitHub](https://github.com/fipguide/fipguide.github.io/wiki/Deutsch).
-{{< /highlight >}}
+{{% /highlight %}}

--- a/content/snippets/wip.en.md
+++ b/content/snippets/wip.en.md
@@ -1,4 +1,4 @@
 <!-- This placeholder is needed, otherwise huge recognizes the file as JSON -->
-{{< highlight >}}
+{{% highlight %}}
 This page is still under construction and content may be incomplete. We would be happy if you contribute to improve this page. [More information on GitHub](https://github.com/fipguide/fipguide.github.io/wiki/English).
-{{< /highlight >}}
+{{% /highlight %}}

--- a/layouts/shortcodes/expander.html
+++ b/layouts/shortcodes/expander.html
@@ -1,8 +1,8 @@
 <details name="{{ (.Get 1) }}">
     <summary>
-        {{ (.Get 0) | markdownify }}
+        {{ (.Get 0) }}
     </summary>
     <div>
-        {{ .Inner | markdownify }}
+        {{ .Inner }}
     </div>
 </details>

--- a/layouts/shortcodes/highlight.html
+++ b/layouts/shortcodes/highlight.html
@@ -1,3 +1,3 @@
 <div class="m-text-highlight m-text-highlight--{{ (.Get 0) | markdownify }}" aria-label='{{ T (printf "highlight-%s" (.Get 0)) }}'>
-    <p>{{ .Inner | markdownify }}</p>
+    {{ .Inner }}
 </div>


### PR DESCRIPTION
## Description

Fixing the rendering of footnodes in shortcodes.

![image](https://github.com/user-attachments/assets/64d01ec2-f0fa-437c-854a-26ca058b3b0b)

Compare:
https://github.com/jmooring/hugo-testing/tree/hugo-forum-topic-43832
https://discourse.gohugo.io/t/isolation-of-links-and-footnotes-inside-codeblocks/43795/7

## Checklist
<!-- Check fields with: [x] / Abhaken von Punkten: [x] -->

- [ ] Changed the date in updatet content pages <!-- Auf Inhaltsseiten wurde das Bearbeitungsdatum angepasst -->
- [x] Check the License of new pictures (non-commercial use without attribution) <!-- Die Lizenz neuer Bilder geprüft (nicht-kommerzielle Nutzung ohne Namensnennung) -->

The content was modified in the following languages: <!-- Der Inhalt wurde für die folgenden Sprachen angepasst -->
- [x] English
- [x] German
