### PR TITLE
fix: Scroll to search when using it

### DIFF
--- a/assets/sass/headings.scss
+++ b/assets/sass/headings.scss
@@ -4,7 +4,6 @@ h1 {
   margin-bottom: 2rem;
   font-weight: 700;
   text-wrap: balance;
-  scroll-margin-top: 7rem;
 }
 
 h2 {
@@ -13,7 +12,6 @@ h2 {
   margin-bottom: 1rem;
   font-weight: 700;
   text-wrap: balance;
-  scroll-margin-top: 7rem;
 }
 
 h3 {
@@ -22,7 +20,6 @@ h3 {
   margin-bottom: 1rem;
   font-weight: 700;
   text-wrap: balance;
-  scroll-margin-top: 7rem;
 }
 
 h4 {
@@ -31,9 +28,4 @@ h4 {
   margin-bottom: 1rem;
   font-weight: 700;
   text-wrap: balance;
-  scroll-margin-top: 7rem;
-}
-
-sup {
-  scroll-margin-top: 7rem;
 }

--- a/assets/sass/navigation.scss
+++ b/assets/sass/navigation.scss
@@ -1,5 +1,5 @@
 #header {
-  position: fixed;
+  position: sticky;
   width: 100%;
   top: 0;
   box-shadow: 0 .4rem 1rem 0 rgba(0,0,0,.1);
@@ -9,6 +9,7 @@
   background-color: var(--bg-default);
   z-index: 5;
   position: relative;
+  height: 6rem;
 }
 
 .o-header__wrapper {

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -1,6 +1,7 @@
 html {
   font-size: 62.5%;
   color: var(--color-onLight);
+  scroll-padding-top: 8rem;
 }
 
 body {
@@ -29,9 +30,8 @@ a {
   }
 }
 
-//space for fixed header
 main {
-  margin-top: 8rem;
+  margin-top: 2rem;
 }
 
 .container.o-list:not(.o-list--news) {

--- a/layouts/partials/search-slot.html
+++ b/layouts/partials/search-slot.html
@@ -26,9 +26,20 @@
       const search = document.getElementById('search');
       if (!search) return;
       if (search.contains(e.target)) return;
-      const closeBtn = search.querySelector('.pagefind-ui__search-clear');
-      if (closeBtn) closeBtn.click();
+      const searchInput = search.querySelector('input.pagefind-ui__search-input');
+      if (searchInput && document.activeElement === searchInput) {
+        const closeBtn = search.querySelector('.pagefind-ui__search-clear');
+        if (closeBtn) closeBtn.click();
+      }
     });
+
+    // Scroll to search on click
+    const search = document.getElementById('search');
+    if (search) {
+      search.addEventListener('click', function() {
+        search.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
+    }
   });
 
   // Open search on Ctrl + K or Cmd + K
@@ -38,6 +49,10 @@
       const searchElement = document.querySelector('#search input');
       if (searchElement) {
         searchElement.focus();
+        const search = document.getElementById('search');
+        if (search) {
+          search.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
       }
     }
   });


### PR DESCRIPTION
This improves the usage of the search, since it's always placed at the top of the screen when using it. Search results are no longer hidden below a keyboard or the end of the screen.