### PR TITLE
fix: Handle search highlight in expander summary correctly

### DIFF
--- a/layouts/shortcodes/expander.html
+++ b/layouts/shortcodes/expander.html
@@ -1,6 +1,6 @@
 <details name="{{ (.Get 1) }}" class="details-screen">
 <summary>
-    {{ (.Get 0) }}
+    <span>{{ (.Get 0) }}</span>
 </summary>
 <div>
     {{ .Inner }}


### PR DESCRIPTION
The span in #145 was only added to the print version (due to a rebase / merge). This adds it to the normal version for which it was originally planned.

It fixes the following display issue: 
![image](https://github.com/user-attachments/assets/122db018-8dde-4af5-8e9d-ed08cce20b8e)
