### PR TITLE
fix: Detection of image in pagefind was broken

### DIFF
--- a/layouts/country/single.html
+++ b/layouts/country/single.html
@@ -14,7 +14,7 @@
                     <div class="o-single__header__title">
                         {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
                         {{ $image := resources.Get (printf "images/flags/%s.webp" $object) }}
-                        <img data-pagefind-meta="img" src="{{ $image.RelPermalink }}" alt="" />
+                        <img data-pagefind-meta="image[src]" src="{{ $image.RelPermalink }}" alt="" />
                         <h1 data-pagefind-meta="title">{{ .Title }}</h1>
                     </div>
                     {{ partial "updateDate.html" . }}

--- a/layouts/operator/single.html
+++ b/layouts/operator/single.html
@@ -12,7 +12,7 @@
                             {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
                             {{ $logo := resources.Get (printf "images/logos/%s.svg" $object) }}
                             {{ if $logo }}
-                                <img data-pagefind-meta="img" src="{{ $logo.RelPermalink }}" alt="" />
+                                <img data-pagefind-meta="image[src]" src="{{ $logo.RelPermalink }}" alt="" />
                             {{ end }}
                             <h1 data-pagefind-meta="title">{{ .Title }}</h1>
                         </div>

--- a/layouts/partials/logo.html
+++ b/layouts/partials/logo.html
@@ -1,4 +1,4 @@
 {{ $logo := resources.Get (printf "/images/logos/%s.svg" .) }}
 {{ if $logo }}
-<img data-pagefind-meta="img" src="{{ $logo.RelPermalink }}" alt="" style="height: 1.3em; width: auto" />
+<img src="{{ $logo.RelPermalink }}" alt="" style="height: 1.3em; width: auto" />
 {{ end }}


### PR DESCRIPTION
`data-pagefind-meta="img"` is not a valid option, therefore it was ignored and the first picture of the page was used.