### PR TITLE
fix: Always show snack bar in front of other elements

### DIFF
--- a/assets/sass/anchorlink.scss
+++ b/assets/sass/anchorlink.scss
@@ -63,6 +63,7 @@
   align-self: flex-start;
   margin: 1rem;
   text-wrap: balance;
+  z-index: 1000;
 }
 
 .a-snackbar--show {


### PR DESCRIPTION
Resolves #195
