### PR TITLE
fix: Mark `tel:` links as safe

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -2,5 +2,5 @@
 {{- if strings.HasPrefix $url "http" -}}
 {{ partial "link" . }}
 {{- else -}}
-<a href="{{ $url }}">{{ .Text }}</a>
+<a href="{{ $url | safeURL }}">{{ .Text }}</a>
 {{- end -}}


### PR DESCRIPTION
## Description
By default, Hugo only allows using `http:`, `https:`, and `mailto:`. URLs using other schemes are replaced with `#ZgotmplZ`. To allow using `tel:`, we have to declare it as safe using `| safeURL`. This marks every URL as safe which should be fine, since all content inside the repo is trusted.
See https://gohugo.io/functions/safe/url/ for more info.

Closes #185

Originally merged into booking-shortcode in https://github.com/fipguide/fipguide.github.io/pull/189, but it's relevant for main already. Credit goes to @zusorio, I just reopened the PR.