### PR TITLE
fix: Always place the copy icon on the right side on mobile

### DIFF
--- a/assets/sass/anchorlink.scss
+++ b/assets/sass/anchorlink.scss
@@ -1,9 +1,13 @@
 .a-anchorlink {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   margin-bottom: 1.2rem;
   align-items: center;
   column-gap: .8rem;
+
+  @media (max-width: #{$breakpoint-md}) {
+    justify-content: space-between;
+  }
 }
 
 .a-anchorlink > h2 {


### PR DESCRIPTION
Instead of having the copy icon directly after the text (which produced some issues with multi-line texts), always place the the copy icon on the right side. It's easier to reach for right-handed people.

Not 100% sure if the link icon is still recognized with a connection to the title, so happy to hear any feedback.

Resolves https://github.com/fipguide/fipguide.github.io/issues/49

Was originally approved in https://github.com/fipguide/fipguide.github.io/pull/177, but didn't target the correct branch. Here is another attempt to get it to the main branch.