### PR TITLE
docs: Remove ignore cache instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ npm i
 Then, we can start the integrated hugo server with:
 
 ```zsh
-hugo server --ignoreCache
+hugo server
 ```
 
 Check the output and follow the link to see a local preview of the changes.


### PR DESCRIPTION
The cache is mainly used by images and is generally not bad. With an increasing number of images, the preprocessing takes longer, leading to increased startup time.

There are some caching issues with hugo, but these are not solved using the `--ignoreCache` attribute. Instead, a full restart of the application is necessary in certain cases. 