### PR TITLE
fix: Scope footnotes to their corresponding booking section

### DIFF
--- a/layouts/partials/booking.html
+++ b/layouts/partials/booking.html
@@ -46,8 +46,8 @@
 {{- if or (eq .reservations false) (eq .reservations "nil") }}
   {{- $contentClasses = $contentClasses | append "o-booking__section-reservations--hidden" -}}
 {{- end -}}
-<div class="{{ delimit $contentClasses " " }}">
-    {{- .page.Content -}}
+<div class="{{ delimit $contentClasses ' ' }}">
+    {{- partial "prefix-footnotes" (dict "content" .page.Content "prefix" .page.File.ContentBaseName) | safeHTML -}}
 </div>
 
 {{ partial "booking-links" .page }}

--- a/layouts/partials/prefix-footnotes.html
+++ b/layouts/partials/prefix-footnotes.html
@@ -1,0 +1,7 @@
+{{- $patternFnref := `fnref:(\d+)` -}}
+{{- $replacementFnref := (printf "fnref:%s:$1" .prefix) -}}
+{{- $patternFn := `fn:(\d+)` -}}
+{{- $replacementFn := (printf "fn:%s:$1" .prefix) -}}
+{{- $content := replaceRE $patternFnref $replacementFnref .content -}}
+{{- $content := replaceRE $patternFn $replacementFn $content -}}
+{{- return $content -}}


### PR DESCRIPTION
Otherwise, the anchor ids are conflicting when a booking section with footnotes is embedded into an operator page.