### PR TITLE
fix: Remove "Last updated" from news articles (only show date instead)

### DIFF
--- a/layouts/partials/updateDate.html
+++ b/layouts/partials/updateDate.html
@@ -3,7 +3,6 @@
 
 {{ if eq .Type "news" }}
   <div class="updateDate" data-pagefind-ignore="all">
-    <span>{{ T "updateDate"}}:</span>
     <time datetime="{{ $dateMachine }}">{{ $dateHuman }}</time>
   </div>
 


### PR DESCRIPTION
Resolves #198
