### PR TITLE
refactor: Replace `::before` for dividers with explicit hr

### DIFF
--- a/assets/sass/anchorlink.scss
+++ b/assets/sass/anchorlink.scss
@@ -1,10 +1,16 @@
 .a-anchorlink {
   display: flex;
   flex-wrap: wrap;
+  margin-bottom: 1.2rem;
+  align-items: center;
+  column-gap: .8rem;
 }
 
-.a-anchorlink::before {
-  content: "";
+.a-anchorlink > h2 {
+  margin-bottom: 0;
+}
+
+.o-divider {
   display: block;
   width: 100%;
   margin: 2rem 0;
@@ -13,6 +19,11 @@
   background-repeat: no-repeat;
   height: 2.4rem;
   opacity: 50%;
+  border-top: 0;
+
+  @media print {
+    margin: 0;
+  }
 }
 
 .a-anchorlink__link {
@@ -21,7 +32,6 @@
   height: 3.2rem;
   align-items: center;
   justify-content: center;
-  margin-left: .8rem;
   border-radius: var(--border-radius-s);
   opacity: .8;
   text-decoration: none;

--- a/assets/sass/print.scss
+++ b/assets/sass/print.scss
@@ -10,10 +10,6 @@
         color: var(--bs-body-color);
     }
 
-    .a-anchorlink::before {
-        margin: 0;
-    }
-
     p {
         margin-bottom: 1rem;
     }

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -172,6 +172,7 @@ img {
   justify-content: space-between;
   flex-flow: wrap;
   column-gap: 2rem;
+  row-gap: 1rem;
   margin-bottom: 1.6rem;
   align-items: center;
 

--- a/layouts/country/single.html
+++ b/layouts/country/single.html
@@ -17,9 +17,7 @@
             </div>
 
             <div data-pagefind-weight="2">
-                {{- with .Content -}}
-                    {{ . | replaceRE "(<h[2] id=\"([^\"]+)\".+)(</h[2]+>)" (print `<span class="a-anchorlink">${1}${3}<a href="#${2}" class="a-anchorlink__link" title="` (T "anchorLink.copy") `">` (partial "icon" "link") `</a></span>`) | safeHTML }}
-                {{- end -}}
+                {{ partial "content" . }}
             </div>
         </div>
         <div class="o-single__container o-related__operator-wrapper">

--- a/layouts/operator/single.html
+++ b/layouts/operator/single.html
@@ -16,9 +16,7 @@
                     {{ partial "updateDate.html" . }}
                 </div>
                 <div data-pagefind-weight="2.5">
-                    {{- with .Content -}}
-                        {{ . | replaceRE "(<h[2] id=\"([^\"]+)\".+)(</h[2]+>)" (print `<span class="a-anchorlink">${1}${3}<a href="#${2}" class="a-anchorlink__link" title="` (T "copyAnchorLink") `">` (partial "icon" "link") `</a></span>`) | safeHTML }}
-                    {{- end -}}
+                    {{ partial "content" . }}
                 </div>
             </div>
             {{ partial "image" (partial "helper/contentImage" . ) }}

--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -1,3 +1,3 @@
 {{- with .Content -}}
-    {{ . | replaceRE "(<h[2] id=\"([^\"]+)\".+)(</h[2]+>)" (print `<hr class="o-divider"><span class="a-anchorlink">${1}${3}<a href="#${2}" class="a-anchorlink__link" title="` (T "anchorLink.copy") `">` (partial "icon" "link") `</a></span>`) | safeHTML }}
+    {{ . | replaceRE "(<h[2] id=\"([^\"]+)\".+)(</h[2]+>)" (print `<hr class="o-divider" aria-hidden="true"><span class="a-anchorlink">${1}${3}<a href="#${2}" class="a-anchorlink__link" title="` (T "anchorLink.copy") `">` (partial "icon" "link") `</a></span>`) | safeHTML }}
 {{- end -}}

--- a/layouts/partials/content.html
+++ b/layouts/partials/content.html
@@ -1,0 +1,3 @@
+{{- with .Content -}}
+    {{ . | replaceRE "(<h[2] id=\"([^\"]+)\".+)(</h[2]+>)" (print `<hr class="o-divider"><span class="a-anchorlink">${1}${3}<a href="#${2}" class="a-anchorlink__link" title="` (T "anchorLink.copy") `">` (partial "icon" "link") `</a></span>`) | safeHTML }}
+{{- end -}}


### PR DESCRIPTION
Dividers can be added more easily in any HTML template via `<hr class="o-divider">` instead of restricting them to `a-anchorlink`. Required for https://github.com/fipguide/fipguide.github.io/pull/178.