### PR TITLE
fix: Close search when clicking outside of search area

### DIFF
--- a/layouts/partials/stage.html
+++ b/layouts/partials/stage.html
@@ -20,7 +20,18 @@
         placeholder: placeholderText,
       }
     });
+
+    // Close search drawer on outside click
+    document.addEventListener('mousedown', function(e) {
+      const search = document.getElementById('search');
+      if (!search) return;
+      if (search.contains(e.target)) return;
+      const closeBtn = search.querySelector('.pagefind-ui__search-clear');
+      if (closeBtn) closeBtn.click();
+    });
   });
+
+  // Open search on Ctrl + K or Cmd + K
   document.addEventListener('keydown', (e) => {
     if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
       e.preventDefault();


### PR DESCRIPTION
So far, the search dialog could be closed by clicking outside of the search element, but only if no text was entered. If text was entered in the input field, it was no longer possible. This commit closes the search on click outside, independent of entered text in the search field.