### PR TITLE
fix: Remove "Last updated" from general pages

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,6 @@
     <article class="container o-single">
         <div class="o-single__header">
             <h2 data-pagefind-meta="title">{{ .Title }}</h2>
-            {{ partial "updateDate.html" . }}
         </div>
 
         <div class="o-single__content" data-pagefind-body>


### PR DESCRIPTION
Resolves #174