### PR TITLE
feat: Cross-linking of news with operators and countries

### DIFF
--- a/archetypes/operator/index.de.md
+++ b/archetypes/operator/index.de.md
@@ -6,6 +6,7 @@ country:
   - 'country1'
   - 'country2'
   - 'country3'
+operator: '{{ .File.ContentBaseName }}'
 ---
 
 <!-- Entferne das "WIP" Snippet, wenn die Inhalte der Seite vollständig sind -->

--- a/archetypes/operator/index.en.md
+++ b/archetypes/operator/index.en.md
@@ -6,6 +6,7 @@ country:
   - 'country1'
   - 'country2'
   - 'country3'
+operator: '{{ .File.ContentBaseName }}'
 ---
 
 <!-- Remove the WIP snippet if the page is complete -->

--- a/assets/sass/content.scss
+++ b/assets/sass/content.scss
@@ -31,11 +31,6 @@ th, td {
     padding: 1rem;
 }
 
-p {
-    margin-bottom: 3.2rem;
-    text-align: justify;
-}
-
 .footnotes {
 
     p {

--- a/assets/sass/sidemenu.scss
+++ b/assets/sass/sidemenu.scss
@@ -78,12 +78,18 @@
     }
 }
 
-.o-news__list {
-    list-style-type: none;
-    list-style-position: outside;
-    padding-left: 0;
+.o-related {
+    &__list {
+        list-style-type: none;
+        list-style-position: outside;
+        padding-left: 0;
+    }
 
     &-date {
         padding-left: 2.5rem;
+    }
+
+    p {
+        margin-bottom: 0;
     }
 }

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -205,7 +205,7 @@ img {
   padding: 0px;
 }
 
-.o-flag {
+.a-flag {
   height: 2rem;
   width: auto;
 }

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -102,22 +102,27 @@ img {
 }
 
 .o-list__picture {
-  width: 15rem;
   margin-right: 1.2rem;
 }
 
 .o-list__picture--operator {
   width: auto;
+  margin-left: 1rem;
 }
 
-.o-list__link-wrapper {
+.o-related__operator-wrapper > .o-related__list {
   display: flex;
-  gap: 2rem;
+  flex-wrap: wrap;
   margin-bottom: 0;
   padding-left: 0;
+  column-gap: 4rem;
+  row-gap: 1rem;
+  list-style-type: none;
 
-  li {
-    list-style-type: none;
+  li > a {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
   }
 }
 
@@ -147,6 +152,10 @@ img {
     display: flex;
     flex-direction: column;
     gap: 1.5rem;
+
+    p {
+        text-align: justify;
+    }
   }
 
   &__news-image {
@@ -194,4 +203,9 @@ img {
 
 .pagefind-highlight {
   padding: 0px;
+}
+
+.o-flag {
+  height: 2rem;
+  width: auto;
 }

--- a/content/news/2/index.de.md
+++ b/content/news/2/index.de.md
@@ -3,6 +3,11 @@ date: "2025-02-16"
 draft: false
 author: "Willy"
 title: "Grenzüberschreitende FIP-Tickets der SNCB"
+country:
+    - belgium
+    - netherlands
+operator:
+    - sncb
 ---
 
 Die belgische Staatsbahn SNCB / NMBS bietet auf ihrer [Website für internationale Fahrkarten ](https://www.b-europe.com/) neben regulären grenzüberschreitenden Tickets nun auch Tickets mit FIP-Rabatt an. Dies erleichtert den Kauf von Fahrkarten, die über die Grenze Belgiens hinausgehen, erheblich. Bisher mussten diese an einem Schalter in Belgien oder bestimmten Nachbarländern wie Deutschland oder den Niederlanden gekauft werden.

--- a/content/news/2/index.en.md
+++ b/content/news/2/index.en.md
@@ -3,6 +3,11 @@ date: "2025-02-16"
 draft: false
 author: "Willy"
 title: "Cross-border FIP Tickets of SNCB"
+country:
+    - belgium
+    - netherlands
+operator:
+    - sncb
 ---
 
 The Belgian national railway company SNCB / NMBS now offers tickets with FIP discount on their [international ticket website](https://www.b-europe.com/) in addition to regular cross-border tickets. This significantly simplifies the purchase of tickets that go beyond the borders of Belgium. Previously, these had to be purchased at a counter in Belgium or certain neighboring countries such as Germany or the Netherlands.

--- a/content/news/4/index.de.md
+++ b/content/news/4/index.de.md
@@ -2,6 +2,11 @@
 date: "2025-05-16"
 draft: false
 title: "Eurostar Preiserhöhung"
+country:
+    - belgium
+    - netherlands
+operator:
+    - eurostar
 ---
 
 Ab dem 1. Mai 2025 erhöht Eurostar die Preise auf alle FIP Fahrkarten um 5€ bzw. 5£. Die Preiserhöhung betrifft alle FIP Globalpreise bei Eurostar Blue und Eurostar Red (Thalys) in allen Klassen. Die neuen Preise gelten für alle Buchungen, die ab dem 1. Mai 2025 getätigt werden. [^1]

--- a/content/news/4/index.en.md
+++ b/content/news/4/index.en.md
@@ -2,6 +2,11 @@
 date: "2025-05-16"
 draft: false
 title: "Eurostar Price Increase"
+country:
+    - belgium
+    - netherlands
+operator:
+    - eurostar
 ---
 
 Starting May 1, 2025, Eurostar will increase prices on all FIP tickets by €5 or £5. The price increase applies to all FIP Global Fares for Eurostar Blue and Eurostar Red (Thalys) in all classes. The new prices apply to all bookings made from May 1, 2025 onwards. [^1]

--- a/content/operator/dsb/index.de.md
+++ b/content/operator/dsb/index.de.md
@@ -4,6 +4,7 @@ title: "DSB"
 description: "Informationen über die FIP-Bedingungen bei DSB."
 country:
   - "denmark"
+operator: "dsb"
 ---
 
 Die DSB (Danske Statsbaner) ist die staatliche Eisenbahngesellschaft in Dänemark. Sie betreibt den Großteil des Personenverkehrs auf dem dänischen Schienennetz.

--- a/content/operator/dsb/index.en.md
+++ b/content/operator/dsb/index.en.md
@@ -4,6 +4,7 @@ title: 'DSB'
 description: "Information about FIP conditions at DSB."
 country:
  - "denmark"
+operator: "dsb"
 ---
 
 The DSB (Danske Statsbaner) is the state-owned railway company in Denmark. It operates the majority of passenger traffic on the Danish rail network.

--- a/content/operator/eurostar/index.de.md
+++ b/content/operator/eurostar/index.de.md
@@ -5,6 +5,7 @@ description: "Informationen über die FIP-Bedingungen bei Eurostar."
 country:
   - "belgium"
   - "netherlands"
+operator: "eurostar"
 ---
 
 Eurostar ist ein Betreiber von Hochgeschwindigkeitszügen in Westeuropa. Ursprünglich wurden nur die blauen Züge zwischen London und Paris/Brüssel/Amsterdam durch den Eurotunnel als Eurostar bezeichnet. Nach dem Zusammenschluss zwischen Thalys und Eurostar werden auch die roten Thalys-Züge als Eurostar (Red) bezeichnet.

--- a/content/operator/eurostar/index.en.md
+++ b/content/operator/eurostar/index.en.md
@@ -5,6 +5,7 @@ description: "Information about FIP conditions for Eurostar."
 country:
   - "belgium"
   - "netherlands"
+operator: "eurostar"
 ---
 
 Eurostar is an operator of high-speed trains in Western Europe. Originally, only the blue trains between London and Paris/Brussels/Amsterdam through the Eurotunnel were referred to as Eurostar. After the merger between Thalys and Eurostar, the red Thalys trains are now also referred to as Eurostar (Red).

--- a/content/operator/ns/index.de.md
+++ b/content/operator/ns/index.de.md
@@ -4,6 +4,7 @@ title: "NS"
 description: "Informationen über die FIP-Bedingungen bei NS."
 country:
   - "netherlands"
+operator: "ns"
 ---
 
 Die Nederlandse Spoorwegen (NS) ist die staatliche Eisenbahngesellschaft der Niederlande und betreibt den Großteil des Personenverkehrs auf dem niederländischen Schienennetz.

--- a/content/operator/ns/index.en.md
+++ b/content/operator/ns/index.en.md
@@ -4,6 +4,7 @@ title: "NS"
 description: "Information about FIP conditions at NS."
 country:
   - "netherlands"
+operator: "ns"
 ---
 
 Nederlandse Spoorwegen (NS) is the state railway company of the Netherlands and operates the majority of passenger traffic on the Dutch rail network.

--- a/content/operator/renfe/index.de.md
+++ b/content/operator/renfe/index.de.md
@@ -5,6 +5,7 @@ description: "Informationen über die FIP-Bedingungen bei Renfe."
 country:
   - "spain"
   - "france"
+operator: "renfe"
 ---
 
 Renfe Operadora ist ein staatliches spanisches Eisenbahnunternehmen. Hierzu gehören komfortable Hochgeschwindkeitszüge, diverse Regionalzüge und S-Bahnen.

--- a/content/operator/renfe/index.en.md
+++ b/content/operator/renfe/index.en.md
@@ -5,6 +5,7 @@ description: "Information about the FIP conditions at Renfe."
 country:
   - "spain"
   - "france"
+operator: "renfe"
 ---
 
 Renfe Operadora is a Spanish state-owned railroad company. It operates comfortable high-speed trains, various regional trains and suburban trains.

--- a/content/operator/sncb/index.de.md
+++ b/content/operator/sncb/index.de.md
@@ -4,6 +4,7 @@ title: "SNCB"
 description: "Informationen über die FIP-Bedingungen bei SNCB."
 country:
   - "belgium"
+operator: "sncb"
 ---
 
 Die SNCB (Société nationale des chemins de fer belges) bzw. NMBS (Nationale Maatschappij der Belgische Spoorwegen) ist die belgische Staatsbahn und die wichtigste Bahngesellschaft in Belgien.

--- a/content/operator/sncb/index.en.md
+++ b/content/operator/sncb/index.en.md
@@ -4,6 +4,7 @@ title: "SNCB"
 description: "Find out about the FIP conditions at SNCB."
 country:
   - "belgium"
+operator: "sncb"
 ---
 
 The SNCB (Société nationale des chemins de fer belges) or NMBS (Nationale Maatschappij der Belgische Spoorwegen) is the Belgian national railway operator and the most important railway operator in Belgium.

--- a/content/operator/zsr/index.de.md
+++ b/content/operator/zsr/index.de.md
@@ -4,6 +4,7 @@ title: "ZSR / ZSSK"
 description: "Informationen über die FIP-Bedingungen bei ZSR / ZSSK."
 country:
   - "slovakia"
+operator: "zsr"
 ---
 
 Die ZSR (Železnice Slovenskej republiky) sowie der dazugehörige Zugbetreiber ZSSK (Železničná spoločnosť Slovensko) ist die slowakische Staatsbahn und die wichtigste Bahngesellschaft in der Slowakei.

--- a/content/operator/zsr/index.en.md
+++ b/content/operator/zsr/index.en.md
@@ -4,6 +4,7 @@ title: "ZSR / ZSSK"
 description: "Find out about the FIP conditions at ZSR / ZSSK."
 country:
   - "slovakia"
+operator: "zsr"
 ---
 
 The ZSR (Železnice Slovenskej republiky) and its associated train operator ZSSK (Železničná spoločnosť Slovensko) are the Slovak state railways and the most important railway operator in Slovakia.

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -32,6 +32,8 @@ related:
  indices:
    - name: country
      weight: 100
+   - name: operator
+     weight: 100
 
 markup:
   tableOfContents:

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -19,9 +19,13 @@ news-headline: Was gibt's Neues?
 news-other: Weitere News
 _operator__list_title: Betreiber mit FIP
 updateDate: Zuletzt aktualisiert
-related: Verwandte Seiten
 toc_name: Inhalt
 _operator__nearby: Angrenzende Betreiber
+related:
+  news: Verwandte News
+  countries: Verwandte Länder
+  operators: Verwandte Betreiber
+  operators-nearby: Angrenzende Betreiber
 related-news: Verwandte News
 related-countries: Verwandte Länder
 related-operators: Verwandte Betreiber

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -22,7 +22,9 @@ updateDate: Zuletzt aktualisiert
 related: Verwandte Seiten
 toc_name: Inhalt
 _operator__nearby: Angrenzende Betreiber
-toc-backlink: Zurück zu
+related-news: Verwandte News
+related-countries: Verwandte Länder
+related-operators: Verwandte Betreiber
 editPage: Seite bearbeiten
 reportError: Melde ein Fehler
 anchorLink:
@@ -30,3 +32,4 @@ anchorLink:
   copied: Link wurde in die Zwischenablage kopiert
 skipToContent: Zum Inhalt springen
 wip: An dieser Seite wird noch gearbeitet und Inhalte können unvollständig sein. Wir freuen uns, wenn du zur Verbesserung dieser Seite beträgst. [Mehr Information auf GitHub](https://github.com/fipguide/fipguide.github.io/wiki/Deutsch).
+navigate-to-country: Gehe zu Land

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -19,12 +19,12 @@ news-headline: What's new?
 news-other: Other News
 _operator__list_title: Operators supporting FIP
 updateDate: Last updated
-related: Related Pages
 toc_name: Contents
-_operator__nearby: Neighboring Operators
-related-news: Related News
-related-countries: Related Countries
-related-operators: Related Operators
+related:
+  news: Related News
+  countries: Related Countries
+  operators: Related Operators
+  operators-nearby: Neighboring Operators
 editPage: Edit page
 reportError: Report an error
 anchorLink:

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -22,7 +22,9 @@ updateDate: Last updated
 related: Related Pages
 toc_name: Contents
 _operator__nearby: Neighboring Operators
-toc-backlink: Back to
+related-news: Related News
+related-countries: Related Countries
+related-operators: Related Operators
 editPage: Edit page
 reportError: Report an error
 anchorLink:
@@ -30,3 +32,4 @@ anchorLink:
   copied: Link has been copied to the clipboard
 skipToContent: Skip to content
 wip: This page is still under construction and content may be incomplete. We would be happy if you contribute to improve this page. [More information on GitHub](https://github.com/fipguide/fipguide.github.io/wiki/English).
+navigate-to-country: Navigate to country

--- a/layouts/country/list.html
+++ b/layouts/country/list.html
@@ -7,8 +7,7 @@
       <a href="{{ .RelPermalink }}" class="col-12 col-lg-4 col-sm-6 o-list__link">
         <div class="o-list__picture">
           {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
-          {{ $image := resources.Get (printf "images/flags/%s.webp" $object) }}
-          {{ partialCached "image.html" $image $image }}
+          {{ partial "flag" $object }}
         </div>
         <div>
           {{ .Title }}

--- a/layouts/country/single.html
+++ b/layouts/country/single.html
@@ -22,15 +22,9 @@
                 {{- end -}}
             </div>
         </div>
-        <div class="o-single__container">
-            <h3 id="related">{{ T "_operator__list_title"}} in {{ .Title }}</h3>
-            <ul class="o-list__link-wrapper" aria-labelledby="related">
-                {{ range $related }}
-                    <li class="col-12 col-lg-3 col-sm-6">
-                        {{ partial "operator-list-item" . }}
-                    </li>
-                {{ end }}
-            </ul>
+        <div class="o-single__container o-related__operator-wrapper">
+            {{ $title := print (T "_operator__list_title") " in " .Title}}
+            {{ partial "related" (dict "index" "country" "pageType" "operator" "title" $title "page" . "identifier" "operators") }}
         </div>
         {{ partial "image" (partial "helper/contentImage" . ) }}
     </div>

--- a/layouts/news/single.html
+++ b/layouts/news/single.html
@@ -4,21 +4,25 @@
         <aside id="aside" class="o-aside">
             {{ partial "image" (partial "helper/contentImage" . ) }}
             <div class="o-single__container">
-                <h3 id="other-news-list-title">{{ T "news-other" }}</h3>
-                <ul class="o-news__list" aria-labelledby="other-news-list-title">
+                <h3 id="o-related__title">{{ T "news-other" }}</h3>
+                <ul class="o-related__list" aria-labelledby="o-related__title">
                     {{ $current := . }}
                     {{ range first 5 (where (where site.RegularPages "Section" "news") "Permalink" "ne" $current.Permalink) }}
-                    <li>
+                    <li class="o-related__item">
                         {{ partial "internal_link"
                             (dict
                                 "Destination" .RelPermalink
                                 "Text" ((print (partial "icon" "newspaper" ) (.Title)) | .Page.RenderString)
                             )
                         }}
-                        <span class="o-news__list-date">{{ .Date | time.Format ":date_long"}}</span>
+                        {{ if eq .Page.Type "news" }}
+                            <span class="o-related__date">{{ .Date | time.Format ":date_long"}}</span>
+                        {{ end }}
                     </li>
                     {{ end }}
                 </ul>
+                {{ partial "related" (dict "index" "country" "title" (T "related-countries") "page" . "identifier" "countries") }}
+                {{ partial "related" (dict "index" "operator" "title" (T "related-operators") "page" . "identifier" "operators") }}
                 <hr>
                 {{ partial "link"
                     (dict

--- a/layouts/news/single.html
+++ b/layouts/news/single.html
@@ -21,8 +21,8 @@
                     </li>
                     {{ end }}
                 </ul>
-                {{ partial "related" (dict "index" "country" "title" (T "related-countries") "page" . "identifier" "countries") }}
-                {{ partial "related" (dict "index" "operator" "title" (T "related-operators") "page" . "identifier" "operators") }}
+                {{ partial "related" (dict "index" "country" "title" (T "related.countries") "page" . "identifier" "countries") }}
+                {{ partial "related" (dict "index" "operator" "title" (T "related.operators") "page" . "identifier" "operators") }}
                 <hr>
                 {{ partial "link"
                     (dict

--- a/layouts/operator/list.html
+++ b/layouts/operator/list.html
@@ -1,15 +1,19 @@
 {{ define "main" }}
-<div class="container o-list">
-  <div class="row">
-    <h2 data-pagefind-meta="title">{{ .Title }}</h2>
-    {{ .Content }}
-    <ul class="o-list__link-wrapper row">
+  <div class="container o-list">
+    <div class="row">
+      <h2 data-pagefind-meta="title">{{ .Title }}</h2>
+      {{ .Content }}
       {{ range .Pages }}
-    <li class="col-12 col-lg-3 col-sm-6">
-      {{ partial "operator-list-item" . }}
-    </li>
-    {{ end }}
-    </ul>
+      <a href="{{ .RelPermalink }}" class="col-12 col-lg-4 col-sm-6 o-list__link">
+        <div class="o-list__picture">
+          {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
+          {{ partial "logo" $object }}
+        </div>
+        <div>
+          {{ .Title }}
+        </div>
+      </a>
+      {{ end }}
+    </div>
   </div>
-</div>
 {{ end }}

--- a/layouts/partials/flag.html
+++ b/layouts/partials/flag.html
@@ -1,0 +1,2 @@
+{{ $image := resources.Get (printf "images/flags/%s.webp" .) }}
+<img class="o-flag" src="{{ $image.RelPermalink }}" alt="" />

--- a/layouts/partials/flag.html
+++ b/layouts/partials/flag.html
@@ -1,2 +1,2 @@
 {{ $image := resources.Get (printf "images/flags/%s.webp" .) }}
-<img class="o-flag" src="{{ $image.RelPermalink }}" alt="" />
+<img class="a-flag" src="{{ $image.RelPermalink }}" alt="" />

--- a/layouts/partials/operator-list-item.html
+++ b/layouts/partials/operator-list-item.html
@@ -1,9 +1,0 @@
-<a href="{{ .RelPermalink }}" class="o-list__link">
-  <div class="o-list__picture o-list__picture--operator">
-    {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
-    {{ partial "logo" $object }}
-  </div>
-  <div>
-    {{ .Title }}
-  </div>
-</a>

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -2,7 +2,6 @@
 {{ $related := where (.page.Site.RegularPages.RelatedIndices .page .index) ".Page.Type" $pageType }}
 {{ if gt (len $related) 0 }}
 <h3 id="o-related__title-{{ .identifier }}">{{ .title }}</h3>
-{{ end }}
 <ul class="o-related__list" aria-labelledby="o-related__title-{{ .identifier }}">
 {{ range $related }}
     {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
@@ -29,3 +28,4 @@
     </li>
 {{ end }}
 </ul>
+{{ end }}

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -1,0 +1,31 @@
+{{ $pageType := .pageType | default .index }}
+{{ $related := where (.page.Site.RegularPages.RelatedIndices .page .index) ".Page.Type" $pageType }}
+{{ if gt (len $related) 0 }}
+<h3 id="o-related__title-{{ .identifier }}">{{ .title }}</h3>
+{{ end }}
+<ul class="o-related__list" aria-labelledby="o-related__title-{{ .identifier }}">
+{{ range $related }}
+    {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
+    <li class="o-related__item">
+        {{ $text := .LinkTitle }}
+        {{ if eq .Page.Type "news" }}
+            {{ $text = print (partial "icon" "newspaper") $text }}
+        {{ else if eq .Page.Type "operator" }}
+            {{ $text = print (partial "logo" $object) $text }}
+        {{ else if eq .Page.Type "country" }}
+            {{ $text = print (partial "flag" $object) $text }}
+        {{ end }}
+
+        {{ partial "internal_link" (
+            dict
+                "Destination" .RelPermalink
+                "Text" ($text | .Page.RenderString)
+            )
+        }}
+
+        {{ if eq .Page.Type "news" }}
+            <span class="o-related__date">{{ .Date | time.Format ":date_long"}}</span>
+        {{ end }}
+    </li>
+{{ end }}
+</ul>

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -24,11 +24,11 @@
 
         {{ if eq .Page.Type "country" }}
             {{ partial "related" (dict "index" "country" "pageType" "operator" "title" (T "_operator__list_title") "page" . "identifier" "operators") }}
-            {{ partial "related" (dict "index" "country" "pageType" "news" "title" (T "related-news") "page" . "identifier" "news") }}
+            {{ partial "related" (dict "index" "country" "pageType" "news" "title" (T "related.news") "page" . "identifier" "news") }}
         {{ end }}
         {{ if eq .Page.Type "operator" }}
-            {{ partial "related" (dict "index" "country" "pageType" "operator" "title" (T "_operator__nearby") "page" . "identifier" "operators") }}
-            {{ partial "related" (dict "index" "operator" "pageType" "news" "title" (T "related-news") "page" . "identifier" "news") }}
+            {{ partial "related" (dict "index" "country" "pageType" "operator" "title" (T "related.operators-nearby") "page" . "identifier" "operators") }}
+            {{ partial "related" (dict "index" "operator" "pageType" "news" "title" (T "related.news") "page" . "identifier" "news") }}
         {{ end }}
         <hr>
         {{ partial "link"

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -7,9 +7,10 @@
                 {{ range . }}
                     {{ if eq .Page.Type "country" }}
                     <li>
-                        <a href="{{ .RelPermalink }}">
+                        <a href="{{ .RelPermalink }}" aria-label="{{ print (T "navigate-to-country") " " .LinkTitle }}">
                             {{ partial "icon" "arrow_back" }}
-                            <span>{{ T "toc-backlink"}}: {{ .LinkTitle }}</span>
+                            {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
+                            <span>{{ partial "flag" $object }} {{ .LinkTitle }}</span>
                         </a>
                     </li>
                     {{ end }}
@@ -22,42 +23,12 @@
         {{ partial "toc.html" (dict "context" . "startLevel" 2 "endLevel" 3 ) }}
 
         {{ if eq .Page.Type "country" }}
-            <h3 id="related">{{ T "_operator__list_title"}}</h3>
-            <ul aria-labelledby="related">
-                {{ $related := .Site.RegularPages.RelatedIndices . "country" }}
-                {{ with $related }}
-                    {{ range . }}
-                    {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
-                    <li>
-                        <a id="{{ .LinkTitle }}" href="{{ .RelPermalink }}">
-                            {{ partial "logo" $object }}
-                            {{ .LinkTitle }}
-                        </a>
-                    </li>
-                    {{ end }}
-                {{ end }}
-            </ul>
+            {{ partial "related" (dict "index" "country" "pageType" "operator" "title" (T "_operator__list_title") "page" . "identifier" "operators") }}
+            {{ partial "related" (dict "index" "country" "pageType" "news" "title" (T "related-news") "page" . "identifier" "news") }}
         {{ end }}
         {{ if eq .Page.Type "operator" }}
-            {{ $related := .Site.RegularPages.RelatedIndices . "country" }}
-            {{ with $related }}
-            {{ if gt (len $related) 1 }}
-            <h3 id="related">{{ T "_operator__nearby"}}</h3>
-            {{ end }}
-            <ul aria-labelledby="related">
-                {{ range . }}
-                    {{ if eq .Page.Type "operator" }}
-                        {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
-                        <li>
-                            <a id="{{ .LinkTitle }}" href="{{ .RelPermalink }}">
-                                {{ partial "logo" $object }}
-                                <span>{{ .LinkTitle }}</span>
-                            </a>
-                        </li>
-                        {{ end }}
-                    {{ end }}
-                {{ end }}
-            </ul>
+            {{ partial "related" (dict "index" "country" "pageType" "operator" "title" (T "_operator__nearby") "page" . "identifier" "operators") }}
+            {{ partial "related" (dict "index" "operator" "pageType" "news" "title" (T "related-news") "page" . "identifier" "news") }}
         {{ end }}
         <hr>
         {{ partial "link"


### PR DESCRIPTION
Cross-link news, operators and countries. For news, related countries and operators are displayed in the sidebar. For countries and operators, related news are displayed.

A flag is displayed for countries in the sidebar navigation (resolves #105). The PR contains some refactoring to unify all "related" links. The operator and country lists haven been unified.