### PR TITLE
fix: aside backlink positioning

### DIFF
--- a/assets/sass/sidemenu.scss
+++ b/assets/sass/sidemenu.scss
@@ -41,7 +41,13 @@
     text-decoration-line: none;
     display: flex;
     align-items: flex-start;
-    gap: .5rem;
+    gap: .4rem;
+}
+
+.o-aside__backlink-text {
+    display: flex;
+    align-items: center;
+    gap: .4rem;
 }
 
 .toc li {

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -10,7 +10,7 @@
                         <a href="{{ .RelPermalink }}" aria-label="{{ print (T "navigate-to-country") " " .LinkTitle }}">
                             {{ partial "icon" "arrow_back" }}
                             {{ $object := replace .Path (printf "/%s/" .Page.Type) "" }}
-                            <span>{{ partial "flag" $object }} {{ .LinkTitle }}</span>
+                            <span class="o-aside__backlink-text">{{ partial "flag" $object }} {{ .LinkTitle }}</span>
                         </a>
                     </li>
                     {{ end }}


### PR DESCRIPTION
## Description

Before
<img width="145" alt="Bildschirmfoto 2025-06-07 um 11 35 37" src="https://github.com/user-attachments/assets/559281df-3d13-419d-b99a-cfc934ad5e6f" />

After
<img width="175" alt="Bildschirmfoto 2025-06-07 um 11 35 51" src="https://github.com/user-attachments/assets/ee786166-d782-4433-ae1c-1b9bf9ad564c" />


## Checklist
<!-- Check fields with: [x] / Abhaken von Punkten: [x] -->

- [ ] Check the License of new pictures (non-commercial use without attribution) <!-- Die Lizenz neuer Bilder geprüft (nicht-kommerzielle Nutzung ohne Namensnennung) -->

The content was modified in the following languages: <!-- Der Inhalt wurde für die folgenden Sprachen angepasst -->
- [ ] English
- [ ] German
