### PR TITLE
fix: add Ouigo EC and ZSR Highlight

### DIFF
--- a/content/country/belgium/index.de.md
+++ b/content/country/belgium/index.de.md
@@ -11,7 +11,7 @@ In Belgien können sowohl FIP 50 als auch FIP Freifahrtsscheine umfangreich genu
 
 Zusätzlich verkehren internationale [Eurostar]({{< ref "/operator/eurostar" >}} "Eurostar") Züge, welche vergünstigt mit speziellen FIP-Fahrkarten genutzt werden können. Die Züge sind in der Verbindungsauskunft als Zugkategorie `EST` ausgewiesen.
 
-Darüber hinaus verkehren internationale TGV-Züge der SNCF aus Frankreich, für die Freifahrtscheine der belgischen Staatsbahn keine Gültigkeit haben. Für diese Züge lassen sich ausschließlich spezielle FIP Globalpreise buchen.
+Darüber hinaus verkehren internationale TGV-Züge der SNCF aus Frankreich, für die Freifahrtscheine der belgischen Staatsbahn keine Gültigkeit haben. Für diese Züge lassen sich ausschließlich spezielle FIP Globalpreise buchen. Für die Eurocity Züge von Brüssel nach Paris von OuiGo gelten keine FIP Vergünstigungen.
 
 ## Wissenswertes
 
@@ -24,3 +24,4 @@ Noch ausstehend
 ## Betreiber ohne FIP
 
 - European Sleeper
+- OuiGo

--- a/content/country/belgium/index.en.md
+++ b/content/country/belgium/index.en.md
@@ -11,7 +11,7 @@ In Belgium, both FIP 50 and FIP Coupons can be extensively used. The Belgian Nat
 
 Additionally, international [Eurostar]({{< ref "/operator/eurostar" >}} "Eurostar") trains operate, which can be used at a discount with special FIP tickets. The trains are listed as train category `EST` in the connection information.
 
-Furthermore, international TGV trains of the SNCF from France operate, for which the free travel passes of the Belgian National Railway Company are not valid. Only special FIP global prices can be booked for these trains.
+Furthermore, international TGV trains of the SNCF from France operate, for which the free travel passes of the Belgian National Railway Company are not valid. Only special FIP global prices can be booked for these trains. For the Eurocity trains from Brussels tp Paris operated by OuiGo, no FIP discounts apply.
 
 ## Insteresting
 
@@ -24,3 +24,4 @@ Still pending
 ## Operators without FIP
 
 - European Sleeper
+- OuiGo

--- a/content/operator/zsr/index.de.md
+++ b/content/operator/zsr/index.de.md
@@ -25,7 +25,9 @@ FIP Freifahrtscheine und FIP 50 Tickets sind auf Verbindungen der ZSSK mit der E
 
 ## Zugkategorien und Reservierungen
 
+{{% highlight important %}}
 Reservierungspflicht für SC- und IC-Züge. Andere ZSSK Züge erfordern nur eine Reservierung in der 1. Klasse. [^2]
+{{% /highlight %}}
 
 {{% expander "SuperCity (SC) ⚠️" category %}}
 **Beschreibung:** \

--- a/content/operator/zsr/index.en.md
+++ b/content/operator/zsr/index.en.md
@@ -25,7 +25,9 @@ FIP Coupons and FIP 50 tickets are valid on ZSSK connections with the restrictio
 
 ## Train categories and reservations
 
+{{% highlight important %}}
 Reservation required for SC and IC trains. Other ZSSK trains only require a reservation in 1st class.  [^2]
+{{% /highlight %}}
 
 {{% expander "SuperCity (SC) ⚠️" category %}}
 **Description:** \


### PR DESCRIPTION
## Description

- No FIP on OuiGo Eurocity Services from Brussels to Paris
- Highlight the ZSR info

## Checklist
<!-- Check fields with: [x] / Abhaken von Punkten: [x] -->

- [x] Check the License of new pictures (non-commercial use without attribution) <!-- Die Lizenz neuer Bilder geprüft (nicht-kommerzielle Nutzung ohne Namensnennung) -->

The content was modified in the following languages: <!-- Der Inhalt wurde für die folgenden Sprachen angepasst -->
- [x] English
- [x] German
