### PR TITLE
fix: Add original image quality to srcset

### DIFF
--- a/layouts/partials/image.html
+++ b/layouts/partials/image.html
@@ -12,20 +12,20 @@
 
 <picture>
   {{- $widths := slice -}}
-  {{- if gt $image.Width 2200 -}}
-    {{- $widths = $widths | append 2200 -}}
-  {{- end -}}
-  {{- if gt $image.Width 1500 -}}
-    {{- $widths = $widths | append 1500 -}}
-  {{- end -}}
-  {{- if gt $image.Width 1200 -}}
-    {{- $widths = $widths | append 1200 -}}
+  {{- if gt $image.Width 500 -}}
+    {{- $widths = $widths | append 500 -}}
   {{- end -}}
   {{- if gt $image.Width 800 -}}
     {{- $widths = $widths | append 800 -}}
   {{- end -}}
-  {{- if gt $image.Width 500 -}}
-    {{- $widths = $widths | append 500 -}}
+  {{- if gt $image.Width 1200 -}}
+    {{- $widths = $widths | append 1200 -}}
+  {{- end -}}
+  {{- if gt $image.Width 1500 -}}
+    {{- $widths = $widths | append 1500 -}}
+  {{- end -}}
+  {{- if gt $image.Width 2200 -}}
+    {{- $widths = $widths | append 2200 -}}
   {{- end -}}
 
   {{- $srcset := slice -}}
@@ -34,6 +34,6 @@
       {{- $srcset = $srcset | append (printf "%s %dw" .RelPermalink $width) -}}
     {{- end -}}
   {{- end -}}
-
+  {{- $srcset = $srcset | append (printf "%s %dw" $image.RelPermalink $image.Width) -}}
   {{- printf "<img src=\"%s\" alt=\"\" loading=\"%s\" srcset=\"%s\" sizes=\"(max-width: 576px) calc(100vw - 3.2rem), (max-width: 768px) 540px, (max-width: 992px) 720px, (max-width: 1200px) 960px, (max-width: 1400px) 1140px, 1320px\">" $image.RelPermalink $loading (delimit $srcset ", ") | safeHTML -}}
 </picture>


### PR DESCRIPTION
This allows browsers to render the highest possible image quality.

Resolves #235.
