### PR TITLE
ci: Sort i18n yaml files alphabetically

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,11 @@ repos:
       - id: end-of-file-fixer
       - id: fix-byte-order-marker
       - id: trailing-whitespace
+  - repo: local
+    hooks:
+      - id: yaml-sort-i18n
+        name: Sort i18n YAML files
+        entry: npx yaml-sort -i
+        language: system
+        types: [file]
+        files: ^i18n/.*\.ya?ml$

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -1,40 +1,46 @@
-countryselection: Länderauswahl
+_operator__list_title: Betreiber mit FIP
+_operator__nearby: Angrenzende Betreiber
+anchorLink:
+  copied: Link wurde in die Zwischenablage kopiert
+  copy: Link zu diesem Abschnitt kopieren
 country:
-  one: Land
   many: Länder
+  one: Land
   other: Länder
-search-placeholder: Suche
+countryselection: Länderauswahl
+editPage: Seite bearbeiten
 footer-love:
-  text: Made with ♥️ in Frankfurt & Köln
   aria-label: Made with love in Frankfurt & Köln
-menu-open: Menü
-menu-close: Schließen
+  text: Made with ♥️ in Frankfurt & Köln
 general: Übergreifendes
-information-disclaimer-short: Diese Informationen sind inoffiziell und ohne Gewähr. Es besteht keine rechtliche Verbindung zu FIP oder Bahngesellschaften.
 highlight:
   important: Wichtige Information
   inofficial: Inoffizielle Information
   tip: Persönlicher Tipp
+home-page-text: FIP Guide Startseite
+information-disclaimer-short: >-
+  Diese Informationen sind inoffiziell und ohne Gewähr. Es besteht keine
+  rechtliche Verbindung zu FIP oder Bahngesellschaften.
+menu-close: Schließen
+menu-open: Menü
+navigate-to-country: Gehe zu Land
 news-headline: Was gibt's Neues?
 news-other: Weitere News
-_operator__list_title: Betreiber mit FIP
-updateDate: Zuletzt aktualisiert
-toc_name: Inhalt
-_operator__nearby: Angrenzende Betreiber
 related:
-  news: Verwandte News
   countries: Verwandte Länder
+  news: Verwandte News
   operators: Verwandte Betreiber
   operators-nearby: Angrenzende Betreiber
-related-news: Verwandte News
 related-countries: Verwandte Länder
+related-news: Verwandte News
 related-operators: Verwandte Betreiber
-editPage: Seite bearbeiten
 reportError: Melde ein Fehler
-anchorLink:
-  copy: Link zu diesem Abschnitt kopieren
-  copied: Link wurde in die Zwischenablage kopiert
+search-placeholder: Suche
 skipToContent: Zum Inhalt springen
-wip: An dieser Seite wird noch gearbeitet und Inhalte können unvollständig sein. Wir freuen uns, wenn du zur Verbesserung dieser Seite beträgst. [Mehr Information auf GitHub](https://github.com/fipguide/fipguide.github.io/wiki/Deutsch).
-home-page-text: FIP Guide Startseite
-navigate-to-country: Gehe zu Land
+toc_name: Inhalt
+updateDate: Zuletzt aktualisiert
+wip: >-
+  An dieser Seite wird noch gearbeitet und Inhalte können unvollständig sein.
+  Wir freuen uns, wenn du zur Verbesserung dieser Seite beträgst. [Mehr
+  Information auf
+  GitHub](https://github.com/fipguide/fipguide.github.io/wiki/Deutsch).

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,36 +1,41 @@
-countryselection: choose country
+_operator__list_title: Operators supporting FIP
+anchorLink:
+  copied: Link has been copied to the clipboard
+  copy: Copy link to this section
 country:
-  one: country
   many: countries
+  one: country
   other: countries
-search-placeholder: Search
+countryselection: choose country
+editPage: Edit page
 footer-love:
-  text: Made with ♥️ in Frankfurt & Cologne
   aria-label: Made with love in Frankfurt & Cologne
-menu-open: Menu
-menu-close: Close
+  text: Made with ♥️ in Frankfurt & Cologne
 general: general
-information-disclaimer-short: The information provided is unofficial and without guarantee. There is no legal connection to FIP or railway companies.
 highlight:
   important: Important Information
   inofficial: Unofficial Information
   tip: Personal Tip
+home-page-text: FIP Guide Home Page
+information-disclaimer-short: >-
+  The information provided is unofficial and without guarantee. There is no
+  legal connection to FIP or railway companies.
+menu-close: Close
+menu-open: Menu
+navigate-to-country: Navigate to country
 news-headline: What's new?
 news-other: Other News
-_operator__list_title: Operators supporting FIP
-updateDate: Last updated
-toc_name: Contents
 related:
-  news: Related News
   countries: Related Countries
+  news: Related News
   operators: Related Operators
   operators-nearby: Neighboring Operators
-editPage: Edit page
 reportError: Report an error
-anchorLink:
-  copy: Copy link to this section
-  copied: Link has been copied to the clipboard
+search-placeholder: Search
 skipToContent: Skip to content
-wip: This page is still under construction and content may be incomplete. We would be happy if you contribute to improve this page. [More information on GitHub](https://github.com/fipguide/fipguide.github.io/wiki/English).
-home-page-text: FIP Guide Home Page
-navigate-to-country: Navigate to country
+toc_name: Contents
+updateDate: Last updated
+wip: >-
+  This page is still under construction and content may be incomplete. We would
+  be happy if you contribute to improve this page. [More information on
+  GitHub](https://github.com/fipguide/fipguide.github.io/wiki/English).


### PR DESCRIPTION
This avoids merge conflicts in i18n files if two diverging branches add a new key to the file.