### PR TITLE
fix: standardize wording and spain&renfe information

### DIFF
--- a/archetypes/country/index.en.md
+++ b/archetypes/country/index.en.md
@@ -11,7 +11,7 @@ country: '{{ .File.ContentBaseName }}'
 
 <!--
     A short summary text that should answer the following questions in this order:
-    - Which FIP tickets (FIP 50/FIP free travel tickets) are recognized in the country and by which railway operator?
+    - Which FIP tickets (FIP 50/FIP Coupon tickets) are recognized in the country and by which railway operator?
     - What are the special features of using FIP with the respective railway operator? (Add link to the railway operator)
     - Which railway operators do not recognize FIP tickets and how can you identify these operators in the connection information?
 -->

--- a/archetypes/operator/index.de.md
+++ b/archetypes/operator/index.de.md
@@ -47,6 +47,8 @@ FIP Globalpreis: <✅/⛔>
   Im Titel können folgende Emojis verwendet werden:
   - ⚠️ für eine generelle Reservierungspflicht
   - 1️⃣ für eine Reservierungspflicht in der 1. Klasse
+  - ⛔ für eine Nichtanerkennung von FIP
+  - ℹ️ für Verwechslungsgefahr mit anderen Bahngesellschaften/Zugkategorien
 -->
 {{% expander "Zugkategorie" "category" %}}
 <!-- Ersetze Zugkategorie mit dem Name der Zugkategorie, z.B. ICE. -->
@@ -57,7 +59,28 @@ FIP Globalpreis: <✅/⛔>
 **Kosten für Reservierung:** <!-- Füge hier die Kosten nach Klasse, Strecke, etc. hinzu. Gibt es keine Festpreise, dann eine Preisspanne oder Beispiele angeben. --> \
 2\. Klasse: XX€ \
 1\. Klasse: XX€
+<!-- Wenn FIP nicht gültig ist, ergänze folgendes:
+**FIP:** ⛔ FIP wird nicht anerkannt
+-->
+<!-- Wenn es FIP Globalpreise gibt, ergänze folgendes:
+**FIP Globalpreis:**
+-->
 {{% /expander %}}
+
+## Klassenkategorien
+
+
+<!--
+  Wenn die Klassenkategorien zusätzliche/andere Klassen zu 1. und 2. Klasse haben, dann können diese hier beschrieben werden. Ansonsten kann dieser Abschnitt entfernt werden.
+-->
+
+<!--
+
+**Standard**: Vergleichbar mit der 2. Klasse. \
+**Plus**: 1. Klasse ohne Verpflegung. Ein FIP-Ausweis für die 1. Klasse wird benötigt. \
+**Premium**: 1. Klasse inkl. Verpflegung. Nicht mit FIP buchbar.
+
+-->
 
 ## Ticket- und Reservierungskauf
 

--- a/archetypes/operator/index.en.md
+++ b/archetypes/operator/index.en.md
@@ -46,7 +46,9 @@ FIP Global Fare: <✅/⛔>
   For each train category, a separate section can be added according to the following principle:
   In the title, the following emojis can be used:
   - ⚠️ for a general reservation requirement
-  - 1️⃣ für a reservation requirement in 1st class
+  - 1️⃣ for a reservation requirement in 1st class
+  - ⛔ for a non-acceptance of FIP
+  - ℹ️ for confusion with other railway companies/train categories
 -->
 {{% expander "Train category" "category" %}}
 <!-- Replace "Train category" with the name of the category, e.g. ICE. -->
@@ -56,8 +58,27 @@ FIP Global Fare: <✅/⛔>
 **Reservation required:** <⚠️ yes/no/⚠️1️⃣ only first class> \
 **Cost of reservation:** <!-- Enter the costs here by class, route, etc. If there are no fixed prices, then provide a price range or examples. --> \
 2nd class: XX€ \
-1st class: XX€
+<!-- If FIP is not valid, add the following:
+**FIP:** ⛔ FIP is not accepted
+-->
+<!-- If there are FIP Global Fares, add the following:
+**FIP Global Fare:**
+-->
 {{% /expander %}}
+
+## Class Categories
+
+<!--
+  If the class categories include additional/different classes beyond 1st and 2nd class, they can be described here. Otherwise, this section can be removed.
+-->
+
+<!--
+
+**Standard**: Comparable to 2nd class. \
+**Plus**: 1st class without catering. An FIP pass for 1st class is required. \
+**Premium**: 1st class including catering. Not bookable with FIP.
+
+-->
 
 ## Ticket and Reservation Purchase
 

--- a/content/country/spain/index.de.md
+++ b/content/country/spain/index.de.md
@@ -19,3 +19,4 @@ Die Bahnhöfe haben meist Ticketbarrieren, es wird hier ein gültiges digitales 
 
 - Iryo
 - OUIGO
+- Avlo

--- a/content/country/spain/index.en.md
+++ b/content/country/spain/index.en.md
@@ -7,15 +7,16 @@ country: "spain"
 
 ## FIP Information
 
-In Spain, using FIP is not always straightforward, as simply boarding and riding along rarely works. On most routes, a ticket at the FIP global fare must be booked in advance. Since only as many tickets are sold as there are available seats, this purchase should not be made at the last minute (even for regional trains). [Renfe]({{< ref "/operator/renfe" >}} "Renfe") is the largest railway operator in Spain and accepts FIP. On lucrative routes, it competes with many private providers like OUIGO or Iryo, which do not accept FIP. Another provider in the Basque Country is Euskotren, which also accepts FIP.
+In Spain, using FIP is not always straightforward, as simply boarding and riding along rarely works. On most routes, a ticket at the FIP Global Fare must be booked in advance. Since only as many tickets are sold as there are available seats, this purchase should not be made at the last minute (even for regional trains). [Renfe]({{< ref "/operator/renfe" >}} "Renfe") is the largest railway operator in Spain and accepts FIP. On lucrative routes, it competes with many private providers like OUIGO or Iryo, which do not accept FIP. Another provider in the Basque Country is Euskotren, which also accepts FIP.
 
 ## Insteresting
 
 Spain does not have a particularly dense rail network; instead, it mainly consists of new high-speed standard gauge lines and older regional lines in Iberian broad gauge. The focus is on (mostly fast) connections between major cities. In addition, there are suburban trains in and around the metropolitan areas that ensure dense local transport.
 
-Stations usually have ticket barriers, which require a valid digital or analog ticket on a card to pass through. With FIP free travel coupons, staff on site must be approached so they can manually open the barriers. Furthermore, for long-distance travel, luggage checks are conducted at the stations. While not as strict as at airports, they still take time. Therefore, it is recommended to arrive at the station at least 30 minutes before departure for such trips.
+Stations usually have ticket barriers, which require a valid digital or analog ticket on a card to pass through. With FIP Coupons, staff on site must be approached so they can manually open the barriers. Furthermore, for long-distance travel, luggage checks are conducted at the stations. While not as strict as at airports, they still take time. Therefore, it is recommended to arrive at the station at least 30 minutes before departure for such trips.
 
 ## Operators without FIP
 
 - Iryo
 - OUIGO
+- Avlo

--- a/content/news/4/index.en.md
+++ b/content/news/4/index.en.md
@@ -4,7 +4,7 @@ draft: false
 title: "Eurostar Price Increase"
 ---
 
-Starting May 1, 2025, Eurostar will increase prices on all FIP tickets by €5 or £5. The price increase applies to all FIP global fares for Eurostar Blue and Eurostar Red (Thalys) in all classes. The new prices apply to all bookings made from May 1, 2025 onwards. [^1]
+Starting May 1, 2025, Eurostar will increase prices on all FIP tickets by €5 or £5. The price increase applies to all FIP Global Fares for Eurostar Blue and Eurostar Red (Thalys) in all classes. The new prices apply to all bookings made from May 1, 2025 onwards. [^1]
 
 The new prices can be found on the [Eurostar page]({{< ref "/operator/eurostar" >}} "Eurostar").
 

--- a/content/operator/eurostar/index.de.md
+++ b/content/operator/eurostar/index.de.md
@@ -61,7 +61,7 @@ Hochgeschwindigkeitszug zwischen Belgien, Deutschland, Frankreich und den Nieder
 Hochgeschwindigkeitszug von Amsterdam und Brüssel in die Französischen Alpen. \
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
-**FIP Globalpreis:** ⛔
+**FIP:** ⛔ FIP wird nicht anerkannt
 {{% /expander %}}
 
 Die Eurostar Kategorie Standard entspricht der 2. Klasse. Die Kategorie Plus entspricht der 1. Klasse und kann nur mit einem FIP Ausweis 1. Klasse gebucht werden.
@@ -70,6 +70,12 @@ Für die Eurostar Kategorie Premiere sind keine FIP Vergünstigungen erhältlich
 {{% highlight tip %}}
 Bei der Buchung kann teilweise in Pfund oder Euro bezahlt werden. In der Regel sind die Euro-Preise jedoch günstiger.
 {{% /highlight %}}
+
+## Klassenkategorien
+
+**Standard**: Vergleichbar mit der 2. Klasse. \
+**Plus**: 1. Klasse inkl. Mahlzeit (nur Eurostar Blue). Ein FIP-Ausweis für die 1. Klasse wird benötigt. \
+**Premium**: 1. Klasse inkl. umfangreicher Verpflegung und Loungezugang. Nicht mit FIP buchbar.
 
 ## Ticket- und Reservierungskauf
 

--- a/content/operator/eurostar/index.en.md
+++ b/content/operator/eurostar/index.en.md
@@ -60,7 +60,7 @@ High-speed train between Belgium, Germany, France, and the Netherlands \
 High-speed train from Amsterdam and Brussels to the French Alps. \
 **Reservation possible:** yes \
 **Reservation required:** ⚠️ yes \
-**FIP Global Fare:** ⛔
+**FIP:** ⛔ FIP is not accepted
 {{% /expander %}}
 
 The Eurostar Standard category corresponds to 2nd class. The Plus category corresponds to 1st class and can only be booked with a 1st class FIP card.
@@ -69,6 +69,12 @@ FIP discounts are not available for the Eurostar Premiere category.
 {{% highlight tip %}}
 When booking, payment can sometimes be made in pounds or euros. Generally, euro prices are cheaper.
 {{% /highlight %}}
+
+## Class Categories
+
+**Standard**: Comparable to 2nd class.
+**Plus**: 1st class including a meal (only Eurostar Blue). A 1st class FIP pass is required.
+**Premium**: 1st class including extensive catering and lounge access. Not available with FIP.
 
 ## Ticket and Reservation Purchase
 

--- a/content/operator/renfe/index.de.md
+++ b/content/operator/renfe/index.de.md
@@ -12,7 +12,7 @@ Renfe Operadora ist ein staatliches spanisches Eisenbahnunternehmen. Hierzu geh�
 ## Zusammenfassung
 
 - FIP Freifahrtsscheine werden in Pendlerzügen (hauptsächlich S-Bahnen) akzeptiert, jedoch nicht in reservierungspflichtigen Zügen.
-- Für reservierungspflichtige Züge können Tickets zum Pauschalpreis inkl. Reservierung erworden werden, FIP Freifahrtsscheine werden nicht benötigt.
+- Für reservierungspflichtige Züge können Tickets zum FIP Globalpreis (Distanzunabhängig) inkl. Reservierung erworden werden, FIP Freifahrtsscheine werden nicht benötigt.
 - In Avlo-Zügen wird FIP nicht akzeptiert.
 
 ## Gültigkeit FIP-Tickets
@@ -23,6 +23,10 @@ FIP 50 Tickets: ✅ (Ausnahmen: Reservierungspflichtige Züge) \
 FIP Globalpreis: ✅ für reservierungspflichtige Züge außer Avlo
 
 ## Zugkategorien und Reservierungen
+
+{{% highlight important %}}
+Nur S-Bahnen sind mit FIP Freifahrtsscheinen uneingeschränkt nutzbar. In anderen Zügen muss in der Regel ein Ticket zum FIP Globalpreis erworben werden.
+{{% /highlight %}}
 
 ### Langstrecke
 
@@ -37,10 +41,12 @@ Langstreckenverbindungen mit normalspurigen Hochgeschwindigkeitszügen (bis 300�
 - 23,50€ (Premium)
 {{% /expander %}}
 
-{{% expander "Avlo ⚠️" "long-distance" %}}
+{{% expander "Avlo ⛔⚠️" "long-distance" %}}
 **Beschreibung:** \
 Niedrigpreis-Hochgeschwindigkeitszüge (bis 300 km/h). \
-⚠️ FIP wird nicht anerkannt.
+**Reservierung möglich:** ja \
+**Reservierungspflicht:** ⚠️ ja \
+**FIP:** ⛔ FIP wird nicht anerkannt
 {{% /expander %}}
 
 {{% expander "Euromed ⚠️" "long-distance" %}}
@@ -97,29 +103,15 @@ Beschleunigter Regionalverkehr. FIP Freifahrtsscheine werden nur auf nicht reser
 {{% expander "Cercanías / Rodalia / Aldiriak" "local-transportation" %}}
 **Beschreibung:** \
 Pendlerzüge, vergleichbar mit einer S-Bahn. FIP Freifahrtsscheine sind hier uneingeschränkt gültig. \
-**Reservierungspflicht:** nein \
+**Reservierung möglich:** nein \
+**Reservierungspflicht:** nein
 {{% /expander %}}
 
 ## Klassenkategorien
 
-{{% expander "Elige Standard / Turista" "local-transportation" %}}
-Vergleichbar mit der 2. Klasse
-{{% /expander %}}
-
-{{% expander "Elige Confort" "local-transportation" %}}
-1. Klasse ohne Verpflegung. Ein FIP-Ausweis für die 1. Klasse wird benötigt.
-{{% /expander %}}
-
-{{% expander "Premium" "local-transportation" %}}
-1. Klasse inkl. Mahlzeit. Ein FIP-Ausweis für die 1. Klasse wird benötigt.
-{{% /expander %}}
-
-## Internationale Verbindungen
-
-{{% expander "Celta: Porto ↔️ Vigo" "international" %}}
-Der Celta ist ein internationaler Kooperationszug zwischen der Renfe und der portugiesischen CP. \
-**FIP Globalpreis (Distanzunabhängig):** 4 €
-{{% /expander %}}
+**Elige Standard / Turista**: Vergleichbar mit der 2. Klasse. \
+**Elige Confort**: 1. Klasse ohne Verpflegung. Ein FIP-Ausweis für die 1. Klasse wird benötigt. \
+**Premium**: 1. Klasse inkl. Verpflegung. Ein FIP-Ausweis für die 1. Klasse wird benötigt.
 
 ## Ticket- und Reservierungskauf
 
@@ -168,6 +160,11 @@ Die Verbindungen zwischen Spanien und Portugal sind aktuell nur sehr spärlich v
 {{% /expander %}}
 
 ## Tarifliche Besonderheiten
+
+### Celta: Porto - Vigo
+Der Celta ist ein internationaler Kooperationszug zwischen der Renfe und der portugiesischen CP. \
+**FIP Globalpreis (Distanzunabhängig):** 4 €
+
 ### Reiseunterbrechung
 Bei FIP 50 und FIP Globalpreis Tickets darf die Reise zwischenzeitlich nicht unterbrochen werden.[^2]
 

--- a/content/operator/renfe/index.en.md
+++ b/content/operator/renfe/index.en.md
@@ -12,64 +12,69 @@ Renfe Operadora is a Spanish state-owned railroad company. It operates comfortab
 ## Summary
 
 - FIP free tickets are accepted on commuter trains (mainly suburban trains), but not on trains requiring reservations.
-- For trains requiring reservations, tickets can be purchased at a flat rate including reservation, FIP free coupons are not required.
+- For trains requiring reservations, tickets can be purchased at the FIP Global Fare (regardless of distance), including the reservation; FIP Coupons are not needed.
 - FIP is not accepted on Avlo and metro trains.
 
 ## Validity of FIP tickets
 
 FIP free ticket: ✅ (exceptions: trains requiring reservations) \
-FIP free travel for relatives: ⛔ \
+FIP Coupons for relatives: ⛔ \
 FIP 50 tickets: ✅ (exceptions: trains requiring reservations, metro) \
-FIP global price: ✅ for trains subject to reservation except Avlo
+FIP Global Fare: ✅ for trains subject to reservation except Avlo
 
 ## Train categories and reservations
+{{% highlight important %}}
+Only commuter trains can be used without restrictions with FIP Coupons. For other trains, a ticket at the FIP Global Fare usually needs to be purchased.
+{{% /highlight %}}
 
 ### Long distance
 
 {{% expander "AVE ⚠️" "long-distance" %}}
 **Description:** \
-Long-distance connections with high-speed trains (up to 300 km/h). FIP free travel passes are not accepted. \
+Long-distance connections with high-speed trains (up to 300 km/h). FIP Coupons are not accepted. \
 **Reservation possible:** yes \
 **Reservation required:** ⚠️ yes \
-**FIP global price (independent of distance):**
+**FIP Global Fare (regardless of distance):**
 - 10 € (Elige)
 - 13 € (Elige Confort)
 - 23,50€ (Premium)
 {{% /expander %}}
 
-{{% expander "Avlo ⚠️" "long-distance" %}}
-**Beschreibung:** \
+{{% expander "Avlo ⛔⚠️" "long-distance" %}}
+**Description:** \
 Low-cost high-speed trains (up to 300 km/h). \
-⚠️ FIP is not accepted.
+**Reservation possible:** yes \
+**Reservation required:** ⚠️ yes \
+**FIP:** ⛔ FIP is not accepted
 {{% /expander %}}
 
 {{% expander "Euromed ⚠️" "long-distance" %}}
-**Beschreibung:** \
-High-speed trains that can be re-gauged (Figueres <-> Alicante). FIP free travel passes are not accepted. \
-**Reservierung möglich:** yes \
-**Reservierungspflicht:** ⚠️ yes \
-**FIP Globalpreis (Distanzunabhängig):**
+**Description:** \
+High-speed trains that can be re-gauged (Figueres <-> Alicante). FIP Coupons are not accepted. \
+**Reservation possible:** yes \
+**Reservation required:** ⚠️ yes \
+**FIP Global Fare (regardless of distance):**
 - 6,50 € (Elige)
 - 10 € (Elige Confort)
 - 23,50€ (Premium)
 {{% /expander %}}
 
 {{% expander "Alvia ⚠️" "long-distance" %}}
-**Beschreibung:** \
-High-speed trains that can be re-gauged (up to 250 km/h). FIP free travel passes are not accepted. \
-**Reservierung möglich:** yes \
-**Reservierungspflicht:** ⚠️ yes \
-**FIP Globalpreis (Distanzunabhängig):**
+**Description:** \
+High-speed trains that can be re-gauged (up to 250 km/h). FIP Coupons are not accepted. \
+**Reservation possible:** yes \
+**Reservation required:** ⚠️ yes \
+**FIP Global Fare (regardless of distance):**
 - 6,50 € (Elige)
 - 10 € (Elige Confort)
 {{% /expander %}}
 
 {{% expander "Intercity (IC) ⚠️" "long-distance" %}}
-**Beschreibung:** \
-Passenger trains between regional and high-speed services (up to 250 km/h). FIP free travel passes are not accepted. \
-**Reservierung möglich:** yes \
-**Reservierungspflicht:** ⚠️ yes \
-**FIP Globalpreis (Distanzunabhängig):**
+**Description:** \
+Passenger trains between regional and high-speed services (up to 250 km/h). FIP Coupons are not accepted. \
+**Reservation possible:** yes \
+**Reservation required:** ⚠️ yes \
+**FIP Global Fare (regardless of distance):**
 - 6,50 € (Elige)
 - 10 € (Elige Confort)
 {{% /expander %}}
@@ -78,61 +83,40 @@ Passenger trains between regional and high-speed services (up to 250 km/h). FIP 
 
 {{% expander "Avant ⚠️" "middle-distance" %}}
 **Description:** \
-High-speed trains, travel time < 90 minutes. FIP free travel passes are not accepted. \
+High-speed trains, travel time < 90 minutes. FIP Coupons are not accepted. \
 **Reservation possible:** yes \
 **Reservation required:** ⚠️ yes \
-**FIP global price (independent of distance):** 4€
+**FIP Global Fare (regardless of distance):** 4€
 {{% /expander %}}
 
 {{% expander "MD ⚠️" "middle-distance" %}}
 **Description:** \
-Accelerated regional transport. FIP free travel vouchers are only accepted on trains that do not require reservations. Currently, this is only the case on the Barcelona (Girona-Figueres)-Port Bou route. \
+Accelerated regional transport. FIP Coupons are only accepted on trains that do not require reservations. Currently, this is only the case on the Barcelona (Girona-Figueres)-Port Bou route. \
 **Reservation possible:** yes \
 **Reservation required:** ⚠️ yes (exception: Barcelona(-Girona-Figueres)-Port Bou route[^1]) \
-**FIP coupons**: Only valid on the route Barcelona(-Girona-Figueres)-Port Bou[^1]. \
-**FIP global price (regardless of distance):** 4€
+**FIP Global Fare (regardless of distance):** 4€
 {{% /expander %}}
 
 ### Local transportation
 
 {{% expander "Cercanías / Rodalia / Aldiriak" "local-transportation" %}}
 **Description:** \
-Commuter trains, comparable to suburban trains. FIP free tickets are valid without restrictions. \
-**Reservation required:** no \
-FIP coupons are valid.
+Commuter trains, comparable to suburban trains. FIP Coupons are valid without restrictions. \
+**Reservation possible:** no \
+**Reservation required:** no
 {{% /expander %}}
 
-{{% expander "Metro Services ⚠️" "local-transportation" %}}
-**Description:** \
-⚠️ FIP is not accepted
-{{% /expander %}}
+## Class Categories
 
-## Class categories
-
-{{% expander "Elige Standard / Turista" "classes" %}}
-Comparable to 2nd class
-{{% /expander %}}
-
-{{% expander "Elige Confort" "classes" %}}
-1st class without meals. A 1st class FIP Card is required.
-{{% /expander %}}
-
-{{% expander "Premium" "classes" %}}
-1st class incl. meal. A FIP-Card 1st class is required.
-{{% /expander %}}
-
-## International connections
-
-{{% expander "Celta: Porto ↔️ Vigo" "international" %}}
-The Celta is an international cooperation train between Renfe and the Portuguese CP. \
-**FIP global price (regardless of distance):** 4 €
-{{% /expander %}}
+**Elige Standard / Turista**: Comparable to 2nd class. \
+**Elige Confort**: 1st class without catering. A 1st class FIP pass is required. \
+**Premium**: 1st class including catering. A 1st class FIP pass is required.
 
 ## Ticket and reservation purchase
 
 ### Online
 
-- It is not possible to book reservations, FIP global price or FIP 50 online.
+- It is not possible to book reservations, FIP Global Fare or FIP 50 online.
 
 ### By telephone
 
@@ -159,10 +143,10 @@ Children up to the age of 4 travel free of charge, provided they do not require 
 ## Arrival and Border Points
 
 ### France
-From Paris, direct TGV trains operated by the French SNCF run to Barcelona. Renfe also operates cross-border services between Lyon and Barcelona. FIP global fares are available with both operators, although they can be very expensive. Overall, there are very few cross-border connections, and the network was significantly better developed just a few years ago.
+From Paris, direct TGV trains operated by the French SNCF run to Barcelona. Renfe also operates cross-border services between Lyon and Barcelona. FIP Global Fares are available with both operators, although they can be very expensive. Overall, there are very few cross-border connections, and the network was significantly better developed just a few years ago.
 
 ### Portugal
-Connections between Spain and Portugal are currently very limited. For example, to travel from Lisbon to Madrid, one must change trains and take a long regional journey to the Spanish border at Badajoz, where one of the few trains to Madrid can be caught. This requires FIP tickets or free passes from Portuguese rail operator CP, as well as a Renfe ticket for the Spanish section. Additionally, there is the Celta connection from Porto to Vigo, although this does not extend further into Spain. A FIP global fare is valid for the entire route. A continuous high-speed rail line between Lisbon and Madrid is currently under development.
+Connections between Spain and Portugal are currently very limited. For example, to travel from Lisbon to Madrid, one must change trains and take a long regional journey to the Spanish border at Badajoz, where one of the few trains to Madrid can be caught. This requires FIP tickets or free passes from Portuguese rail operator CP, as well as a Renfe ticket for the Spanish section. Additionally, there is the Celta connection from Porto to Vigo, although this does not extend further into Spain. A FIP Global Fare is valid for the entire route. A continuous high-speed rail line between Lisbon and Madrid is currently under development.
 
 ### Border Points
 
@@ -176,14 +160,18 @@ Connections between Spain and Portugal are currently very limited. For example, 
 
 ## Special Tariff Conditions
 
+### Celta: Porto - Vigo
+The Celta is an international joint train service operated by Renfe and the Portuguese CP. \
+**FIP Global Fare (regardless of distance):** 4 €
+
 ### Interruption of Travel
 
-With FIP 50 and FIP Global Price tickets, the journey may not be interrupted along the way.[^2]
+With FIP 50 and FIP Global Fare tickets, the journey may not be interrupted along the way.[^2]
 
 ## Experiences
 
 {{% highlight tip %}}
-Renfe can often be compared more to an airline than to other railway companies. Luggage checks are common on long-distance routes, and there are few trains that allow spontaneous boarding. Therefore, an FIP free travel pass is only marginally worthwhile, as it can be used in only a few cases. Due to ticket barriers at many stations, staff must be contacted each time in order to open them with the free travel pass. Personal experience shows that especially in the greater Madrid area, the free travel option is sometimes not recognized, and access is consequently denied.
+Renfe can often be compared more to an airline than to other railway companies. Luggage checks are common on long-distance routes, and there are few trains that allow spontaneous boarding. Therefore, an FIP Coupon is only marginally worthwhile, as it can be used in only a few cases. Due to ticket barriers at many stations, staff must be contacted each time in order to open them with the free travel pass. Personal experience shows that especially in the greater Madrid area, the free travel option is sometimes not recognized, and access is consequently denied.
 {{% /highlight %}}
 
 ## Sources

--- a/content/operator/sncb/index.en.md
+++ b/content/operator/sncb/index.en.md
@@ -10,7 +10,7 @@ The SNCB (Société nationale des chemins de fer belges) or NMBS (Nationale Maat
 
 ## Summary
 
-- SNCB accepts FIP free travel and FIP 50 tickets
+- SNCB accepts FIP Coupons and FIP 50 tickets
 - No reservation required
 - Surcharge for trips to/from Brussels Zaventem Airport
 
@@ -140,7 +140,7 @@ From the Netherlands, cross-border regional trains (including IC here) can be us
 
 ### France
 
-From France, cross-border regional trains can be used, requiring an additional FIP ticket for the French section. For international TGV trains, there is a global price, and FIP free travel passes are not valid as they are not operated by SNCB. The Eurostar (formerly Thalys) can also be used from France to reach the SNCB network. Here, a special FIP ticket from Eurostar is required for the entire section including within Belgium. ([see Eurostar]({{% ref "/operator/eurostar" %}} "Eurostar"))
+From France, cross-border regional trains can be used, requiring an additional FIP ticket for the French section. For international TGV trains, there is a global price, and FIP Coupons passes are not valid as they are not operated by SNCB. The Eurostar (formerly Thalys) can also be used from France to reach the SNCB network. Here, a special FIP ticket from Eurostar is required for the entire section including within Belgium. ([see Eurostar]({{% ref "/operator/eurostar" %}} "Eurostar"))
 
 ### Border Points
 

--- a/content/operator/zsr/index.en.md
+++ b/content/operator/zsr/index.en.md
@@ -10,7 +10,7 @@ The ZSR (Železnice Slovenskej republiky) and its associated train operator ZSSK
 
 ## Summary
 
-- ZSSK accepts FIP free travel and FIP 50 tickets
+- ZSSK accepts FIP Coupons and FIP 50 tickets
 - Reservation required in IC and SC trains
 - Reservation required in 1st class in all trains
 - Offers for free travel for certain groups (children between 6 and 16, students up to 26, and pensioners from 62 years) regardless of FIP


### PR DESCRIPTION
## Description

- Update some wording like FIP Coupon so it's called and written the same anywhere
- Fixed some renfe translastions
- Modified some structure of the renfe information to match the standard

## Checklist
<!-- Check fields with: [x] / Abhaken von Punkten: [x] -->

- [x] Check the License of new pictures (non-commercial use without attribution) <!-- Die Lizenz neuer Bilder geprüft (nicht-kommerzielle Nutzung ohne Namensnennung) -->

The content was modified in the following languages: <!-- Der Inhalt wurde für die folgenden Sprachen angepasst -->
- [x] English
- [x] German
