### PR TITLE
fix: HTML rendering in expander

### DIFF
--- a/layouts/shortcodes/expander.html
+++ b/layouts/shortcodes/expander.html
@@ -1,8 +1,8 @@
 <details name="{{ (.Get 1) }}">
-    <summary>
-        {{ (.Get 0) }}
-    </summary>
-    <div>
-        {{ .Inner }}
-    </div>
+<summary>
+    {{ (.Get 0) }}
+</summary>
+<div>
+    {{ .Inner }}
+</div>
 </details>


### PR DESCRIPTION
## Description

Fixes an issue where `</div>` was rendered as code block in some expanders.
Unfortunately, indentation code blocks are quite annoying in CommonMark, but I couldn't find a way to disable it.
So without indentation seems to be the way to go.

![image](https://github.com/user-attachments/assets/a8634c56-a5db-4115-80be-41c9dfaea44e)