### PR TITLE
Revert "fix: Avoid page jumping when scrollbar appears"

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -1,8 +1,6 @@
 html {
   font-size: 62.5%;
   color: var(--color-onLight);
-
-  overflow-y: scroll;
 }
 
 body {


### PR DESCRIPTION
This reverts commit 85ceeee4991c6c58775f12f20768aae8898959d1.

It breaks the relative positioning of the aside element.