### PR TITLE
feat: Add interactive map to navigate countries

### DIFF
--- a/assets/js/interactiveMap.js
+++ b/assets/js/interactiveMap.js
@@ -1,0 +1,39 @@
+import Panzoom from '@panzoom/panzoom';
+
+window.initializeInteractiveMap = function() {
+    const svg = document.querySelector('.o-interactive-map__container svg');
+    if (svg) {
+            // Ensure proper scaling
+            svg.setAttribute('viewBox', '0 0 1300 1300');
+
+            const panzoom = Panzoom(svg, {
+                maxScale: 5,
+                minScale: 1,
+                startScale: 1,
+                contain: 'outside'
+            });
+
+            // Enable mouse wheel zoom
+            svg.parentElement.addEventListener('wheel', panzoom.zoomWithWheel);
+
+            // Enable double-click zoom
+            svg.addEventListener('dblclick', (e) => {
+                e.preventDefault();
+                panzoom.zoomIn({ step: 0.5 });
+            });
+
+            // Add country click functionality
+            const countries = svg.querySelectorAll('[id]');
+            countries.forEach(country => {
+                if (window.availableCountries && window.availableCountries.includes(country.id)) {
+                    country.style.cursor = 'pointer';
+                    country.classList.add('o-interactive-map__country--available');
+
+                    country.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        window.location.href = `/${window.currentLanguage}/country/${country.id}/`;
+                    });
+                }
+            });
+    }
+};

--- a/assets/js/interactiveMap.js
+++ b/assets/js/interactiveMap.js
@@ -22,6 +22,31 @@ window.initializeInteractiveMap = function() {
                 panzoom.zoomIn({ step: 0.5 });
             });
 
+            const zoomInBtn = document.querySelector('.o-interactive-map__zoom-in');
+            const zoomOutBtn = document.querySelector('.o-interactive-map__zoom-out');
+            const resetBtn = document.querySelector('.o-interactive-map__reset');
+
+            if (zoomInBtn) {
+                zoomInBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    panzoom.zoomIn({ step: 0.5 });
+                });
+            }
+
+            if (zoomOutBtn) {
+                zoomOutBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    panzoom.zoomOut({ step: 0.5 });
+                });
+            }
+
+            if (resetBtn) {
+                resetBtn.addEventListener('click', (e) => {
+                    e.preventDefault();
+                    panzoom.reset();
+                });
+            }
+
             // Add country click functionality
             const countries = svg.querySelectorAll('[id]');
             countries.forEach(country => {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -4,3 +4,4 @@ import './resizeObserver.js';
 import './mediaqueries.js';
 import './highlightHeadline.js';
 import './anchorlinks.js';
+import './interactiveMap.js';

--- a/assets/sass/interactiveMap.scss
+++ b/assets/sass/interactiveMap.scss
@@ -1,4 +1,8 @@
 .o-interactive-map {
+  &__wrapper {
+    position: relative;
+  }
+
   &__container {
     border-radius: var(--border-radius-m);
     box-shadow: var(--box-shadow);
@@ -9,6 +13,16 @@
       width: 100%;
       height: 100%;
     }
+  }
+
+  &__controls {
+    position: absolute;
+    bottom: 1rem;
+    right: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    z-index: 10;
   }
 
   .o-interactive-map__country--available {
@@ -25,5 +39,23 @@
 
   .o-interactive-map--loading {
     padding: 1rem;
+  }
+
+  .o-interactive-map__controls button {
+    background-color: var(--link-default);
+    color: var(--bg-neutral);
+    border-radius: var(--border-radius-m);
+    border: 0;
+    width: 4rem;
+    aspect-ratio: 1 / 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 3rem;
+    transition: all 0.2s ease;
+
+    &:hover {
+      background-color: var(--link-hovered);
+    }
   }
 }

--- a/assets/sass/interactiveMap.scss
+++ b/assets/sass/interactiveMap.scss
@@ -1,0 +1,29 @@
+.o-interactive-map {
+  &__container {
+    border-radius: var(--border-radius-m);
+    box-shadow: var(--box-shadow);
+    width: 100%;
+    aspect-ratio: 1 / 1;
+
+    svg {
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  .o-interactive-map__country--available {
+    path {
+      fill: var(--link-default) !important;
+      transition: all 0.2s ease;
+      cursor: pointer;
+    }
+
+    &:hover path {
+      fill: var(--link-hovered) !important;
+    }
+  }
+
+  .o-interactive-map--loading {
+    padding: 1rem;
+  }
+}

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -16,3 +16,4 @@
 @import "booking.scss";
 @import "button.scss";
 @import "startpage.scss";
+@import "interactiveMap.scss";

--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -142,6 +142,17 @@ img {
   align-items: center;
 }
 
+.o-list__countries{
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+
+  @media (max-width: #{$breakpoint-lg}) {
+    display: flex;
+    flex-direction: column;
+  }
+}
+
 @mixin add-columns($columns) {
   &--columns-#{$columns} {
     columns: $columns;

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -14,11 +14,13 @@ booking:
   reservation-costs: Reservierungskosten
   visit-additional-information-website: Weitere Informationen
   visit-booking-website: Zur Buchungsseite
+countries:
+  overview: Alle Länder
+  selection: Länderauswahl
 country:
   many: Länder
   one: Land
   other: Länder
-countryselection: Länderauswahl
 editPage: Seite bearbeiten
 footer-love:
   aria-label: Made with love in Aachen, Frankfurt, Köln & Paris
@@ -32,6 +34,9 @@ home-page-text: FIP Guide Startseite
 information-disclaimer-short: >-
   Diese Informationen sind inoffiziell und ohne Gewähr. Es besteht keine
   rechtliche Verbindung zu FIP oder Bahngesellschaften.
+interactiveMap:
+  loading: Lade interaktive Karte...
+  title: Interaktive Länderkarte
 menu-close: Schließen
 menu-open: Menü
 navigate-to-country: Gehe zu Land

--- a/i18n/de.yaml
+++ b/i18n/de.yaml
@@ -36,7 +36,10 @@ information-disclaimer-short: >-
   rechtliche Verbindung zu FIP oder Bahngesellschaften.
 interactiveMap:
   loading: Lade interaktive Karte...
+  resetZoom: Zoom zurücksetzen
   title: Interaktive Länderkarte
+  zoomIn: Hineinzoomen
+  zoomOut: Herauszoomen
 menu-close: Schließen
 menu-open: Menü
 navigate-to-country: Gehe zu Land

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -35,7 +35,10 @@ information-disclaimer-short: >-
   legal connection to FIP or railway companies.
 interactiveMap:
   loading: Loading interactive map...
+  resetZoom: Reset Zoom
   title: Interactive Country Map
+  zoomIn: Zoom In
+  zoomOut: Zoom Out
 menu-close: Close
 menu-open: Menu
 navigate-to-country: Navigate to country

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -13,11 +13,13 @@ booking:
   reservation-costs: Reservation Costs
   visit-additional-information-website: Additional Information
   visit-booking-website: To Booking Website
+countries:
+  overview: All Countries
+  selection: choose country
 country:
   many: countries
   one: country
   other: countries
-countryselection: choose country
 editPage: Edit page
 footer-love:
   aria-label: Made with love in Aachen, Frankfurt, Cologne & Paris
@@ -31,6 +33,9 @@ home-page-text: FIP Guide Home Page
 information-disclaimer-short: >-
   The information provided is unofficial and without guarantee. There is no
   legal connection to FIP or railway companies.
+interactiveMap:
+  loading: Loading interactive map...
+  title: Interactive Country Map
 menu-close: Close
 menu-open: Menu
 navigate-to-country: Navigate to country

--- a/i18n/fr.yaml
+++ b/i18n/fr.yaml
@@ -30,6 +30,12 @@ home-page-text: Page d'accueil du FIP Guide
 information-disclaimer-short: >-
   Les informations fournies sont non officielles et sans garantie. Il n'existe
   aucun lien juridique avec le FIP ou les compagnies ferroviaires.
+interactiveMap:
+  loading: Chargement de la carte interactive...
+  resetZoom: Réinitialiser le zoom
+  title: Carte interactive des pays
+  zoomIn: Zoom avant
+  zoomOut: Zoom arrière
 menu-close: Fermer
 menu-open: Menu
 navigate-to-country: Aller au pays

--- a/layouts/country/list.html
+++ b/layouts/country/list.html
@@ -2,17 +2,50 @@
   <article class="o-list o-list__container">
     <h1 data-pagefind-meta="title">{{ .Title }}</h1>
     {{ .Content }}
-    <div class="o-list__list">
-      {{ range .Pages }}
-      <a href="{{ .RelPermalink }}" class="o-list__link">
-        <div class="o-list__picture">
-          {{ partial "flag" (dict "country" .File.ContentBaseName) }}
+    <div class="o-list__countries">
+      <div>
+        <h2>{{ T "countries.overview" }}</h2>
+        <div class="o-list__list">
+          {{ range .Pages }}
+          <a href="{{ .RelPermalink }}" class="o-list__link">
+            <div class="o-list__picture">
+              {{ partial "flag" (dict "country" .File.ContentBaseName) }}
+            </div>
+            <div>
+              {{ .Title }}
+            </div>
+          </a>
+          {{ end }}
         </div>
-        <div>
-          {{ .Title }}
+      </div>
+      <div class="o-interactive-map">
+        <h2>{{ T "interactiveMap.title" }}</h2>
+        <div id="interactive-map__container" class="o-interactive-map__container">
+          <p class="o-interactive-map--loading"><em>{{ T "interactiveMap.loading" }}</em></p>
         </div>
-      </a>
-      {{ end }}
+      </div>
     </div>
   </article>
+
+
+  <script>
+    window.availableCountries = [
+      {{- range .Pages -}}
+      "{{ .File.ContentBaseName }}"{{ if not (eq . (index (last 1 $.Pages) 0)) }},{{ end }}
+      {{- end -}}
+    ];
+
+    window.currentLanguage = "{{ .Language.Lang }}";
+
+    fetch('/map_europe.svg')
+      .then(response => response.text())
+      .then(svgContent => {
+        document.getElementById('interactive-map__container').innerHTML = svgContent;
+
+        window.initializeInteractiveMap();
+      })
+      .catch(error => {
+        console.error('Error loading SVG:', error);
+      });
+  </script>
 {{ end }}

--- a/layouts/country/list.html
+++ b/layouts/country/list.html
@@ -20,8 +20,21 @@
       </div>
       <div class="o-interactive-map">
         <h2>{{ T "interactiveMap.title" }}</h2>
-        <div id="interactive-map__container" class="o-interactive-map__container">
-          <p class="o-interactive-map--loading"><em>{{ T "interactiveMap.loading" }}</em></p>
+        <div class="o-interactive-map__wrapper">
+          <div id="interactive-map__container" class="o-interactive-map__container">
+            <p class="o-interactive-map--loading"><em>{{ T "interactiveMap.loading" }}</em></p>
+          </div>
+          <div class="o-interactive-map__controls">
+            <button class="o-interactive-map__zoom-in" title="{{ T "interactiveMap.zoomIn" }}" aria-label="{{ T "interactiveMap.zoomIn" }}">
+              {{ partial "icon" "add" }}
+            </button>
+            <button class="o-interactive-map__zoom-out" title="{{ T "interactiveMap.zoomOut" }}" aria-label="{{ T "interactiveMap.zoomOut" }}">
+              {{ partial "icon" "remove" }}
+            </button>
+            <button class="o-interactive-map__reset" title="{{ T "interactiveMap.resetZoom" }}" aria-label="{{ T "interactiveMap.resetZoom" }}">
+              {{ partial "icon" "crop_free" }}
+            </button>
+          </div>
         </div>
       </div>
     </div>

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -19,7 +19,7 @@
       <menu>
         <li class="o-header__item">
           <button class="o-header__expand-button" aria-haspopup="true" aria-expanded="false">
-            <span>{{ T "countryselection" }}</span>
+            <span>{{ T "countries.selection" }}</span>
             {{ partial "icon" "keyboard_arrow_down" }}
           </button>
           <span id="menu-country-list-title">{{ T "country" }}</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fontsource/material-symbols-rounded": "^5.2.10",
         "@fontsource/roboto": "^5.2.5",
         "@fontsource/sansita": "^5.2.5",
+        "@panzoom/panzoom": "^4.6.0",
         "pagefind": "^1.3.0"
       },
       "devDependencies": {
@@ -109,6 +110,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@panzoom/panzoom": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@panzoom/panzoom/-/panzoom-4.6.0.tgz",
+      "integrity": "sha512-3KxkY1lNKFn98fW5ZFR6vV0YzsXj3I4EQDyFWSXME6/cic86eSS7VjuqIjrA3PEpySo0r5fFtlX8eYCt4JPUFQ==",
+      "license": "MIT"
     },
     "node_modules/pagefind": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@fontsource/material-symbols-rounded": "^5.2.10",
     "@fontsource/roboto": "^5.2.5",
     "@fontsource/sansita": "^5.2.5",
+    "@panzoom/panzoom": "^4.6.0",
     "pagefind": "^1.3.0"
   },
   "devDependencies": {

--- a/static/map_europe.svg
+++ b/static/map_europe.svg
@@ -1,0 +1,5807 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="1300"
+   height="1300"
+   id="svg4036"
+   version="1.1"
+   inkscape:version="1.1 (c4e8f9e, 2021-05-24)"
+   sodipodi:docname="map_europe.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4038">
+    <radialGradient
+       id="Shadow_Sea_1_"
+       cx="272.20831"
+       cy="275.00369"
+       r="396.54739"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69513411,0,0,0.69499014,-39.894723,206.84105)">
+      <stop
+         offset="0.6429"
+         style="stop-color:#B2E0F6"
+         id="stop11-1" />
+      <stop
+         offset="0.7859"
+         style="stop-color:#B0DEF5"
+         id="stop13-8" />
+      <stop
+         offset="0.8374"
+         style="stop-color:#A9D9EF"
+         id="stop15-3" />
+      <stop
+         offset="0.8742"
+         style="stop-color:#9ECFE6"
+         id="stop17-3" />
+      <stop
+         offset="0.9039"
+         style="stop-color:#8DC1D9"
+         id="stop19-0" />
+      <stop
+         offset="0.9293"
+         style="stop-color:#77AFC8"
+         id="stop21-5" />
+      <stop
+         offset="0.9519"
+         style="stop-color:#5B98B2"
+         id="stop23-6" />
+      <stop
+         offset="0.9722"
+         style="stop-color:#3B7E99"
+         id="stop25-5" />
+      <stop
+         offset="0.9903"
+         style="stop-color:#17607D"
+         id="stop27-0" />
+      <stop
+         offset="1"
+         style="stop-color:#004D6B"
+         id="stop29-5" />
+    </radialGradient>
+    <radialGradient
+       id="Shadow_land_1_"
+       cx="272.20831"
+       cy="275.00369"
+       r="396.54739"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6951341,0,0,0.69499013,-39.894723,206.84105)">
+      <stop
+         offset="0.7473"
+         style="stop-color:#FDFBE5"
+         id="stop34" />
+      <stop
+         offset="0.8516"
+         style="stop-color:#FBF9E3"
+         id="stop36" />
+      <stop
+         offset="0.8892"
+         style="stop-color:#F4F2DE"
+         id="stop38" />
+      <stop
+         offset="0.916"
+         style="stop-color:#E9E7D4"
+         id="stop40" />
+      <stop
+         offset="0.9377"
+         style="stop-color:#D8D6C5"
+         id="stop42" />
+      <stop
+         offset="0.9562"
+         style="stop-color:#C2C0B3"
+         id="stop44" />
+      <stop
+         offset="0.9727"
+         style="stop-color:#A6A69C"
+         id="stop46" />
+      <stop
+         offset="0.9872"
+         style="stop-color:#878782"
+         id="stop48" />
+      <stop
+         offset="1"
+         style="stop-color:#646464"
+         id="stop50" />
+    </radialGradient>
+    <radialGradient
+       id="grSea"
+       fy="207.75"
+       fx="345.25"
+       class="seabase gradient"
+       cx="276.5"
+       cy="276.5"
+       r="275"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         style="stop-color:#FFFFFF;stop-opacity:0;"
+         offset="0"
+         id="sEdge" />
+      <stop
+         style="stop-color:#808080;stop-opacity:0.0625;"
+         offset="0.707106781186547"
+         id="sMid" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25;"
+         offset="1"
+         id="sCentre" />
+    </radialGradient>
+    <radialGradient
+       id="radialGradient4130-1-7"
+       cx="265.10001"
+       cy="189.75"
+       r="349.79999"
+       fx="265.10001"
+       fy="189.75"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-opacity="0"
+         stop-color="#000"
+         offset="0"
+         id="stop11-5" />
+      <stop
+         stop-opacity="0.023"
+         stop-color="#000"
+         offset="0.49"
+         id="stop13-5" />
+      <stop
+         stop-opacity="0.035"
+         stop-color="#000"
+         offset="0.57"
+         id="stop15-6" />
+      <stop
+         stop-opacity="0.067"
+         stop-color="#000"
+         offset="0.64"
+         id="stop17-4" />
+      <stop
+         stop-opacity="0.149"
+         stop-color="#000"
+         offset="0.7"
+         id="stop19-1" />
+      <stop
+         stop-opacity="0.213"
+         stop-color="#000"
+         offset="0.73"
+         id="stop21-1" />
+      <stop
+         stop-opacity="0.546"
+         stop-color="#000"
+         offset="1"
+         id="stop23-0" />
+    </radialGradient>
+    <radialGradient
+       id="radialGradient4130-1"
+       cx="265.10001"
+       cy="189.75"
+       r="349.79999"
+       fx="265.10001"
+       fy="189.75"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-opacity="0"
+         stop-color="#000"
+         offset="0"
+         id="stop11" />
+      <stop
+         stop-opacity="0.023"
+         stop-color="#000"
+         offset="0.49"
+         id="stop13" />
+      <stop
+         stop-opacity="0.035"
+         stop-color="#000"
+         offset="0.57"
+         id="stop15" />
+      <stop
+         stop-opacity="0.067"
+         stop-color="#000"
+         offset="0.64"
+         id="stop17" />
+      <stop
+         stop-opacity="0.149"
+         stop-color="#000"
+         offset="0.7"
+         id="stop19" />
+      <stop
+         stop-opacity="0.213"
+         stop-color="#000"
+         offset="0.73"
+         id="stop21" />
+      <stop
+         stop-opacity="0.546"
+         stop-color="#000"
+         offset="1"
+         id="stop23" />
+    </radialGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="275"
+       cy="276.5"
+       cx="276.5"
+       class="seabase gradient"
+       fx="345.25"
+       fy="207.75"
+       id="grSea-1">
+      <stop
+         id="sEdge-5"
+         offset="0"
+         style="stop-color:#FFFFFF;stop-opacity:0;" />
+      <stop
+         id="sMid-2"
+         offset="0.707106781186547"
+         style="stop-color:#808080;stop-opacity:0.0625;" />
+      <stop
+         id="sCentre-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.25;" />
+    </radialGradient>
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       r="275"
+       cy="276.5"
+       cx="276.5"
+       class="seabase gradient"
+       fx="345.25"
+       fy="207.75"
+       id="grSea-9">
+      <stop
+         id="sEdge-1"
+         offset="0"
+         style="stop-color:#FFFFFF;stop-opacity:0;" />
+      <stop
+         id="sMid-9"
+         offset="0.707106781186547"
+         style="stop-color:#808080;stop-opacity:0.0625;" />
+      <stop
+         id="sCentre-3"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.25;" />
+    </radialGradient>
+    <radialGradient
+       gradientTransform="matrix(0.6951341,0,0,0.69499013,-39.894723,206.84105)"
+       gradientUnits="userSpaceOnUse"
+       r="396.54739"
+       cy="275.00369"
+       cx="272.20831"
+       id="Shadow_land_1_-0">
+      <stop
+         id="stop34-4"
+         style="stop-color:#FDFBE5"
+         offset="0.7473" />
+      <stop
+         id="stop36-3"
+         style="stop-color:#FBF9E3"
+         offset="0.8516" />
+      <stop
+         id="stop38-1"
+         style="stop-color:#F4F2DE"
+         offset="0.8892" />
+      <stop
+         id="stop40-7"
+         style="stop-color:#E9E7D4"
+         offset="0.916" />
+      <stop
+         id="stop42-9"
+         style="stop-color:#D8D6C5"
+         offset="0.9377" />
+      <stop
+         id="stop44-4"
+         style="stop-color:#C2C0B3"
+         offset="0.9562" />
+      <stop
+         id="stop46-7"
+         style="stop-color:#A6A69C"
+         offset="0.9727" />
+      <stop
+         id="stop48-0"
+         style="stop-color:#878782"
+         offset="0.9872" />
+      <stop
+         id="stop50-1"
+         style="stop-color:#646464"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       gradientTransform="matrix(0.69513411,0,0,0.69499014,-39.894723,206.84105)"
+       gradientUnits="userSpaceOnUse"
+       r="396.54739"
+       cy="275.00369"
+       cx="272.20831"
+       id="Shadow_Sea_1_-6">
+      <stop
+         id="stop11-1-9"
+         style="stop-color:#B2E0F6"
+         offset="0.6429" />
+      <stop
+         id="stop13-8-1"
+         style="stop-color:#B0DEF5"
+         offset="0.7859" />
+      <stop
+         id="stop15-3-4"
+         style="stop-color:#A9D9EF"
+         offset="0.8374" />
+      <stop
+         id="stop17-3-1"
+         style="stop-color:#9ECFE6"
+         offset="0.8742" />
+      <stop
+         id="stop19-0-4"
+         style="stop-color:#8DC1D9"
+         offset="0.9039" />
+      <stop
+         id="stop21-5-6"
+         style="stop-color:#77AFC8"
+         offset="0.9293" />
+      <stop
+         id="stop23-6-1"
+         style="stop-color:#5B98B2"
+         offset="0.9519" />
+      <stop
+         id="stop25-5-0"
+         style="stop-color:#3B7E99"
+         offset="0.9722" />
+      <stop
+         id="stop27-0-2"
+         style="stop-color:#17607D"
+         offset="0.9903" />
+      <stop
+         id="stop29-5-4"
+         style="stop-color:#004D6B"
+         offset="1" />
+    </radialGradient>
+    <style
+       id="style6789"
+       type="text/css">
+
+    .str0 {stroke:#1F1A17;stroke-width:74.7387}
+    .str13 {stroke:#0093DD;stroke-width:146.241}
+    .str14 {stroke:#0093DD;stroke-width:146.241;stroke-linecap:round;stroke-linejoin:round}
+    .str5 {stroke:#1F1A17;stroke-width:146.241}
+    .str10 {stroke:white;stroke-width:146.241}
+    .str6 {stroke:white;stroke-width:146.241;stroke-linecap:round;stroke-linejoin:round}
+    .str2 {stroke:white;stroke-width:146.241}
+    .str7 {stroke:white;stroke-width:146.241;stroke-linecap:round;stroke-linejoin:round}
+    .str12 {stroke:#0093DD;stroke-width:149.477}
+    .str15 {stroke:#0093DD;stroke-width:149.477;stroke-linejoin:round}
+    .str16 {stroke:#0093DD;stroke-width:149.477;stroke-linecap:round;stroke-linejoin:round}
+    .str1 {stroke:white;stroke-width:149.477}
+    .str8 {stroke:white;stroke-width:149.477;stroke-linejoin:round}
+    .str9 {stroke:white;stroke-width:149.477;stroke-linecap:round;stroke-linejoin:round}
+    .str3 {stroke:white;stroke-width:149.477}
+    .str4 {stroke:white;stroke-width:149.477;stroke-linecap:round;stroke-linejoin:round}
+    .str11 {stroke:white;stroke-width:149.477;stroke-dasharray:149.477 149.477}
+    .fil0 {fill:none}
+    .fil9 {fill:none;fill-rule:nonzero}
+    .fil10 {fill:white}
+    .fil5 {fill:#00873B}
+    .fil4 {fill:#A3D39A}
+    .fil1 {fill:#C0C1C5}
+    .fil11 {fill:#CCCED1}
+    .fil3 {fill:#D1D2D5}
+    .fil7 {fill:white}
+    .fil8 {fill:white;fill-rule:nonzero}
+    .fil12 {fill:#00873B;fill-rule:nonzero}
+    .fil6 {fill:#C0C1C5;fill-rule:nonzero}
+    .fil2 {fill:#D1D2D5;fill-rule:nonzero}
+
+  </style>
+    <inkscape:perspective
+       id="perspective7400"
+       inkscape:persp3d-origin="1024 : 573.33333 : 1"
+       inkscape:vp_z="2048 : 860 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 860 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <style
+       id="style6789-9"
+       type="text/css">
+
+    .str0 {stroke:#1F1A17;stroke-width:74.7387}
+    .str13 {stroke:#0093DD;stroke-width:146.241}
+    .str14 {stroke:#0093DD;stroke-width:146.241;stroke-linecap:round;stroke-linejoin:round}
+    .str5 {stroke:#1F1A17;stroke-width:146.241}
+    .str10 {stroke:white;stroke-width:146.241}
+    .str6 {stroke:white;stroke-width:146.241;stroke-linecap:round;stroke-linejoin:round}
+    .str2 {stroke:white;stroke-width:146.241}
+    .str7 {stroke:white;stroke-width:146.241;stroke-linecap:round;stroke-linejoin:round}
+    .str12 {stroke:#0093DD;stroke-width:149.477}
+    .str15 {stroke:#0093DD;stroke-width:149.477;stroke-linejoin:round}
+    .str16 {stroke:#0093DD;stroke-width:149.477;stroke-linecap:round;stroke-linejoin:round}
+    .str1 {stroke:white;stroke-width:149.477}
+    .str8 {stroke:white;stroke-width:149.477;stroke-linejoin:round}
+    .str9 {stroke:white;stroke-width:149.477;stroke-linecap:round;stroke-linejoin:round}
+    .str3 {stroke:white;stroke-width:149.477}
+    .str4 {stroke:white;stroke-width:149.477;stroke-linecap:round;stroke-linejoin:round}
+    .str11 {stroke:white;stroke-width:149.477;stroke-dasharray:149.477 149.477}
+    .fil0 {fill:none}
+    .fil9 {fill:none;fill-rule:nonzero}
+    .fil10 {fill:white}
+    .fil5 {fill:#00873B}
+    .fil4 {fill:#A3D39A}
+    .fil1 {fill:#C0C1C5}
+    .fil11 {fill:#CCCED1}
+    .fil3 {fill:#D1D2D5}
+    .fil7 {fill:white}
+    .fil8 {fill:white;fill-rule:nonzero}
+    .fil12 {fill:#00873B;fill-rule:nonzero}
+    .fil6 {fill:#C0C1C5;fill-rule:nonzero}
+    .fil2 {fill:#D1D2D5;fill-rule:nonzero}
+
+  </style>
+    <inkscape:perspective
+       id="perspective7400-9"
+       inkscape:persp3d-origin="1024 : 573.33333 : 1"
+       inkscape:vp_z="2048 : 860 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 860 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 238.3638 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="939.74725 : 238.3638 : 1"
+       inkscape:persp3d-origin="469.87363 : 158.9092 : 1"
+       id="perspective2495" />
+    <g
+       id="s">
+      <g
+         id="c">
+        <path
+           d="M 0,0 0,1 0.5,1 Z"
+           id="t"
+           transform="matrix(0.95105652,0.30901699,-0.30901699,0.95105652,0,-1)"
+           inkscape:connector-curvature="0" />
+        <use
+           transform="scale(-1,1)"
+           xlink:href="#t"
+           id="use9"
+           x="0"
+           y="0"
+           width="100%"
+           height="100%" />
+      </g>
+      <g
+         id="a">
+        <use
+           transform="matrix(0.30901699,0.95105652,-0.95105652,0.30901699,0,0)"
+           xlink:href="#c"
+           id="use12"
+           x="0"
+           y="0"
+           width="100%"
+           height="100%" />
+        <use
+           transform="matrix(-0.80901699,0.58778525,-0.58778525,-0.80901699,0,0)"
+           xlink:href="#c"
+           id="use14"
+           x="0"
+           y="0"
+           width="100%"
+           height="100%" />
+      </g>
+      <use
+         transform="scale(-1,1)"
+         xlink:href="#a"
+         id="use16"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </g>
+    <style
+       id="style6789-8"
+       type="text/css">
+
+    .str0 {stroke:#1F1A17;stroke-width:74.7387}
+    .str13 {stroke:#0093DD;stroke-width:146.241}
+    .str14 {stroke:#0093DD;stroke-width:146.241;stroke-linecap:round;stroke-linejoin:round}
+    .str5 {stroke:#1F1A17;stroke-width:146.241}
+    .str10 {stroke:white;stroke-width:146.241}
+    .str6 {stroke:white;stroke-width:146.241;stroke-linecap:round;stroke-linejoin:round}
+    .str2 {stroke:white;stroke-width:146.241}
+    .str7 {stroke:white;stroke-width:146.241;stroke-linecap:round;stroke-linejoin:round}
+    .str12 {stroke:#0093DD;stroke-width:149.477}
+    .str15 {stroke:#0093DD;stroke-width:149.477;stroke-linejoin:round}
+    .str16 {stroke:#0093DD;stroke-width:149.477;stroke-linecap:round;stroke-linejoin:round}
+    .str1 {stroke:white;stroke-width:149.477}
+    .str8 {stroke:white;stroke-width:149.477;stroke-linejoin:round}
+    .str9 {stroke:white;stroke-width:149.477;stroke-linecap:round;stroke-linejoin:round}
+    .str3 {stroke:white;stroke-width:149.477}
+    .str4 {stroke:white;stroke-width:149.477;stroke-linecap:round;stroke-linejoin:round}
+    .str11 {stroke:white;stroke-width:149.477;stroke-dasharray:149.477 149.477}
+    .fil0 {fill:none}
+    .fil9 {fill:none;fill-rule:nonzero}
+    .fil10 {fill:white}
+    .fil5 {fill:#00873B}
+    .fil4 {fill:#A3D39A}
+    .fil1 {fill:#C0C1C5}
+    .fil11 {fill:#CCCED1}
+    .fil3 {fill:#D1D2D5}
+    .fil7 {fill:white}
+    .fil8 {fill:white;fill-rule:nonzero}
+    .fil12 {fill:#00873B;fill-rule:nonzero}
+    .fil6 {fill:#C0C1C5;fill-rule:nonzero}
+    .fil2 {fill:#D1D2D5;fill-rule:nonzero}
+
+  </style>
+    <inkscape:perspective
+       id="perspective7400-5"
+       inkscape:persp3d-origin="1024 : 573.33333 : 1"
+       inkscape:vp_z="2048 : 860 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 860 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <clipPath
+       id="clip0">
+      <use
+         id="use10"
+         xlink:href="#Frame"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </clipPath>
+    <path
+       d="m -739.91,26.75 c 12.057,97.116 39.088,136.432 75.023,179.214 63.674,78.07 176.124,141.611 267.812,168.91 l 794.15,0 c 91.688,-27.299 204.138,-90.84 267.812,-168.91 35.935,-42.782 62.966,-82.098 75.023,-179.214 l 0,-53.5 c -12.057,-97.116 -39.088,-136.432 -75.023,-179.214 -63.674,-78.07 -176.124,-141.611 -267.812,-168.91 l -794.15,0 c -91.688,27.299 -204.138,90.84 -267.812,168.91 -35.935,42.782 -62.966,82.098 -75.023,179.214 z"
+       id="Frame"
+       transform="translate(749.5,386.931)"
+       inkscape:connector-curvature="0" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.55708397"
+     inkscape:cx="674.94313"
+     inkscape:cy="735.07769"
+     inkscape:document-units="px"
+     inkscape:current-layer="Boders"
+     showgrid="false"
+     inkscape:window-width="1871"
+     inkscape:window-height="1027"
+     inkscape:window-x="49"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
+  <metadata
+     id="metadata4041">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+        <cc:license
+           rdf:resource="" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Addicted04</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Sea"
+     inkscape:groupmode="layer"
+     id="Sea"
+     transform="translate(-603.68384,627.99738)"
+     sodipodi:insensitive="true">
+    <g
+       transform="matrix(7.2635634,0,0,7.2635634,116.59226,-2779.0465)"
+       id="g4497"
+       style="fill:#ffffff;fill-opacity:1">
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         d="m 424.94841,397.98558 c 0.42403,-80.39507 -36.67389,-159.95894 -98.61729,-211.27908 -61.62363,-52.04643 -147.0438,-74.98666 -226.3301,-59.71008 -84.456013,14.49262 -160.042123,71.50544 -197.541133,148.50827 -34.880437,69.19461 -38.262257,153.31274 -8.881027,225.05935 30.678347,78.41504 99.7837167,140.41025 181.003187,162.59224 78.144893,22.71715 165.977873,7.75957 232.454933,-39.19258 66.94976,-46.06811 111.29097,-123.41843 116.99316,-204.54462 0.72293,-6.56418 0.91271,-13.2486 0.91896,-19.90244"
+         id="Sea-1" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Countries"
+     inkscape:label="Countries"
+     transform="translate(-603.68384,627.99738)"
+     style="display:inline">
+    <g
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       id="netherlands"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 257.74,274.56 -0.06,0.18 -0.13,0.19 -0.42,0.25 -0.43,0.15 -0.21,-0.04 -0.14,-0.12 -0.07,-0.11 -0.21,-0.12 -0.3,-0.07 -0.2,0.09 -0.14,0.08 -0.12,-0.02 -0.08,-0.1 -0.05,-0.14 -0.05,-0.42 0.23,-0.05 0.49,0.02 0.37,0.18 0.49,0.11 0.39,-0.16 0.29,0.19 z"
+         id="polyF1S162P4" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 257.07,272.8 0.26,0.29 0.06,0.09 0.01,0.09 -0.38,0.07 -0.36,-0.36 -0.26,0.05 -0.08,-0.16 v -0.09 l 0.28,-0.06 z"
+         id="polyF1S162P5" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 261.84,270.47 h -0.22 l -0.52,-0.21 -0.17,-0.13 -0.03,-0.1 0.64,-0.49 0.5,-0.29 0.35,-0.12 0.23,0.04 0.17,0.1 0.08,0.14 0.01,0.16 -0.11,0.17 -0.19,0.17 -0.36,0.23 -0.23,0.23 z"
+         id="polyF1S162P6" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 260.33,266.66 -0.31,0.32 -0.17,-0.11 -0.04,-0.08 0.11,-0.26 0.45,-0.41 z"
+         id="polyF1S162P7" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 261.06,265.57 -0.56,0.32 -0.04,-0.06 0.36,-0.28 z"
+         id="polyF1S162P8" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 257.74,274.56 -0.25,-0.09 -0.38,-0.24 -0.56,0.11 -0.37,-0.23 -0.31,-0.04 -0.18,-0.18 -0.19,-0.28 0.17,-0.16 0.15,-0.04 0.58,0.02 0.41,0.14 0.71,0.64 0.19,0.01 0.21,-0.06 -0.09,-0.16 -0.19,-0.09 -0.26,-0.18 -0.21,-0.23 0.53,-0.02 -0.06,-0.12 -0.05,-0.19 -0.5,-0.71 0.11,-0.17 0.17,-0.37 0.21,-0.3 0.14,-0.08 0.25,-0.2 0.54,-0.62 0.36,-0.51 0.28,-0.62 0.48,-1.73 0.13,-0.29 0.19,-0.32 0.19,0.08 0.14,0.11 0.51,-0.21 0.91,-0.59 0.29,-0.55 0.26,-0.24 1.01,-0.45 0.55,-0.12 0.83,0.01 0.61,-0.06 0.72,0.01 0.26,0.33 0.15,0.23 0.25,0.14 0.39,0.11 -0.04,0.45 -0.04,0.9 -0.04,0.16 -0.2,0.37 -0.22,0.68 -0.07,0.44 -0.07,0.08 -0.77,-0.04 -0.11,0.08 -0.02,0.09 0.03,0.12 -0.02,0.11 -0.07,0.09 0.03,0.15 0.12,0.18 0.24,0.12 0.26,0.02 0.14,-0.01 0.09,0.12 0.09,0.19 -0.02,0.24 -0.05,0.31 -0.14,0.28 -0.38,0.32 -0.16,0.11 -0.16,0.05 -0.07,0.08 -0.04,0.11 v 0.1 l 0.24,0.29 -0.01,0.06 -0.08,0.13 -0.1,0.13 -0.68,0.24 -0.27,-0.04 -0.17,0.13 -0.05,0.02 -0.16,-0.13 -0.38,-0.17 -0.15,0.04 -0.09,0.07 -0.25,0.09 -0.18,0.13 -0.01,0.2 0.28,0.52 0.1,0.1 -0.01,0.19 0.14,0.24 0.14,0.3 v 0.19 l -0.03,0.19 -0.09,0.26 -0.31,0.61 -0.01,0.12 0.02,0.09 0.09,0.03 0.07,0.05 -0.03,0.09 -0.53,0.4 -0.07,0.07 -0.22,-0.03 -0.03,0.07 0.02,0.12 0.07,0.11 0.18,0.06 0.15,0.12 0.11,0.22 -0.2,0.73 -0.31,-0.03 -0.29,-0.02 -0.15,-0.04 -0.16,-0.08 -0.06,-0.15 -0.08,-0.19 0.03,-0.11 0.29,-0.3 0.05,-0.08 -0.03,-0.05 0.04,-0.13 0.24,-0.46 0.03,-0.18 -0.08,-0.14 -0.13,-0.09 -0.42,-0.17 -0.19,-0.21 -0.08,-0.17 -0.09,-0.06 -0.15,0.05 -0.36,0.04 -0.28,-0.11 -0.32,-0.35 -0.06,-0.3 -0.02,-0.22 -0.08,-0.08 -0.12,0.1 -0.16,0.17 h -0.29 l -0.08,-0.05 -0.01,-0.1 v -0.1 l -0.07,-0.12 -0.08,-0.07 -0.39,0.3 -0.14,-0.01 -0.16,-0.14 -0.07,-0.13 -0.19,0.05 -0.18,0.14 0.03,0.3 -0.09,0.04 -0.21,-0.04 z"
+         id="polyF1S162P9" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 262.74,269.92 0.24,-0.26 0.01,-0.37 -0.08,-0.23 -0.52,-0.13 -0.09,-0.15 -0.01,-0.12 0.04,-0.35 0.03,-0.11 0.13,-0.17 -0.02,-0.16 h -0.31 l -0.27,-0.07 -0.09,-0.09 -0.01,-0.13 v -0.67 l -0.05,-0.12 -0.32,0.16 -0.36,0.27 -0.26,0.18 0.06,0.19 0.05,0.24 0.12,0.25 0.22,0.29 -0.04,0.28 -0.31,0.19 h -0.21 l -0.04,0.28 0.01,0.21 -0.03,0.33 -0.02,0.1 -0.09,0.12 -0.08,0.19 0.07,0.1 0.79,0.31 0.51,0.23 z"
+         id="polyF1S162P10" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 261.7,265.25 -0.27,0.02 -0.11,-0.08 0.65,-0.14 0.41,-0.03 0.07,0.03 z"
+         id="polyF1S162P11" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 263.45,265.01 -0.57,0.04 -0.19,-0.07 -0.02,-0.06 0.15,-0.02 0.48,0.02 0.15,0.06 z"
+         id="polyF1S162P12" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 264.61,264.83 -0.41,0.14 -0.09,-0.04 0.03,-0.05 0.35,-0.08 z"
+         id="polyF1S162P13" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region NL1 NLD"
+         d="m 265.77,264.55 h -0.26 l 0.08,-0.12 0.25,-0.08 h 0.13 z"
+         id="polyF1S162P14" />
+    </g>
+    <g
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       id="united_kingdom"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 241.57,275.95 -0.28,0.12 -0.11,0.18 -0.07,0.07 -0.17,0.02 -0.17,-0.03 -0.56,-0.48 -0.14,-0.01 0.17,-0.15 0.41,-0.08 0.24,-0.16 0.48,0.27 z"
+         id="polyF1S77P1-2" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 234.82,261.89 0.1,0.11 0.29,0.05 -0.13,0.17 -0.37,0.15 -0.26,0.17 -0.3,0.13 -0.09,-0.23 -0.15,-0.03 -0.14,-0.44 0.09,-0.6 0.32,-0.09 0.41,0.09 z"
+         id="polyF1S77P2" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 230.98,251.61 0.34,0.21 0.28,0.06 0.16,0.4 0.01,0.56 0.18,0.6 0.29,0.55 -0.05,0.29 -0.18,0.12 -0.34,0.12 -0.05,0.2 0.22,-0.06 h 0.19 l 0.4,0.13 0.1,0.24 0.03,0.33 v 0.26 l -0.1,0.27 -0.09,-0.11 -0.06,-0.27 -0.1,-0.14 -0.14,-0.1 -0.01,0.35 -0.13,0.45 0.06,0.05 0.19,0.06 -0.23,0.43 -0.31,0.06 -0.33,-0.03 -0.11,0.15 -0.11,0.2 -0.24,0.27 -0.26,0.13 -0.26,-0.1 -0.23,-0.2 -0.23,-0.09 -0.18,0.05 -0.12,0.05 -0.1,-0.04 -0.3,-0.04 -0.27,-0.07 -0.01,-0.13 0.14,-0.36 -0.04,-0.11 -0.25,-0.11 -0.07,-0.11 -0.09,-0.29 v -0.13 l 0.02,-0.17 -0.1,-0.24 -0.16,-0.2 -0.11,-0.04 -0.28,0.19 -0.25,0.21 0.03,0.14 0.02,0.18 -0.13,0.09 -0.37,0.2 -0.07,0.09 -0.1,0.03 -0.13,-0.11 -0.36,-0.07 -0.16,-0.09 -0.14,-0.25 -0.43,-0.25 v -0.34 l -0.07,-0.08 -0.39,-0.69 -0.02,-0.2 0.1,-0.09 0.24,-0.11 0.74,-0.1 0.13,-0.08 0.05,-0.1 -0.17,-0.16 -0.14,-0.16 -0.04,-0.1 0.02,-0.07 0.12,-0.06 0.2,0.04 0.15,0.08 0.14,-0.05 0.24,-0.02 0.18,-0.07 0.2,-0.23 0.19,-0.21 0.05,-0.13 0.23,-0.42 0.1,-0.1 0.49,-0.19 0.06,0.18 0.2,0.1 0.22,-0.11 0.34,-0.42 0.16,0.01 0.16,0.08 0.34,0.02 0.64,-0.08 z"
+         id="polyF1S77P3" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 234.54,251.4 -0.33,-0.06 -0.11,-0.07 -0.12,-0.15 -0.01,-0.67 0.11,-0.22 0.09,-0.09 0.09,-0.07 h 0.18 l 0.15,0.16 0.04,0.12 0.04,0.47 -0.05,0.38 z"
+         id="polyF1S77P4" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 232.41,248.56 -0.05,0.62 v 0.39 l -0.03,0.13 -0.13,0.15 -0.48,0.14 -0.14,-0.03 0.01,-0.06 0.16,-0.22 -0.02,-0.28 0.09,-0.2 -0.03,-0.05 -0.09,0.01 -0.38,0.26 h -0.11 v -0.07 l 0.14,-0.24 0.06,-0.18 0.07,-0.11 0.11,-0.08 0.12,-0.05 h 0.08 l 0.06,0.1 0.31,-0.16 z"
+         id="polyF1S77P5" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 232.69,249.19 -0.07,0.04 -0.13,-0.04 -0.03,-0.09 0.01,-0.12 0.04,-0.21 0.12,-0.14 0.39,-0.15 -0.13,-0.11 0.01,-0.06 0.13,-0.17 0.43,-0.22 0.11,-0.03 0.09,0.03 -0.31,0.49 z"
+         id="polyF1S77P6" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 233.78,246.84 -1.08,0.02 -0.35,-0.1 v -0.13 l 0.09,-0.07 0.31,-0.02 0.27,-0.59 -0.36,-0.39 v -0.09 l 0.06,-0.12 0.07,-0.05 0.3,-0.09 h 0.12 l 0.08,0.04 0.15,0.21 0.12,0.4 0.27,0.12 0.15,0.19 z"
+         id="polyF1S77P7" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 231.95,245.23 -0.15,-0.01 v -0.07 l 0.33,-0.25 0.17,-0.01 0.05,0.04 -0.16,0.15 z"
+         id="polyF1S77P8" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 230.38,242.97 -0.24,0.01 -0.07,-0.06 v -0.06 l 0.09,-0.15 0.19,-0.01 0.09,0.11 v 0.09 z"
+         id="polyF1S77P9" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 233.22,243.66 -0.09,0.05 -0.09,-0.04 -0.08,-0.1 -0.07,-0.24 0.32,-0.09 0.09,0.11 0.01,0.12 -0.02,0.11 z"
+         id="polyF1S77P10" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 230.98,242.38 h -0.12 l -0.13,-0.06 -0.06,-0.09 -0.01,-0.31 0.03,-0.17 0.12,-0.31 0.1,-0.39 0.28,0.06 0.06,0.07 -0.26,1.15 z"
+         id="polyF1S77P11" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 234.18,241.23 -0.06,0.21 -0.1,0.23 -0.01,0.27 -0.03,0.18 0.09,0.09 0.04,0.1 0.45,0.2 0.44,0.07 0.06,0.1 -0.02,0.12 -0.1,0.11 -0.3,0.19 -0.4,0.32 -0.1,0.06 -0.1,-0.02 -0.06,-0.05 0.12,-0.7 -0.34,0.01 -0.26,-0.07 -0.12,-0.12 -0.05,-0.18 -0.1,-0.47 -0.53,-0.3 -0.1,-0.27 -0.02,-0.15 0.04,-0.07 0.17,-0.14 0.13,0.1 0.1,-0.02 0.08,-0.06 0.01,-0.06 -0.04,-0.17 0.01,-0.05 0.64,-0.05 0.12,-0.28 0.14,0.01 0.12,0.13 0.12,0.35 z"
+         id="polyF1S77P12" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 231.78,239.78 0.21,0.33 -0.33,0.38 -0.34,-0.09 -0.39,-0.43 0.01,-0.07 0.07,-0.08 0.09,-0.06 h 0.08 l 0.1,0.08 0.19,-0.04 0.12,0.06 z"
+         id="polyF1S77P13" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 235.05,237.23 -0.52,0.73 -0.12,-0.01 -0.16,0.18 -0.38,0.15 0.28,0.07 0.06,0.09 -0.04,0.16 -0.07,0.08 -0.47,0.28 -0.29,0.08 -0.38,0.32 -0.14,-0.03 -0.2,0.21 -0.15,0.08 -0.06,-0.01 -0.06,-0.07 -0.11,-0.29 0.38,-0.16 0.06,-0.12 0.25,-0.09 -0.01,-0.05 -0.28,-0.27 -0.1,-0.17 0.03,-0.06 0.2,-0.11 -0.07,-0.04 -0.03,-0.09 -0.09,-0.06 v -0.08 l 0.03,-0.2 0.08,-0.2 0.12,-0.06 0.07,-0.09 0.05,-0.02 0.13,0.09 0.11,0.2 0.2,-0.02 0.2,0.08 0.01,-0.04 -0.05,-0.43 0.05,-0.08 0.11,-0.07 0.55,-0.17 0.72,-0.34 0.16,-0.04 0.03,0.08 -0.01,0.26 z"
+         id="polyF1S77P14" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 242.7,238.1 -0.06,0.39 -0.05,0.11 -0.09,0.13 -0.24,0.23 -0.57,0.29 -1.08,0.7 -0.62,0.33 -0.12,0.19 -0.1,0.28 0.3,0.13 0.11,0.12 -0.11,0.13 -0.59,0.42 -0.24,0.43 0.37,0.06 0.32,-0.03 0.66,-0.17 0.61,-0.11 0.27,0.05 0.49,0.27 0.11,0.03 0.24,-0.04 0.23,0.03 1.52,0.33 0.45,-0.03 0.26,0.17 0.18,0.34 0.12,0.6 -0.03,0.09 -0.18,0.23 -0.31,0.27 -0.3,0.41 -0.11,0.22 -0.09,0.25 -0.11,0.23 -0.65,1.05 -0.54,0.54 -0.28,0.41 -0.3,0.31 -0.27,0.18 -0.27,0.11 -0.74,0.02 -0.22,0.08 -0.27,0.15 -0.27,0.05 0.3,0.04 0.3,-0.05 0.53,0.05 0.53,0.49 -0.11,0.29 -0.29,0.2 -0.56,-0.07 -0.62,0.44 -0.27,0.12 -0.26,0.04 -0.3,-0.09 -0.53,-0.25 -0.22,-0.2 0.17,0.29 0.23,0.18 1.39,0.58 0.1,-0.02 0.53,-0.23 0.62,0.11 1.07,0.8 0.26,0.5 0.38,0.73 0.22,0.3 0.16,0.26 0.06,0.36 0.03,1.16 0.08,1.15 0.15,1.25 0.1,0.35 0.18,0.27 0.99,0.71 0.21,0.21 0.34,0.58 0.32,0.61 0.31,0.48 0.36,0.4 -0.23,0.15 -0.18,0.26 0.05,0.39 0.11,0.39 0.25,0.63 0.2,0.67 -0.1,-0.11 -0.1,-0.07 h -0.16 l -0.15,-0.06 -0.25,-0.23 -0.23,-0.29 -0.55,0.02 -0.29,-0.09 -0.26,-0.03 0.47,0.21 0.53,0.09 1.02,1.24 0.31,0.69 0.12,0.86 -0.21,0.35 -0.29,0.21 -0.28,0.24 -0.27,0.29 0.6,0.55 0.15,0.01 0.15,-0.05 0.17,-0.13 0.29,-0.35 0.14,-0.12 0.42,0.01 0.35,0.07 0.33,0.13 0.31,0.02 0.6,0.24 0.29,0.19 0.71,0.76 0.12,0.38 0.02,0.48 -0.05,0.53 -0.19,0.46 -0.21,0.41 -0.16,0.54 -0.09,0.19 -0.12,0.15 -0.48,0.39 -0.3,0.14 -0.11,-0.09 -0.13,-0.01 -0.03,0.1 0.11,0.25 -0.03,0.27 -0.28,0.16 -0.27,0.06 -0.41,-0.17 -0.64,0.3 0.4,0.25 0.06,0.21 -0.16,0.34 -0.29,0.13 -0.31,0.03 -0.3,-0.03 -0.27,0.06 -0.27,0.13 0.32,-0.05 0.2,0.11 0.09,0.32 0.11,0.1 0.59,0.21 0.37,0.05 0.72,0.02 0.35,0.04 0.11,0.07 -0.03,0.25 -0.13,0.61 -0.11,0.12 -1.02,0.39 -0.24,0.33 -0.08,0.21 -0.56,-0.11 -0.29,0.2 -0.48,0.09 -0.37,0.11 -0.37,0.16 -0.29,0.02 -1.19,-0.42 -0.74,-0.09 -1.02,0.06 -0.25,-0.07 -0.36,-0.27 -0.37,-0.2 -0.44,-0.13 -0.36,-0.25 0.19,0.4 -0.6,0.26 -0.26,0.03 -0.26,-0.06 -0.54,0.01 -0.49,-0.14 0.04,0.26 0.09,0.24 -0.12,0.08 h -0.12 l -0.9,-0.33 -0.14,0.01 -0.14,0.13 -0.33,-0.14 -0.28,-0.31 -0.32,-0.24 -0.35,-0.14 -0.3,-0.03 -1.27,0.17 -0.32,0.35 -0.22,0.54 -0.27,0.47 -0.36,0.33 -0.35,-0.02 -0.26,-0.33 -0.55,-0.41 -0.16,-0.24 -0.07,-0.03 -0.08,0.06 -0.25,0.04 -0.25,-0.05 h -0.39 l -0.7,0.11 -0.3,0.1 -0.66,0.33 -0.15,0.1 -0.3,0.4 -0.33,0.01 -0.23,-0.35 -0.31,-0.17 -0.37,0.02 -0.24,0.1 -0.07,-0.14 0.05,-0.26 0.32,-0.25 0.73,-0.08 0.72,-0.47 0.36,-0.3 0.16,-0.18 0.17,-0.1 0.2,-0.01 0.14,-0.21 1,-0.74 0.11,-0.19 0.12,-0.37 0.14,-0.35 0.71,-0.09 0.47,-0.7 0.1,-0.04 0.95,0.05 0.68,0.14 0.65,0.28 0.35,0.08 0.36,0.02 0.31,-0.16 0.6,-0.65 0.33,-0.28 0.35,-0.24 0.34,-0.28 0.57,-0.54 -0.34,0.16 -0.44,0.27 -0.25,0.16 -0.72,0.07 -0.34,0.15 -0.6,0.36 -0.11,0.02 -0.76,-0.26 -0.46,-0.71 -0.33,-0.32 -0.14,-0.06 -0.18,0.04 -0.35,0.01 -0.34,-0.08 0.23,-0.24 0.27,-0.11 -0.51,-0.21 -0.13,-0.12 -0.13,-0.22 -0.41,-0.12 h -0.21 l -0.39,0.19 -0.59,0.15 -0.55,-0.51 -0.09,-0.19 0.07,-0.31 -0.04,-0.27 -0.16,-0.13 0.3,-0.28 0.31,-0.16 0.65,-0.08 1.01,-0.32 0.55,-0.12 0.55,-0.28 0.24,-0.19 0.2,-0.28 0.22,-0.36 0.26,-0.27 -0.17,-0.12 -0.04,-0.25 0.07,-0.23 0.13,-0.2 -0.02,-0.28 -0.09,-0.31 0.06,-0.21 0.08,-0.23 -0.36,-0.06 h -0.37 l -0.36,0.1 -0.36,0.16 -0.28,-0.02 0.04,-0.18 0.17,-0.19 0.38,-0.25 0.39,-0.19 0.16,-0.18 0.14,-0.21 0.21,-0.15 0.51,-0.26 0.92,-0.23 0.13,0.01 0.32,0.11 h 0.33 l 0.31,-0.09 0.29,0.03 0.56,0.53 -0.07,-0.67 0.31,-0.1 0.3,0.65 0.14,0.09 0.34,-0.03 -0.11,-0.12 -0.14,-0.03 -0.17,-0.12 -0.13,-0.21 -0.15,-0.63 0.08,-0.35 0.25,-0.32 0.26,-0.3 -0.16,-0.1 -0.1,-0.15 0.02,-0.33 0.11,-0.29 0.4,-0.19 0.18,-0.37 0.12,-0.43 -0.02,-0.2 -0.35,-0.04 -0.18,0.05 -0.17,0.1 -0.16,-0.03 -0.33,-0.56 -0.17,-0.41 -0.28,-0.84 0.03,-0.47 0.55,-0.91 0.65,-0.53 0.66,-0.1 -0.11,-0.07 -0.94,-0.18 -0.33,0.01 -0.34,0.2 -0.18,0.05 -0.18,-0.01 -0.18,0.1 -0.19,0.15 -0.18,0.08 -0.31,-0.1 -0.16,0.01 -0.09,-0.12 -0.06,-0.19 -0.11,-0.07 -0.14,0.02 -0.33,0.17 -0.32,0.08 -0.32,-0.22 -0.39,-0.36 -0.12,0.07 -0.15,0.23 -0.15,0.38 -0.24,-0.41 -0.18,-0.51 -0.03,-0.3 0.07,-0.32 0.18,-0.09 0.13,0.15 0.41,-0.71 0.7,-0.88 0.23,-0.25 0.2,-0.35 0.03,-0.25 -0.06,-0.23 -0.33,-0.57 0.09,-0.38 0.15,-0.42 0.18,-0.24 0.06,-0.03 0.57,0.12 -0.19,-0.18 -0.36,-0.48 0.04,-0.14 0.18,-0.34 -0.05,0.03 -0.14,0.14 -0.27,0.37 -0.14,0.07 -0.33,0.03 -0.11,0.18 -0.06,0.04 -0.16,-0.01 -0.09,0.18 h -0.04 v -0.21 l 0.07,-0.33 0.13,-0.29 0.18,-0.22 0.59,-0.44 -0.27,0.12 -0.62,0.39 -0.34,0.27 -0.1,0.1 -0.04,0.09 -0.02,0.11 -0.02,0.6 -0.1,0.26 -0.86,1.68 -0.12,0.16 -0.1,0.07 -0.08,0.01 -0.21,-0.08 -0.07,-0.16 0.04,-0.15 0.09,-0.22 0.38,-0.8 0.14,-0.21 0.17,-0.19 0.35,-0.33 v -0.02 l -0.19,0.03 -0.07,-0.04 -0.04,-0.08 0.31,-1.13 0.22,-0.34 0.18,-0.52 0.23,-0.44 0.22,-0.31 0.21,-0.4 0.2,-0.16 0.11,-0.28 0.26,-0.28 0.21,-0.3 -0.08,0.01 -1.08,0.67 -0.26,0.11 -0.3,-0.11 -0.21,-0.15 -0.13,-0.25 0.01,-0.41 -0.22,-0.06 -0.18,-0.11 0.02,-0.05 0.3,-0.16 0.41,0.02 0.46,-0.26 -0.28,-0.31 0.05,-0.06 0.33,-0.13 0.53,-0.58 0.22,-0.59 -0.11,-0.32 -0.02,-0.2 -0.29,-0.29 0.01,-0.28 0.07,-0.14 0.15,-0.12 0.2,-0.07 0.29,-0.05 -0.21,-0.17 -0.06,-0.16 -0.02,-0.21 0.02,-0.12 0.25,-0.48 0.12,-0.19 0.21,-0.24 0.63,0.16 0.1,-0.1 0.08,0.01 0.3,0.18 -0.03,-0.13 -0.37,-0.76 -0.02,-0.13 0.23,-0.31 0.05,-0.15 0.02,-0.17 0.07,-0.11 0.18,-0.02 0.51,0.11 0.14,-0.03 -0.02,-0.18 -0.07,-0.24 0.02,-0.19 0.07,-0.15 0.08,-0.33 0.06,-0.13 0.17,-0.19 0.11,-0.05 0.13,-0.01 0.27,0.13 0.08,0.11 0.08,0.24 h 0.09 l 0.4,-0.15 0.11,-0.01 0.08,0.29 0.64,-0.09 0.82,0.07 0.51,-0.04 0.51,0.05 0.51,-0.07 0.48,0.17 v 0.09 l -0.05,0.12 z"
+         id="polyF1S77P15" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 243.35,237.13 -0.02,0.01 -0.07,-0.11 -0.08,-0.33 0.24,-0.02 0.1,0.06 -0.07,0.12 z"
+         id="polyF1S77P16" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 242.83,236.77 -0.15,0.04 -0.13,-0.03 -0.16,-0.31 -0.04,-0.21 0.04,-0.13 0.1,-0.03 0.19,0.11 0.06,0.24 -0.01,0.15 0.01,0.06 0.12,0.08 z"
+         id="polyF1S77P17" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 243.32,235.72 -0.05,0.11 0.18,0.03 0.24,0.15 0.16,0.04 0.11,0.15 -0.12,0.21 -0.09,0.05 h -0.1 l -0.26,-0.29 -0.44,0.02 -0.07,-0.04 -0.05,-0.08 v -0.08 l 0.03,-0.16 -0.01,-0.05 -0.18,0.12 -0.06,-0.03 -0.03,-0.08 0.02,-0.15 0.06,-0.21 0.15,-0.29 0.16,-0.04 0.22,0.08 0.21,0.22 0.06,0.12 -0.02,0.09 z"
+         id="polyF1S77P18" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 244.73,235.01 -0.27,-0.05 0.19,-0.25 0.18,-0.04 0.3,0.09 -0.08,0.11 z"
+         id="polyF1S77P19" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 244.26,235.14 -0.23,0.07 -0.07,-0.11 0.04,-0.3 -0.22,-0.18 -0.1,-0.1 -0.06,-0.17 0.03,-0.04 0.17,-0.03 0.22,0.32 0.06,0.25 0.19,0.1 0.02,0.04 z"
+         id="polyF1S77P20" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 248.82,229.41 -0.02,0.34 0.14,-0.07 0.12,0.35 0.09,0.01 0.18,-0.1 -0.08,0.29 -0.31,0.79 -0.07,0.13 -0.07,0.24 -0.04,0.05 -0.14,0.49 -0.14,0.15 -0.16,0.38 -0.05,0.03 -0.1,-0.17 0.24,-0.58 0.12,-0.34 v -0.19 l -0.05,-0.18 -0.2,-0.03 -0.18,0.04 -0.02,-0.1 0.02,-0.13 -0.03,-0.05 -0.23,-0.03 -0.06,-0.04 -0.02,-0.13 0.01,-0.1 0.22,-0.04 0.18,0.06 0.32,-0.14 -0.06,-0.66 -0.22,-0.1 -0.04,-0.07 0.06,-0.1 0.14,-0.04 0.25,-0.29 0.13,-0.03 0.14,0.04 z"
+         id="polyF1S77P21" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 249.41,229.62 -0.07,0.04 -0.14,-0.51 0.27,-0.51 0.19,0.05 0.01,0.14 -0.04,0.13 h -0.11 l -0.01,0.04 -0.02,0.25 -0.05,0.3 z"
+         id="polyF1S77P22" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region GB1 GBR"
+         d="m 250.28,228.32 -0.01,0.06 -0.19,0.37 -0.03,0.15 -0.19,-0.04 -0.02,-0.05 v -0.23 l 0.07,-0.24 0.04,-0.06 0.06,-0.02 0.05,0.06 0.12,-0.11 0.05,0.02 z"
+         id="polyF1S77P23" />
+    </g>
+    <g
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       id="gGGY"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region GB1 GGY"
+         d="m 236.28,280.87 -0.16,0.29 -0.26,-0.16 -0.01,-0.08 0.35,-0.13 0.06,0.02 z"
+         id="polyF1S79P1-4" />
+      <circle
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         class="region GB1 GGY"
+         cx="236.08083"
+         cy="281.00659"
+         id="pointF2S60P1"
+         r="0.25" />
+    </g>
+    <g
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       id="gIMN"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region GB1 IMN"
+         d="m 235.08,257.71 -0.67,0.48 -0.2,-0.15 -0.2,0.01 -0.05,-0.02 0.15,-0.2 0.24,-0.47 0.27,-0.14 0.4,-0.46 0.25,-0.09 0.08,0.03 0.04,0.06 -0.02,0.6 -0.19,0.18 z"
+         id="polyF1S98P1-3" />
+      <circle
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         class="region GB1 IMN"
+         cx="234.78885"
+         cy="257.54733"
+         id="pointF2S63P1"
+         r="0.25" />
+    </g>
+    <g
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       id="gJEY"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region GB1 JEY"
+         d="m 237.57,282.38 -0.01,0.24 -0.15,0.03 -0.1,-0.1 -0.22,-0.04 -0.23,0.01 0.12,-0.42 0.41,0.13 z"
+         id="polyF1S109P1-1" />
+      <circle
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         class="region GB1 JEY"
+         cx="237.2256"
+         cy="282.32916"
+         id="pointF2S62P1"
+         r="0.25" />
+    </g>
+    <g
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       id="gGIB"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <circle
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25"
+         class="region GB1 GIB"
+         cx="215.76378"
+         cy="341.18549"
+         id="pointF2S61P1"
+         r="0.25" />
+    </g>
+    <g
+       id="albania"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S5P1-7"
+         d="m 310.16,315.44 0.15,0.09 0.34,0.42 0.24,0.39 0.39,0.09 0.23,0.13 0.3,0.2 0.16,0.23 0.27,0.72 0.08,0.45 -0.03,0.21 -0.04,0.06 -0.09,0.75 0.09,0.37 0.03,0.25 -0.14,0.11 -0.07,0.17 0.22,0.59 0.01,0.26 0.05,0.3 0.36,0.64 0.19,0.19 0.16,0.08 0.26,0.59 0.13,0.1 0.45,-0.13 0.24,0.04 0.1,0.13 0.04,0.1 0.01,0.36 0.15,0.25 0.18,0.25 0.02,0.17 -0.07,0.29 -0.14,0.35 -0.23,0.16 -0.26,0.15 -0.1,0.26 -0.04,0.28 -0.1,0.21 -0.05,0.23 -0.06,0.46 -0.01,0.16 -0.16,0.19 -0.28,0.11 -0.26,0.05 -0.16,0.1 -0.07,0.16 -0.15,0.14 -0.1,0.07 0.02,0.13 0.15,0.27 0.16,0.21 0.02,0.18 -0.06,0.06 -0.21,0.01 -0.04,0.07 v 0.21 l -0.03,0.18 -0.08,0.12 -0.14,0.13 h -0.28 l -0.28,-0.14 -0.14,-0.03 -0.07,0.01 -0.07,-0.42 -0.15,-0.32 -0.49,-0.75 -1.42,-0.61 -0.35,-0.31 -0.16,-0.28 -0.17,-0.26 0.13,-0.03 0.14,0.06 0.17,0.06 0.06,-0.15 -0.11,-0.29 -0.41,-0.67 -0.05,-0.19 0.11,-0.62 0.21,-0.7 -0.11,-0.81 0.02,-0.62 -0.13,-0.39 -0.1,-0.48 0.13,-0.68 0.16,-0.18 0.08,-0.22 -0.06,-0.69 -0.43,-0.27 -0.45,-0.01 -0.01,-0.24 0.02,-0.37 -0.05,-0.12 0.01,-0.22 -0.09,-0.18 0.2,0.08 0.26,0.01 0.03,-0.14 -0.13,-0.22 -0.24,-0.31 -0.13,-0.28 -0.02,0.01 0.12,-0.27 0.19,-0.38 0.24,-0.39 0.15,-0.37 0.17,-0.32 0.16,-0.12 0.09,0.06 0.06,0.12 0.03,0.39 0.07,0.12 0.13,0.09 0.25,-0.08 0.26,-0.13 0.35,-0.26 z"
+         class="region ALB"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gFI1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <g
+         id="gALD"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+        <path
+           id="polyF1S6P1-9"
+           d="m 300.61,232.33 -0.01,0.12 -0.19,0.05 -0.09,-0.09 -0.18,0.04 -0.04,-0.05 0.06,-0.11 0.13,-0.08 h 0.19 z"
+           class="region FI1 ALD"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S6P2"
+           d="m 298.27,231.94 0.02,0.1 -0.09,-0.01 -0.07,0.04 -0.02,0.14 -0.11,-0.03 -0.07,-0.18 0.04,-0.29 0.18,-0.04 z"
+           class="region FI1 ALD"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S6P3"
+           d="m 298.92,231.07 0.08,-0.01 0.02,-0.04 0.13,0.01 0.22,0.16 0.05,0.09 0.14,0.03 0.06,0.1 -0.11,0.34 -0.09,0.02 -0.07,-0.03 -0.12,0.05 -0.06,0.07 -0.01,0.13 0.05,0.28 -0.55,0.13 -0.14,-0.07 -0.26,-0.61 0.01,-0.16 0.11,-0.09 0.09,-0.03 0.07,0.34 0.14,-0.05 0.01,-0.23 -0.01,-0.16 -0.05,-0.07 -0.11,-0.05 -0.07,-0.1 0.06,-0.18 0.14,-0.09 0.16,0.21 z"
+           class="region FI1 ALD"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <circle
+           r="0.25"
+           id="pointF2S52P1"
+           cy="231.62482"
+           cx="299.02603"
+           class="region FI1 ALD"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25" />
+      </g>
+      <g
+         id="finland"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+        <path
+           id="polyF1S70P1-4"
+           d="m 302.95,231.67 -0.2,0.08 -0.15,-0.12 0.03,-0.11 0.12,-0.13 0.16,-0.01 0.06,0.13 z"
+           class="region FI1 FIN"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S70P2"
+           d="m 303.4,231.44 -0.21,0.2 -0.09,-0.03 -0.03,-0.27 0.12,-0.15 0.23,-0.05 z"
+           class="region FI1 FIN"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S70P3"
+           d="m 304.01,230.24 0.31,0.06 0.12,-0.06 0.18,0.22 -0.21,0.2 0.02,0.19 0.12,0.11 0.06,0.17 -0.24,0.04 -0.14,-0.13 -0.08,-0.18 -0.13,-0.11 -0.17,-0.08 0.05,-0.15 0.01,-0.19 z"
+           class="region FI1 FIN"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S70P4"
+           d="m 303.62,230.47 -0.17,0.04 -0.28,-0.19 -0.05,-0.09 0.09,-0.06 -0.1,-0.18 0.01,-0.09 0.21,0.12 0.13,0.16 -0.09,0.05 0.2,0.15 z"
+           class="region FI1 FIN"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S70P5"
+           d="m 302.2,229.76 v 0.22 h -0.16 l -0.15,0.06 -0.17,-0.19 -0.13,-0.36 0.01,-0.08 0.09,-0.1 0.11,0.19 z"
+           class="region FI1 FIN"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S70P6"
+           d="m 299.52,217.21 0.04,0.08 0.12,-0.04 0.14,-0.18 0.13,0.05 0.03,0.23 h -0.09 l -0.02,-0.03 -0.09,0.14 v 0.08 l -0.11,0.07 -0.26,-0.19 -0.2,-0.34 0.32,-0.05 -0.01,0.09 z"
+           class="region FI1 FIN"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S70P7"
+           d="m 305.31,207.88 -0.26,0.21 -0.26,-0.05 -0.07,-0.29 0.11,-0.17 0.25,-0.11 0.4,0.07 0.07,0.07 -0.2,0.1 z"
+           class="region FI1 FIN"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S70P8"
+           d="m 304.89,184.36 0.49,0.35 0.29,0.16 0.74,0.24 0.62,0.13 0.59,0.78 -0.03,0.39 -0.04,0.14 -0.15,0.41 -0.13,0.56 0.05,0.26 0.18,0.23 0.18,0.14 -0.09,0.08 -0.27,0.31 -0.16,0.19 -0.22,0.17 0.11,0.13 0.42,-0.08 0.08,0.02 0.07,0.06 0.04,0.12 0.02,0.19 -0.13,1.15 0.06,0.22 0.34,0.57 0.43,0.66 0.74,0.15 0.56,0.12 0.5,0.5 0.76,0.64 0.37,0.21 0.04,0.08 0.1,0.56 -0.15,0.62 -0.16,0.54 -0.15,0.63 -0.1,0.53 -0.1,0.63 0.02,0.19 0.05,0.17 0.11,0.18 0.57,0.59 0.26,0.31 0.28,0.33 0.28,0.37 0.21,0.35 0.26,0.32 0.15,0.16 0.23,0.21 0.31,0.33 0.16,0.29 0.63,0.97 0.11,0.26 0.06,0.21 -0.11,0.08 -0.27,0.11 -0.25,0.21 v 0.04 l 0.27,0.2 -0.03,0.47 0.17,0.62 -0.08,0.37 0.01,0.08 0.02,0.06 0.05,0.04 0.37,-0.01 0.06,0.08 0.06,0.18 0.02,0.17 -0.13,0.17 -0.13,0.23 0.01,0.18 0.06,0.15 0.14,0.24 0.22,0.26 0.22,0.14 0.61,0.02 0.12,0.13 0.1,0.19 0.05,0.2 -0.14,0.46 0.05,0.15 0.23,0.33 0.24,0.31 0.67,0.22 0.26,0.15 0.11,0.15 0.11,0.26 0.09,0.28 0.04,0.27 -0.06,0.38 -0.2,0.76 -0.33,0.36 -0.01,0.06 0.19,0.18 1,0.62 0.61,0.26 0.82,0.33 0.55,0.3 0.24,0.25 0.29,0.28 0.3,0.21 0.22,0.19 0.11,0.13 0.05,0.17 -0.03,0.55 0.02,0.41 -0.02,0.61 -0.07,0.45 -0.29,0.86 -0.49,1.11 -0.09,0.32 -0.22,0.57 -0.33,1.11 -0.1,0.26 -0.3,0.89 -0.16,0.3 -0.12,0.28 -0.32,0.85 -0.4,0.69 -0.41,0.65 -0.1,0.29 -0.15,0.25 -0.2,0.25 -0.08,0.13 -0.37,0.84 -0.54,1.15 -0.07,0.04 -0.17,0.2 -0.32,0.12 -0.11,0.15 -0.58,-0.22 h -0.09 l -0.27,0.15 -0.22,0.31 -0.5,0.2 -0.24,0.13 -0.14,0.16 -0.1,-0.27 -0.02,-0.36 0.06,-0.25 -0.03,-0.15 -0.08,0.03 -0.08,0.38 0.01,0.41 -0.13,0.23 -0.38,0.17 -0.46,-0.23 -0.18,0.04 0.17,0.2 0.14,0.23 0.02,0.15 -0.21,0.02 -0.19,0.19 -0.15,0.26 -0.1,0.03 -0.21,-0.28 -0.21,0.19 -0.17,0.24 -0.42,0.15 -0.2,0.3 -0.42,0.27 -0.25,0.04 -0.53,0.32 -0.13,0.35 -0.14,0.15 -0.26,-0.05 -0.71,0.29 -0.66,0.34 -0.31,0.04 -0.32,-0.03 -0.26,0.34 -0.27,0.44 -0.35,0.2 -0.14,-0.03 0.07,-0.21 0.21,-0.25 0.11,-0.31 -0.02,-0.23 -0.13,-0.07 h -0.17 l -0.25,-0.21 -0.29,-0.48 -0.11,-0.02 -0.03,0.15 0.02,0.41 -0.04,0.12 -0.08,0.11 -0.11,0.11 -0.11,0.07 -0.43,0.06 -0.09,-0.19 -0.02,-0.08 0.03,-0.28 -0.08,-0.03 0.03,-0.22 0.1,-0.01 0.11,-0.05 0.04,-0.11 -0.02,-0.13 -0.18,-0.01 -0.02,-0.08 0.08,-0.39 v -0.1 l -0.06,-0.01 -0.09,0.05 -0.63,-0.01 -0.83,-0.35 -0.19,0.01 -0.19,-0.4 -0.17,0.08 -0.22,0.28 -0.23,-0.15 -0.23,-0.09 -0.09,-0.18 -0.05,-0.28 -0.07,-0.33 -0.12,-0.37 -0.14,-0.55 -0.03,-0.43 0.11,-0.34 0.03,-0.22 -0.01,-0.52 -0.09,-0.61 -0.08,-0.2 -0.01,-0.14 0.13,-0.02 -0.05,-0.11 -0.07,-0.06 -0.08,-0.12 0.04,-0.08 0.15,-0.03 0.01,-0.05 0.01,-0.06 -0.19,-0.33 -0.04,-0.17 -0.25,-0.48 -0.28,-0.45 -0.34,-0.31 v -0.59 l 0.03,-0.53 -0.07,-0.25 -0.09,-0.29 -0.41,-0.28 -0.13,-0.47 -0.17,-0.49 -0.02,-0.31 0.02,-0.24 0.07,-0.25 0.44,-0.83 -0.04,-0.39 0.38,-0.08 -0.24,-0.32 -0.08,-0.19 -0.04,-0.22 0.51,-0.24 0.22,0.09 0.45,-0.23 0.37,-0.37 -0.04,-0.16 -0.1,-0.14 -0.14,-0.27 0.05,-0.08 0.16,0.03 -0.09,-0.13 -0.02,-0.15 0.18,0.03 0.19,-0.45 -0.05,-0.31 0.44,-0.25 0.4,-0.73 0.21,-0.24 0.21,-0.18 0.37,-0.73 0.21,-0.07 0.01,-0.44 0.31,-0.65 0.11,-0.1 0.08,-0.55 0.39,-0.69 0.15,-0.81 0.12,-0.3 -0.01,-0.3 0.19,-0.06 0.13,-0.24 0.35,-0.23 0.38,-0.03 0.19,0.06 0.13,-0.06 -0.07,-0.25 -0.14,-0.14 0.04,-0.16 0.17,-0.16 -0.08,-0.25 -0.08,-0.14 -0.21,-0.17 -0.03,-0.47 -0.1,-0.5 -0.07,-0.59 -0.28,-0.27 -0.89,-0.36 -0.14,0.05 -0.19,-0.03 -0.27,-0.36 v -0.35 l -0.02,-0.13 -0.07,0.02 -0.07,0.18 -0.21,0.24 -0.35,-0.08 -0.15,0.06 -0.39,-0.8 -0.18,-0.3 -0.25,-0.37 -0.34,-0.14 -0.08,-0.1 -0.08,-0.16 -0.06,-0.24 -0.11,-0.34 -0.05,-0.28 v -0.18 l 0.1,-0.14 0.11,-0.35 -0.02,-0.24 -0.06,-0.36 0.01,-0.33 0.05,-0.17 -0.05,-0.13 -0.1,-0.16 -0.19,-0.23 -0.27,-0.28 -0.22,-0.26 -0.13,-0.27 -0.08,-0.24 -0.05,-0.23 0.02,-0.16 0.15,-0.23 v -0.08 l -0.17,-0.42 -0.14,-0.05 h -0.23 l -0.13,0.02 -0.03,-0.05 -0.03,-0.08 -0.01,-0.18 0.02,-0.21 0.03,-0.14 -0.01,-0.11 -0.16,-0.36 -0.12,-0.44 -0.05,-0.36 0.17,-0.31 -0.01,-0.09 -0.35,-0.23 -0.28,-0.29 -0.11,-0.18 -0.24,0.02 -0.27,-0.52 -0.27,-0.23 -0.25,-0.19 -0.15,-0.09 -0.79,-0.21 -0.3,-0.01 -0.38,-0.14 -0.3,-0.2 -0.25,-0.12 -0.22,-0.17 -0.3,-0.14 -0.1,-0.14 -0.33,-0.24 -0.16,-0.17 -0.52,-0.29 -0.04,-0.13 -0.03,-0.14 -0.03,-0.05 -0.5,-0.19 0.06,-0.16 0.36,-0.06 0.32,0.09 0.06,-0.07 0.01,-0.12 -0.21,-0.46 v -0.13 l 0.1,-0.16 0.19,-0.15 0.32,-0.07 0.22,-0.01 h 0.05 l 0.43,0.47 0.39,0.47 0.19,0.19 0.5,0.56 0.21,0.33 0.1,0.25 0.16,-0.03 0.55,0.02 0.46,0.02 0.16,0.12 0.3,-0.08 0.21,-0.17 0.37,-0.24 0.07,-0.22 0.09,-0.24 0.25,-0.01 0.3,0.12 0.35,0.16 0.3,0.05 0.4,0.09 0.22,0.18 0.25,0.01 0.19,-0.26 v -0.59 l 0.07,-0.27 0.13,-0.22 0.19,-0.13 0.15,-0.06 0.08,-0.17 0.09,-0.35 -0.07,-0.39 -0.22,-0.68 -0.03,-0.23 0.04,-0.4 -0.09,-1.03 0.01,-0.3 0.05,-0.19 0.1,-0.13 0.17,-0.35 0.18,-0.67 0.08,-0.07 0.23,-0.08 0.32,-0.05 0.3,0.04 0.03,-0.02 0.11,-0.08 0.17,-0.23 0.27,-0.46 0.22,-0.15 0.22,-0.04 z"
+           class="region FI1 FIN"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      </g>
+    </g>
+    <g
+       id="andorra"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S7P1-1"
+         d="m 245.5,315.98 -0.1,0.02 -0.34,0.16 -0.19,0.04 -0.17,0.01 -0.13,-0.03 -0.06,-0.12 0.02,-0.17 -0.01,-0.16 -0.02,-0.08 0.08,-0.22 0.12,-0.11 0.15,-0.08 0.23,0.06 0.48,0.21 0.09,0.14 v 0.1 l -0.11,0.13 z"
+         class="region AND"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <circle
+         r="0.25"
+         id="pointF2S68P1"
+         cy="315.76242"
+         cx="244.96802"
+         class="region AND"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gAU1"
+       transform="matrix(1.4331066,0,0,1.4331066,-0.25396626,260.10818)"
+       style="fill:#ccced1;fill-opacity:1;stroke:none">
+      <g
+         id="gATC"
+         style="fill:#ccced1;fill-opacity:1;stroke:none" />
+      <g
+         id="gAUS"
+         style="fill:#ccced1;fill-opacity:1;stroke:none" />
+      <g
+         id="gHMD"
+         style="fill:#ccced1;fill-opacity:1;stroke:none" />
+      <g
+         id="gIOA"
+         style="fill:#ccced1;fill-opacity:1;stroke:none" />
+      <g
+         id="gNFK"
+         style="fill:#ccced1;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gFR1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <g
+         id="gATF"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <g
+         id="france"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+        <path
+           id="polyF1S73P8"
+           d="m 272.9,316.38 -0.1,0.7 0.07,0.2 0.12,0.14 0.06,0.16 0.09,1.86 -0.02,0.15 -0.45,0.74 -0.1,0.22 -0.03,0.92 -0.08,0.25 -0.16,0.24 -0.29,0.78 -0.25,0.36 -0.65,-0.45 -0.38,-0.2 -0.19,-0.2 -0.12,-0.15 0.08,-0.18 0.18,-0.19 0.03,-0.15 -0.41,-0.18 -0.18,-0.12 v -0.2 l 0.15,-0.31 -0.06,-0.27 -0.24,0.01 -0.18,-0.04 -0.02,-0.14 0.14,-0.17 0.18,-0.22 v -0.25 l -0.21,-0.11 -0.19,-0.21 -0.07,-0.27 0.15,-0.19 0.25,-0.11 -0.17,-0.29 -0.12,-0.01 -0.09,-0.06 0.08,-0.13 0.19,-0.19 0.27,-0.58 0.36,-0.27 0.64,-0.16 0.18,-0.07 0.16,-0.21 0.17,-0.13 0.22,0.03 0.19,0.08 0.12,0.09 0.09,-0.09 0.09,-0.25 -0.05,-0.23 0.04,-0.62 0.12,-0.34 0.18,-0.02 0.16,0.2 -0.01,0.16 0.06,0.41 z"
+           class="region FR1 FRA"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S73P9"
+           d="m 237.76,298.55 -0.18,0.4 -0.16,-0.42 -0.24,-0.38 -0.02,-0.32 0.02,-0.08 0.3,0.28 z"
+           class="region FR1 FRA"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S73P10"
+           d="m 253.06,277.18 0.22,0.21 0.07,-0.02 0.19,-0.03 0.32,-0.16 0.26,-0.03 0.13,0.16 0.07,0.09 0.13,0.34 0.01,0.35 0.05,0.29 0.11,0.13 0.49,0.09 0.35,0.14 0.08,0.1 0.07,0.64 0.06,0.1 0.09,-0.07 0.1,-0.09 0.13,-0.01 0.2,0.06 0.28,0.04 0.28,0.1 0.37,0.39 -0.03,0.11 -0.09,0.21 -0.04,0.16 0.06,0.07 0.09,0.18 -0.04,0.2 -0.12,0.13 -0.05,0.11 v 0.07 l 0.03,0.07 0.08,0.06 0.58,0.12 0.55,-0.03 0.36,-0.17 0.07,-0.21 0.12,-0.23 0.22,-0.19 0.14,-0.05 0.12,0.09 -0.28,0.82 0.15,0.23 -0.01,0.33 0.04,0.28 0.19,0.01 0.24,0.07 0.16,0.12 0.18,0.18 0.27,0.18 0.19,0.06 0.06,0.14 0.15,0.16 0.23,0.33 0.22,0.22 0.1,0.01 0.22,-0.07 0.31,-0.03 0.25,0.02 0.1,0.17 0.23,0.08 0.08,0.07 0.09,0.11 0.16,0.06 0.2,-0.03 0.15,-0.14 0.19,-0.06 0.19,0.04 0.11,0.08 0.2,0.13 0.12,-0.02 0.23,0.09 0.23,0.24 0.08,0.24 0.02,0.13 0.1,0.14 0.37,0.65 0.12,0.04 0.15,-0.09 0.09,-0.13 0.14,-0.02 0.2,0.07 0.14,0.08 0.05,0.27 0.04,0.06 0.09,-0.06 h 0.17 l 0.25,0.07 0.36,-0.06 0.29,-0.1 0.15,0.01 0.22,0.33 0.26,0.13 0.59,0.11 0.63,0.18 0.25,0.12 0.17,0.07 v 0.42 l -0.05,0.06 -0.67,0.81 -0.28,0.29 -0.15,0.43 -0.11,0.65 -0.22,0.61 -0.3,0.58 -0.12,0.44 0.06,0.3 -0.06,0.46 -0.2,0.63 -0.05,0.48 0.1,0.32 0.16,0.07 -0.4,0.21 -0.09,0.18 -0.17,0.25 -0.25,0.09 -0.25,0.03 -0.2,-0.05 -0.11,-0.1 0.01,-0.09 -0.11,-0.09 -0.27,-0.01 -0.28,0.16 -0.23,0.27 0.06,0.16 0.2,0.06 0.05,0.06 v 0.08 l -0.08,0.1 -0.09,0.16 -0.45,0.47 -0.46,0.48 -0.08,0.15 -0.14,0.1 -0.56,0.24 -0.07,0.1 -0.05,0.45 -0.08,0.36 -0.43,0.33 -0.43,0.32 -0.11,0.2 -0.09,0.24 -0.14,0.27 -0.04,0.14 0.2,0.25 -0.04,0.19 -0.08,0.28 -0.21,0.18 -0.22,0.1 -0.02,0.3 0.12,0.05 h 0.26 l 0.39,-0.2 0.26,-0.27 -0.13,-0.28 -0.02,-0.05 0.04,-0.06 0.31,-0.28 0.36,-0.15 0.49,-0.01 0.59,0.14 0.06,0.04 -0.04,0.18 0.05,0.27 0.09,0.19 -0.17,0.52 0.11,0.17 0.16,0.2 0.12,0.19 0.18,0.17 0.16,0.29 0.05,0.16 -0.28,0.26 -0.47,0.24 -0.06,0.16 v 0.19 l 0.04,0.15 0.25,0.2 0.25,0.44 0.15,0.39 0.37,0.38 0.08,0.12 -0.02,0.09 -0.11,0.15 -0.15,0.51 -0.16,0.08 -0.17,0.02 -0.49,0.36 -0.21,-0.06 -0.3,-0.01 -0.22,0.12 0.01,0.24 0.18,0.22 0.11,0.25 0.03,0.24 0.2,0.2 0.3,0.12 0.17,0.02 0.11,0.07 0.06,0.09 0.11,0.53 -0.08,0.13 -0.17,0.05 -0.1,0.21 -0.21,0.31 -0.12,0.25 0.11,0.23 0.04,0.17 -0.07,0.17 0.08,0.27 0.21,0.28 0.61,0.4 0.57,0.33 0.18,0.06 0.79,-0.17 0.13,0.03 0.09,0.23 0.04,0.16 -0.1,0.23 -0.22,0.32 -0.25,0.25 -0.14,0.21 0.02,0.2 v 0.27 l -0.19,0.07 -0.01,-0.05 -0.07,-0.05 -0.07,0.02 -0.06,0.06 -0.01,0.1 -0.41,0.15 -0.28,0.17 -1.15,0.99 -0.53,0.29 -0.11,0.18 -0.12,0.34 -0.31,0.28 -0.28,0.12 -0.66,0.11 -0.68,0.28 -0.29,-0.15 -0.78,-0.04 -0.45,-0.41 -0.91,-0.3 -0.27,-0.58 -0.42,-0.06 h -0.27 l -0.16,-0.1 -0.03,-0.19 0.01,-0.18 -0.3,0.06 -0.22,-0.02 -0.14,0.06 -0.11,0.08 -0.12,-0.06 -0.07,0.01 v 0.11 h -0.27 l -0.29,-0.09 -0.74,-0.34 -0.11,-0.06 -0.52,-0.15 -0.2,-0.13 -0.15,-0.3 -0.13,-0.1 -0.07,-0.06 -0.5,0.1 -0.19,0.2 -0.29,0.24 -1.93,1.1 -0.38,0.5 -0.45,0.74 -0.07,0.36 0.07,1.19 0.32,0.65 0.03,0.14 -0.2,-0.02 -0.35,-0.11 -0.28,-0.12 -0.28,0.02 -0.28,0.1 -0.24,0.05 -0.17,0.01 -0.11,0.06 -0.07,0.14 -0.02,0.1 -0.29,-0.06 -0.66,-0.28 -0.6,-0.22 -0.37,0.13 -0.25,0.12 -0.16,-0.04 -0.11,-0.17 -0.06,-0.17 -0.23,-0.18 -0.51,-0.28 0.04,-0.1 0.11,-0.13 v -0.1 l -0.09,-0.14 -0.48,-0.21 -0.23,-0.06 -0.15,0.08 -0.12,0.11 -0.23,-0.48 -0.19,-0.12 -0.29,-0.05 -0.32,-0.18 -0.33,-0.22 -0.82,-0.39 -0.23,-0.07 -0.1,0.03 -0.09,0.16 -0.09,0.47 -0.04,0.05 -0.4,-0.04 -0.48,-0.14 -0.22,0.01 -0.2,-0.03 -0.18,-0.15 -0.85,0.02 -0.14,-0.09 -0.17,-0.24 -0.21,-0.21 -0.16,-0.11 -0.14,-0.12 -0.13,-0.04 -0.22,0.07 h -0.29 l -0.24,-0.05 -0.12,-0.01 -0.47,-0.6 -0.05,-0.15 -0.26,-0.08 -0.33,-0.06 -0.78,-0.47 -0.35,-0.24 -0.04,-0.12 0.01,-0.08 h -0.06 l -0.14,0.14 -0.08,0.11 -0.08,0.01 -0.12,-0.03 -0.1,-0.09 -0.06,-0.11 0.1,-0.14 0.16,-0.19 0.08,-0.22 0.02,-0.2 -0.19,-0.16 -0.3,-0.11 -0.22,-0.05 -0.28,-0.17 -0.12,-0.1 -0.1,-0.25 0.02,-0.16 0.57,-0.05 0.59,-0.51 0.78,-2.07 0.71,-2.49 0.32,-0.44 0.33,-0.08 -0.2,-0.39 -0.19,0.15 -0.09,0.18 -0.1,0.08 0.53,-2.31 0.26,-0.83 0.35,-0.86 0.41,0.43 0.33,0.42 0.15,0.34 0.11,1.09 0.16,0.24 0.25,0.27 -0.08,-0.26 -0.17,-0.21 -0.11,-1.44 -0.13,-0.43 -0.25,-0.37 -0.85,-0.85 -0.07,-0.15 -0.01,-0.27 0.32,0.06 0.25,0.17 -0.01,-0.15 -0.06,-0.17 -0.04,-0.59 0.09,-1.34 0.04,-0.22 v -0.28 l -0.29,-0.11 -0.24,-0.06 -0.24,-0.15 -1.16,-0.99 -0.3,-0.87 -0.35,-0.67 -0.07,-0.28 0.05,-0.26 0.32,-0.51 -0.14,-0.39 -0.19,-0.1 -0.14,-0.2 0.2,-0.27 0.16,-0.16 h 0.26 l 0.33,0.12 0.29,0.22 0.25,0.08 -0.67,-0.57 -1.23,-0.06 -0.25,-0.1 -0.2,-0.14 -0.03,-0.34 0.2,-0.12 0.2,-0.25 -0.14,-0.22 -0.22,-0.11 -0.35,-0.06 -0.34,-0.01 -0.06,-0.12 0.25,-0.27 -0.15,-0.14 -0.24,0.01 h -0.34 l -0.3,-0.16 -0.23,-0.4 -0.2,-0.03 -0.14,0.01 -0.18,-0.17 -0.21,-0.07 -0.15,0.01 -0.17,-0.23 -1.15,-0.64 -0.52,-0.16 -0.52,0.08 -0.26,-0.11 -0.15,-0.3 -0.08,-0.46 -0.71,-0.5 0.2,-0.18 0.37,0.02 0.45,-0.06 0.18,-0.17 -0.28,-0.29 -0.23,-0.1 -0.08,-0.11 -0.06,-0.22 0.16,-0.06 0.09,0.07 0.29,0.09 0.51,0.05 -0.15,-0.24 -0.18,-0.09 -0.08,-0.07 -0.4,-0.1 -0.2,0.03 -0.41,-0.11 -0.05,-0.24 v -0.2 l 0.21,-0.4 0.66,-0.25 1.53,-0.11 0.61,0.18 0.45,0.01 0.56,-0.16 0.27,-0.17 0.76,0.01 0.66,0.37 0.49,1.01 0.26,0.36 0.85,-0.39 1.13,0.22 0.19,0.34 0.13,-0.24 0.26,-0.26 0.15,0.17 0.05,0.19 1.21,0.15 0.2,-0.02 -0.29,-0.27 -0.18,-0.55 0.24,-1.89 -0.24,-0.58 -0.24,-0.9 -0.09,-0.53 0.01,-0.17 0.1,-0.24 0.46,0.09 0.34,0.13 0.71,-0.08 0.3,0.18 -0.08,0.39 0.03,0.5 0.07,0.26 0.13,0.29 0.56,0.07 0.56,0.25 0.75,0.14 1.06,0.44 0.49,-0.09 0.5,-0.28 0.89,-0.1 0.09,-0.11 -0.5,-0.02 -0.43,-0.28 -0.03,-0.24 0.08,-0.2 0.25,-0.46 1.42,-0.58 0.96,-0.1 1.04,-0.29 0.54,-0.37 0.39,-0.51 0.12,-0.11 0.15,-0.09 -0.1,-0.21 0.34,-2.11 0.13,-0.37 0.23,-0.29 0.31,-0.21 0.47,-0.21 1.63,-0.18 0.25,-0.12 0.01,0.23 0.09,0.3 0.06,0.17 -0.09,0.2 0.04,0.18 0.18,0.33 z"
+           class="region FR1 FRA"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      </g>
+      <g
+         id="gNCL"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <g
+         id="gPYF"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <g
+         id="gWLF"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="austria"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S17P1-30"
+         d="m 296.93,287.84 v 0.05 l -0.01,0.18 -0.1,0.24 -0.11,0.31 0.03,0.25 0.42,0.88 0.35,0.52 0.07,0.2 0.21,0.14 -0.17,0.22 -0.01,0.31 -0.11,0.14 -0.01,0.17 0.06,0.16 0.02,0.19 0.09,0.26 -0.3,0.09 -0.35,0.02 -0.13,0.03 -0.11,0.08 -0.13,-0.03 -0.34,-0.22 -0.19,-0.04 -0.12,0.02 -0.09,0.12 -0.15,0.16 -0.15,0.11 0.04,0.08 0.68,0.17 0.15,0.34 -0.11,0.29 -0.03,0.15 -0.15,0.12 -0.18,0.11 -0.23,0.04 -0.02,0.16 0.13,0.44 -0.07,0.11 -0.06,0.14 0.1,0.37 0.14,0.01 0.04,0.08 -0.01,0.15 -0.02,0.17 -0.04,0.17 -0.01,0.08 -0.1,0.05 h -0.3 l -0.25,0.16 -0.48,0.56 -0.18,0.11 -0.18,0.22 0.05,0.45 -0.03,0.05 -0.04,0.09 -0.64,-0.11 h -0.02 l -0.41,0.09 -0.27,0.23 -0.35,0.14 -0.73,-0.01 -0.71,0.12 -0.16,0.07 -0.18,0.05 -0.17,0.13 -0.09,0.18 -0.16,0.23 -0.25,0.18 -0.26,0.15 -0.06,0.11 -0.09,0.07 -0.16,-0.07 -0.12,0.01 -0.16,-0.05 -0.5,-0.04 -0.56,-0.07 -0.27,-0.08 -0.3,-0.07 -0.33,-0.04 -0.29,-0.01 -0.14,-0.02 -0.7,-0.14 -0.46,0.01 -0.6,-0.05 -1.21,-0.21 -0.35,-0.09 -0.33,-0.03 -0.4,-0.07 -0.3,-0.14 -0.2,-0.27 -0.21,-0.36 -0.38,-0.46 -0.09,-0.24 0.11,-0.21 0.12,-0.16 -0.02,-0.07 -0.09,-0.03 -0.65,0.22 -0.63,0.27 -0.25,0.01 -0.24,-0.06 -0.32,0.01 -0.31,0.07 -0.62,0.04 -0.36,0.19 -0.23,0.37 -0.12,0.3 -0.1,0.1 -0.22,0.04 -0.32,-0.03 -0.23,-0.09 -0.23,-0.25 -0.36,-0.03 -0.33,-0.01 -0.09,-0.05 0.01,-0.16 -0.13,-0.31 -0.22,-0.1 -0.56,0.58 -0.15,0.05 -0.45,-0.16 -0.38,-0.25 -0.05,-0.19 -0.06,-0.15 -0.32,-0.14 -0.41,-0.11 h -0.13 l 0.05,-0.09 0.05,-0.14 -0.03,-0.12 -0.09,-0.13 -0.05,-0.13 -0.02,-0.13 -0.03,-0.11 -0.01,-0.09 -0.03,-0.08 0.27,-0.58 0.06,-0.36 -0.23,-0.21 0.42,0.03 0.11,-0.04 0.04,-0.06 -0.11,-0.08 0.06,-0.03 0.11,-0.12 0.29,0.11 0.43,0.23 0.2,0.15 0.09,0.12 0.04,0.1 -0.02,0.17 0.09,0.07 0.21,0.02 0.13,0.05 -0.05,0.23 -0.01,0.18 0.19,-0.03 0.24,-0.14 0.18,-0.25 0.11,-0.24 0.09,-0.59 0.03,-0.06 0.14,0.05 0.57,-0.02 0.27,0.11 0.42,0.01 v 0.1 l 0.07,0.14 0.19,0.21 0.1,0.13 0.2,0.03 0.3,-0.08 0.18,-0.08 0.07,0.05 0.28,-0.05 0.24,-0.17 0.06,-0.13 0.25,-0.1 0.33,-0.21 0.46,-0.17 1.52,-0.2 0.05,-0.13 -0.03,-0.3 0.04,-0.05 0.2,0.07 0.3,0.06 0.24,0.1 0.16,0.14 h 0.14 l 0.21,-0.1 0.3,-0.07 0.28,0.13 0.08,0.15 -0.04,0.08 0.01,0.13 0.09,0.1 0.23,0.17 0.29,0.13 0.15,-0.01 0.05,-0.15 0.04,-0.34 0.01,-0.36 -0.07,-0.21 -0.16,-0.05 -0.19,-0.01 -0.1,-0.04 0.04,-0.11 0.13,-0.3 -0.01,-0.4 -0.35,-0.44 -0.3,-0.43 v -0.15 l 0.16,-0.26 0.26,-0.22 0.58,-0.36 0.18,-0.07 0.24,-0.07 0.34,-0.15 0.16,-0.15 0.1,-0.17 0.13,-0.82 0.04,-0.04 0.04,-0.05 0.61,0.26 0.06,-0.05 0.09,-0.05 0.19,-0.22 0.04,-0.17 -0.02,-0.31 v -0.29 l 0.04,-0.1 0.09,0.03 0.26,0.14 0.21,0.16 0.21,0.43 0.45,0.09 0.57,-0.02 0.19,-0.2 0.18,-0.06 0.21,0.05 0.44,0.05 0.03,-0.36 0.23,-0.37 0.1,-0.14 h 0.32 l 0.06,-0.28 0.04,-0.75 0.06,-0.09 0.23,0.01 0.24,0.12 0.07,0.1 0.12,-0.01 0.16,-0.09 0.18,-0.06 0.3,0.06 0.64,0.3 0.32,0.1 0.21,-0.04 0.18,-0.01 0.77,0.47 0.52,0.04 0.46,-0.04 0.14,-0.17 0.19,-0.15 h 0.21 l 0.18,0.06 0.37,0.2 0.17,0.04 0.22,0.02 0.16,0.04 0.18,0.38 z"
+         class="region AUT"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="belgium"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S20P1-59"
+         d="m 259.51,274.48 0.01,0.1 0.08,0.05 h 0.29 l 0.16,-0.17 0.12,-0.1 0.08,0.08 0.02,0.22 0.06,0.3 0.32,0.35 0.28,0.11 0.36,-0.04 0.15,-0.05 0.09,0.06 0.08,0.17 0.19,0.21 0.42,0.17 0.13,0.09 0.08,0.14 -0.03,0.18 -0.24,0.46 -0.04,0.13 0.03,0.05 -0.05,0.08 -0.29,0.3 -0.03,0.11 0.08,0.19 0.06,0.15 0.01,-0.03 0.42,-0.11 0.17,0.28 0.31,0.03 0.03,0.09 0.33,0.28 0.09,0.21 0.24,0.2 -0.22,0.24 0.02,0.11 0.07,0.12 0.27,0.08 0.14,0.17 -0.01,0.24 0.04,0.41 -0.6,0.37 -0.19,0.43 -0.02,0.09 -0.02,-0.01 -0.06,-0.15 -0.1,-0.01 -0.24,-0.08 -0.36,0.39 -0.17,0.32 -0.11,0.24 -0.15,0.2 -0.04,0.2 0.02,0.09 -0.06,0.11 -0.01,0.12 0.18,0.25 0.04,0.13 0.21,0.44 -0.08,0.15 -0.07,0.16 -0.08,0.11 -0.08,0.07 -0.25,-0.02 -0.31,0.03 -0.22,0.07 -0.1,-0.01 -0.22,-0.22 -0.23,-0.33 -0.15,-0.16 -0.06,-0.14 -0.19,-0.06 -0.27,-0.18 -0.18,-0.18 -0.16,-0.12 -0.24,-0.07 -0.19,-0.01 -0.04,-0.28 0.01,-0.33 -0.15,-0.23 0.28,-0.82 -0.12,-0.09 -0.14,0.05 -0.22,0.19 -0.12,0.23 -0.07,0.21 -0.36,0.17 -0.55,0.03 -0.58,-0.12 -0.08,-0.06 -0.03,-0.07 v -0.07 l 0.05,-0.11 0.12,-0.13 0.04,-0.2 -0.09,-0.18 -0.06,-0.07 0.04,-0.16 0.09,-0.21 0.03,-0.11 -0.37,-0.39 -0.28,-0.1 -0.28,-0.04 -0.2,-0.06 -0.13,0.01 -0.1,0.09 -0.09,0.07 -0.06,-0.1 -0.07,-0.64 -0.08,-0.1 -0.35,-0.14 -0.49,-0.09 -0.11,-0.13 -0.05,-0.29 -0.01,-0.35 -0.13,-0.34 -0.07,-0.09 -0.13,-0.16 -0.26,0.03 -0.32,0.16 -0.19,0.03 -0.07,0.02 -0.22,-0.21 -0.24,-0.32 -0.18,-0.33 -0.04,-0.18 0.09,-0.2 -0.06,-0.17 -0.09,-0.3 -0.01,-0.23 1.39,-0.67 0.83,-0.33 0.38,-0.09 0.05,0.42 0.05,0.14 0.08,0.1 0.12,0.02 0.14,-0.08 0.2,-0.09 0.3,0.07 0.21,0.12 0.07,0.11 0.14,0.12 0.21,0.04 0.43,-0.15 0.42,-0.25 0.13,-0.19 0.06,-0.18 0.22,0.14 0.21,0.04 0.09,-0.04 -0.03,-0.3 0.18,-0.14 0.19,-0.05 0.07,0.13 0.16,0.14 0.14,0.01 0.39,-0.3 0.08,0.07 0.07,0.12 z"
+         class="region BEL"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="bulgaria"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S24P1-3"
+         d="m 338.17,304.31 0.17,1.13 -0.2,0.6 -0.53,-0.05 -0.58,0.3 -0.2,0.67 -0.15,0.22 -0.13,0.25 0.06,0.79 0.24,1.26 -0.21,0.21 -0.21,0.1 -0.68,1.33 0.59,0.18 0.28,0.18 0.52,0.57 0.7,0.6 0.19,0.34 -0.48,0.03 -0.16,0.07 -0.07,0.13 -0.22,0.03 -0.27,0.07 -0.25,0.2 -0.14,0.09 -0.23,-0.07 -0.46,-0.27 -0.28,-0.2 -0.18,-0.02 -0.16,0.11 -0.61,0.23 -0.11,0.18 -0.26,0.23 -0.27,0.14 -0.41,0.15 -0.22,0.04 -0.1,0.11 -0.06,0.26 -0.03,0.25 -0.04,0.11 -0.5,0.23 -0.09,0.16 -0.01,0.13 0.04,0.13 -0.44,-0.03 -0.31,0.15 -0.05,0.12 -0.04,0.16 0.06,0.14 0.15,0.12 0.18,0.38 0.12,0.39 -0.03,0.25 -0.21,0.21 -0.46,0.29 -0.5,0.02 -0.2,0.11 -0.35,0.1 -0.32,0.12 -0.48,0.27 -0.44,0.19 -0.46,-0.25 -0.53,-0.13 -0.54,-0.04 -0.16,0.14 -0.06,0.09 -0.48,-0.21 -0.21,-0.07 -0.11,-0.1 -0.24,-0.36 -0.11,0.01 -0.33,0.22 -0.34,0.05 -0.21,0.02 -0.61,0.13 -0.04,0.28 -0.06,0.06 -0.13,0.06 -0.33,0.04 -0.38,0.28 -0.43,0.2 -0.35,0.07 -0.36,0.01 -0.21,0.08 -0.46,0.1 -0.26,0.35 -0.46,0.06 -0.39,0.02 0.04,-0.1 -0.1,-1.18 0.11,-0.56 -0.02,-0.1 -0.05,-0.08 -0.18,-0.05 -0.17,-0.26 -0.36,-0.7 -0.16,-0.13 -0.42,-0.09 -0.38,-0.15 -0.33,-0.23 -0.64,-0.61 0.26,-0.12 0.07,-0.15 0.21,-0.43 v -0.2 l -0.04,-0.1 -0.21,-0.15 -0.18,-0.39 0.04,-0.39 -0.02,-0.19 -0.12,-0.18 0.06,-0.25 0.18,-0.17 0.11,-0.05 0.51,-0.12 0.25,-0.53 0.17,-0.18 0.16,-0.31 0.08,-0.11 0.06,-0.23 -0.01,-0.22 -0.44,-0.23 -0.17,-0.21 -0.22,-0.22 -0.26,-0.13 -0.53,-0.22 -0.24,-0.27 -0.14,-0.38 -0.17,-0.27 -0.17,-0.17 -0.05,-0.16 -0.09,-0.18 -0.07,-0.38 0.04,-0.52 0.05,-0.19 0.16,-0.08 0.39,-0.34 -0.03,-0.35 0.04,-0.23 0.12,-0.14 0.12,-0.11 0.26,0.16 0.63,0.22 0.31,0.19 0.01,0.15 -0.11,0.16 -0.23,0.18 -0.12,0.21 v 0.24 l 0.06,0.16 0.2,0.11 1,-0.37 1.06,-0.09 1.45,0.06 0.95,-0.07 0.66,-0.27 1.32,0.01 1.22,0.01 1.15,-0.17 0.6,-0.32 0.39,-0.35 0.29,-0.57 0.82,-0.84 0.84,-0.56 1.13,-0.56 0.77,-0.28 0.13,0.08 1.13,0.35 0.44,-0.11 0.39,0.02 0.16,0.12 0.1,0.02 0.45,-0.26 0.28,0.26 0.43,0.37 0.62,0.09 h 0.53 l 0.17,-0.02 z"
+         class="region BGR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="bosnia_herzegovina"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S27P1-1"
+         d="m 305.33,304.91 0.11,-0.02 0.29,-0.17 0.35,-0.11 0.26,0.04 0.13,0.07 0.04,0.1 -0.04,0.38 -0.1,0.41 -0.18,0.45 -0.2,0.41 -0.05,0.22 0.02,0.33 v 0.26 l 0.05,0.14 0.09,0.12 0.28,0.07 0.4,0.22 0.34,0.3 0.44,0.33 0.14,0.13 0.02,0.15 -0.1,0.13 -0.34,0.08 -0.36,0.01 -0.14,-0.02 -0.12,0.06 -0.07,0.1 0.05,0.1 0.42,0.42 0.49,0.61 0.06,0.29 -0.03,0.23 -0.08,0.17 -0.18,-0.01 -0.15,-0.1 -0.2,0.03 -0.16,0.05 -0.18,0.27 h -0.1 l -0.18,0.06 -0.1,0.06 -0.19,-0.05 -0.19,-0.02 -0.07,0.08 -0.02,0.15 0.14,0.24 0.26,0.38 -0.01,0.31 -0.16,0.05 -0.18,-0.24 -0.14,-0.02 -0.15,0.02 -0.32,0.34 -0.24,0.28 -0.04,0.18 -0.07,0.2 -0.02,0.14 0.05,0.46 -0.46,0.12 -0.09,0.08 -0.05,0.15 0.1,0.58 0.07,0.31 0.31,0.46 0.03,0.15 -0.03,0.11 -0.17,0.21 -0.09,0.08 -0.06,0.03 -0.32,-0.09 -0.16,-0.05 -0.67,-0.36 -0.3,-0.21 -0.46,-0.27 -0.29,-0.15 -0.16,-0.26 -0.22,-0.04 -0.25,0.11 -0.3,-0.16 0.19,-0.13 0.04,-0.1 -0.03,-0.12 -0.11,-0.16 -0.83,-0.67 -0.42,-0.47 -0.08,-0.17 -0.05,-0.48 -0.09,-0.11 -0.59,-0.17 -0.68,-0.57 -0.69,-0.56 -0.11,-0.17 -0.37,-0.43 -0.43,-0.39 -0.35,-0.25 -0.29,-0.29 -0.32,-0.4 -0.2,-0.64 -0.17,-0.57 -0.11,-0.22 -0.19,-0.06 -0.62,-0.65 -0.51,-0.36 -0.03,-0.43 0.03,-0.73 0.04,-0.82 0.11,-0.12 0.22,-0.08 h 0.25 l 0.23,0.09 0.47,0.52 0.26,0.2 0.22,0.07 0.23,-0.25 0.26,-0.52 0.24,-0.28 0.88,0.02 0.4,-0.42 0.73,0.44 0.3,0.05 0.15,-0.09 0.22,0.01 0.5,0.1 0.12,0.05 0.15,-0.02 0.34,-0.23 0.13,0.01 0.44,0.34 0.21,-0.01 0.23,-0.19 0.15,-0.16 0.48,0.06 0.27,-0.1 0.22,-0.03 0.25,0.04 0.23,0.07 0.23,0.05 0.59,-0.03 0.3,0.21 0.14,0.23 0.01,0.14 0.05,0.15 0.18,0.13 0.36,0.05 z"
+         class="region BIH"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="belarus"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S29P1-9"
+         d="m 322.94,246.95 0.46,0.31 h 0.08 l 0.15,-0.21 0.04,-0.02 0.39,-0.11 0.23,0.09 0.21,0.24 0.18,0.18 0.16,0.03 0.31,-0.38 0.19,-0.15 0.15,-0.03 0.56,0.11 0.27,0.08 0.09,0.11 0.04,0.14 v 0.23 l 0.01,0.24 0.23,0.24 0.23,0.14 0.29,-0.41 0.12,-0.12 0.15,-0.05 0.17,-0.17 0.1,-0.21 0.12,-0.1 0.28,-0.03 0.48,-0.18 0.64,0.11 0.07,0.07 0.38,0.24 0.14,0.13 0.11,0.02 0.2,0.11 0.23,0.04 0.13,-0.07 0.08,0.03 0.1,0.1 0.07,0.21 0.15,0.59 -0.05,0.2 -0.06,0.17 0.01,0.11 0.04,0.13 0.24,0.21 0.33,0.33 0.12,0.21 0.05,0.18 -0.14,0.58 -0.06,0.15 0.01,0.27 0.04,0.26 0.05,0.1 0.6,0.26 0.42,0.11 0.11,0.09 0.03,0.06 -0.06,0.49 0.02,0.12 0.34,0.09 0.24,0.24 0.28,0.42 0.41,0.36 0.7,0.21 0.51,0.12 0.13,0.09 0.07,0.13 0.06,0.31 v 0.4 l -0.01,0.23 0.2,0.03 0.44,-0.16 0.58,-0.1 0.78,0.2 0.06,0.18 -0.02,0.19 0.1,0.16 0.12,0.12 0.72,0.27 0.1,0.12 0.08,0.21 0.03,0.17 -0.15,0.08 -0.15,0.14 -0.23,0.28 -0.03,0.31 -0.35,0.52 -0.24,0.26 -0.23,0.08 -0.57,0.09 -0.25,-0.12 -0.13,-0.15 -0.24,-0.01 -0.28,0.07 -0.39,0.15 -0.06,0.08 v 0.23 l -0.06,0.4 -0.06,0.24 0.14,0.1 0.23,0.21 0.34,0.26 0.34,0.22 0.13,0.15 0.04,0.13 -0.08,0.19 0.11,0.29 0.36,0.33 -0.06,0.09 0.12,0.49 0.16,0.53 0.1,0.1 0.16,0.07 0.17,0.15 0.32,0.38 0.05,0.11 -0.53,0.13 -0.63,0.2 -0.28,0.36 -0.15,-0.02 -0.27,0.01 -0.23,0.22 -0.25,0.54 -0.17,0.34 -0.14,0.44 -0.02,0.23 -0.05,0.41 -0.03,0.47 0.17,0.28 0.19,0.25 0.11,0.29 0.12,0.22 -0.1,0.21 -0.03,0.28 -0.28,0.03 -0.39,-0.15 -0.16,-0.32 -0.32,-0.17 -0.2,-0.08 -0.28,0.06 -0.4,0.23 -0.55,0.24 -0.43,0.14 -0.2,0.19 -0.32,0.21 -0.17,-0.1 -0.3,-0.34 -0.26,-0.35 -0.15,-0.14 -0.11,-0.02 -0.11,0.04 -0.11,0.16 -0.06,0.15 -0.13,0.08 -0.2,0.16 -0.12,0.18 -0.09,0.4 -0.12,0.01 -0.14,-0.05 -0.24,-0.37 -0.22,-0.04 -0.3,0.07 -0.4,0.01 -0.34,-0.05 -0.1,0.06 -0.14,0.22 -0.19,0.07 -0.47,-0.05 -0.07,0.09 -0.06,0.26 -0.08,0.25 -0.12,0.05 -0.08,-0.04 -0.05,-0.4 -0.29,-0.07 -0.43,0.08 -0.28,0.12 -0.15,0.02 -0.09,-0.06 -0.52,-0.56 -0.2,0.01 -0.34,0.11 -0.53,0.04 -0.62,-0.02 -0.34,0.02 -0.2,-0.11 -0.37,0.03 -1.04,-0.06 -0.4,0.04 -0.59,0.12 -0.91,0.12 -0.57,0.15 -0.24,0.15 -0.3,0.12 -0.51,0.15 -0.22,0.04 -0.32,0.09 -0.37,0.15 -0.09,0.16 -0.06,0.32 -0.35,0.61 -0.36,0.42 -0.08,0.05 -0.28,-0.14 -0.23,-0.02 -0.24,0.02 -0.17,0.09 -0.09,0.11 0.08,0.4 -0.01,0.04 -0.28,-0.44 -0.06,-0.44 0.06,-0.26 0.09,-0.25 -0.12,-0.32 0.05,-0.47 -0.06,-0.31 -0.08,-0.13 -0.13,-0.14 -0.31,-0.13 -0.14,-0.11 -0.41,-0.12 -0.42,-0.16 -0.08,-0.13 v -0.1 l 0.04,-0.16 0.2,-0.48 0.24,-0.47 0.16,-0.2 0.94,-0.72 0.13,-0.21 -0.02,-0.33 -0.04,-0.23 -0.1,-0.4 -0.17,-0.56 -0.15,-0.39 -0.34,-0.71 -0.82,-1.45 -0.61,-1.55 0.22,0.05 0.49,-0.05 0.36,-0.18 0.19,-0.05 h 0.18 l 0.25,-0.11 0.24,-0.07 0.15,0.12 0.25,0.08 0.4,-0.27 0.35,-0.3 0.41,-0.05 0.03,-0.12 -0.01,-0.59 0.09,-0.15 0.49,-0.04 0.16,-0.14 0.13,-0.31 0.24,-0.23 0.24,-0.05 0.2,-0.25 0.15,0.11 0.11,0.22 -0.04,0.2 0.05,0.07 0.19,0.05 0.29,-0.06 0.17,-0.12 0.02,-0.11 -0.04,-0.2 -0.09,-0.17 -0.16,-0.13 -0.25,-0.03 -0.16,0.03 -0.05,-0.09 0.01,-0.22 0.06,-0.42 0.1,-0.39 0.08,-0.16 -0.01,-0.13 -0.07,-0.21 -0.09,-0.38 0.04,-0.57 0.12,-0.45 0.25,-0.19 0.32,-0.14 0.18,-0.24 0.06,-0.25 -0.01,-0.19 0.02,-0.17 0.09,-0.1 0.83,-0.14 0.04,-0.37 0.05,-0.11 0.13,-0.14 0.08,-0.15 -0.06,-0.08 -0.22,-0.02 -0.51,0.06 -0.12,-0.09 v -0.15 l 0.05,-0.38 0.01,-0.49 -0.02,-0.37 -0.04,-0.21 0.06,-0.07 0.37,-0.16 0.12,-0.1 0.22,-0.56 0.24,-0.14 0.69,-0.03 0.3,-0.08 0.09,-0.01 0.31,-0.05 0.02,-0.06 0.01,-0.51 0.1,-0.17 0.36,-0.75 0.28,-0.35 0.2,-0.11 z"
+         class="region BLR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="switzerland"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S40P1-05"
+         d="m 272.24,293.15 0.21,0.35 0.65,0.41 0.33,0.02 0.23,0.21 -0.06,0.36 -0.27,0.58 -0.15,0.47 -0.02,0.36 0.03,0.17 0.04,-0.01 0.26,0.03 h 0.13 l 0.41,0.11 0.32,0.14 0.06,0.15 0.05,0.19 0.38,0.25 0.45,0.16 0.15,-0.05 0.56,-0.58 0.22,0.1 0.13,0.31 -0.01,0.16 -0.15,0.62 -0.03,0.34 0.13,0.22 0.02,0.17 -0.04,0.16 -0.23,0.01 -0.3,-0.08 -0.25,-0.27 -0.19,0.03 -0.17,0.07 -0.08,0.25 -0.08,0.3 0.02,0.17 0.12,0.13 0.09,0.28 0.07,0.36 0.05,0.17 -0.06,0.07 -0.16,0.05 -0.13,-0.05 -0.23,-0.43 -0.1,-0.17 -0.18,-0.03 -0.32,0.1 -0.5,0.24 h -0.2 l -0.17,-0.06 -0.15,-0.2 -0.13,-0.4 -0.04,-0.24 h -0.09 l -0.32,-0.07 -0.14,0.09 -0.01,0.4 -0.04,0.5 -0.16,0.32 -0.45,0.55 -0.17,0.24 -0.06,0.18 -0.02,0.15 0.06,0.26 0.09,0.26 -0.08,0.14 -0.24,0.07 -0.16,-0.16 -0.06,-0.27 -0.35,-0.38 0.17,-0.31 -0.02,-0.07 -0.59,-0.18 -0.25,-0.24 -0.34,-0.42 -0.06,-0.18 0.03,-0.57 -0.02,-0.14 -0.04,-0.07 h -0.18 l -0.24,0.19 -0.23,0.29 -0.46,0.32 -0.05,0.07 0.14,0.34 -0.01,0.12 -0.38,0.51 -0.08,0.17 -0.48,0.31 -0.22,0.12 -0.64,-0.27 -0.18,-0.03 -0.29,0.14 -0.42,0.14 -0.67,0.12 -0.24,-0.12 -0.11,-0.11 -0.05,-0.16 -0.16,-0.29 -0.18,-0.17 -0.12,-0.19 -0.16,-0.2 -0.11,-0.17 0.17,-0.52 -0.09,-0.19 -0.05,-0.27 0.04,-0.18 -0.06,-0.04 -0.59,-0.14 -0.49,0.01 -0.36,0.15 -0.31,0.28 -0.04,0.06 0.02,0.05 0.13,0.28 -0.26,0.27 -0.39,0.2 h -0.26 l -0.12,-0.05 0.02,-0.3 0.22,-0.1 0.21,-0.18 0.08,-0.28 0.04,-0.19 -0.2,-0.25 0.04,-0.14 0.14,-0.27 0.09,-0.24 0.11,-0.2 0.43,-0.32 0.43,-0.33 0.08,-0.36 0.05,-0.45 0.07,-0.1 0.56,-0.24 0.14,-0.1 0.08,-0.15 0.46,-0.48 0.45,-0.47 0.09,-0.16 0.08,-0.1 v -0.08 l -0.05,-0.06 -0.2,-0.06 -0.06,-0.16 0.23,-0.27 0.28,-0.16 0.27,0.01 0.11,0.09 -0.01,0.09 0.11,0.1 0.2,0.05 0.25,-0.03 0.25,-0.09 0.17,-0.25 0.09,-0.18 0.4,-0.21 0.27,0.12 0.73,0.06 0.55,-0.04 0.34,-0.14 0.42,0.02 0.28,0.09 0.05,-0.01 0.07,-0.02 0.08,-0.08 0.27,-0.04 0.04,-0.07 -0.01,-0.07 -0.05,-0.03 -0.33,0.02 -0.12,-0.05 -0.03,-0.12 0.11,-0.21 0.25,-0.16 0.2,-0.04 0.14,0.05 0.35,0.32 0.09,0.02 0.05,-0.06 0.07,-0.03 0.13,0.07 0.13,0.19 0.02,0.04 0.8,-0.06 z"
+         class="region CHE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gNZ1"
+       transform="matrix(1.4331066,0,0,1.4331066,-0.25396626,260.10818)"
+       style="fill:#ccced1;fill-opacity:1;stroke:none">
+      <g
+         id="gCOK"
+         style="fill:#ccced1;fill-opacity:1;stroke:none" />
+      <g
+         id="gNIU"
+         style="fill:#ccced1;fill-opacity:1;stroke:none" />
+      <g
+         id="gNZL"
+         style="fill:#ccced1;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="cyprus"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S55P1-9"
+         style="display:inline;fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         class="region CYN"
+         d="m 367.57006,334.81993 -0.47997,0.31999 -0.42996,0.44017 -0.25007,0.19979 -0.39017,0.48025 -1.49989,1.07987 -0.52004,0.26002 -0.54988,0.15005 -0.68004,0.13982 -0.68998,0.0702 0.06,0.52004 -0.0699,0.48993 -0.36005,0.21995 -0.23018,0.0199 -0.2299,0.0102 -0.32993,0.2299 -0.21996,0.3899 -0.26997,0.28018 -0.36004,-0.05 0.18983,0.55983 0.52999,0.67009 0.18016,0.17989 0.22991,0.0301 0.74994,0.0401 0.21001,-0.06 0.41006,-0.20006 0.20005,0.06 0.16,0.24012 0.25007,-0.05 0.0298,-0.15999 -0.0401,-0.16026 0.10003,-0.21996 0.17021,-0.15004 0.21995,-0.0799 0.42001,-0.22991 0.3899,-0.29013 0.30008,-0.37 0.49988,-0.95 0.21,-0.0799 0.24013,-0.05 0.39984,-0.15999 0.39016,-0.21 -0.15004,-0.22023 -0.10003,-0.0699 -0.33988,-0.23985 -0.15004,-0.25007 0.0199,-0.43991 1.53,-1.97019 z"
+         transform="translate(-2.7534695e-6)" />
+    </g>
+    <g
+       id="czech_republic"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S57P1-9"
+         d="m 289.54,277.51 0.26,-0.03 0.25,-0.13 0.01,-0.2 -0.03,-0.36 0.02,-0.06 0.4,0.08 0.41,0.14 0.08,0.36 0.12,0.17 0.14,0.15 0.13,0.07 h 0.21 l 0.56,0.17 0.26,0.03 0.28,0.13 0.24,0.13 0.16,0.02 0.09,0.17 0.11,0.1 0.18,-0.1 0.64,-0.17 0.25,0.14 0.17,0.16 0.03,0.06 -0.07,0.16 -0.03,0.12 -0.07,0.08 -0.21,0.1 -0.12,0.15 -0.08,0.15 0.07,0.14 0.19,0.09 0.14,0.02 0.05,0.1 0.46,0.43 0.38,0.57 0.14,0.09 0.12,0.01 0.14,-0.1 0.14,-0.21 0.18,-0.16 0.16,-0.09 0.28,-0.19 v -0.11 l -0.28,-0.39 -0.17,-0.32 0.03,-0.06 0.31,0.03 0.54,0.13 0.85,0.52 0.15,-0.02 0.28,-0.07 0.29,-0.13 0.13,-0.12 0.06,0.04 0.08,0.32 -0.06,0.18 -0.35,0.21 0.03,0.08 0.1,0.1 0.18,0.06 0.22,0.19 0.16,0.23 0.13,0.1 0.14,0.04 0.32,-0.16 0.08,-0.11 0.04,-0.08 0.06,0.01 0.13,0.1 0.04,0.07 0.34,0.1 0.21,0.14 0.12,0.07 0.13,-0.09 0.53,0.07 0.15,0.1 0.06,0.18 -0.01,0.11 0.11,0.28 0.73,0.61 0.11,0.34 0.02,0.14 -0.08,0.02 -0.17,0.09 -0.22,0.05 -0.25,0.02 -0.17,0.15 -0.16,0.22 -0.17,0.17 -0.09,0.14 -0.04,0.14 -0.6,0.44 -0.07,0.17 -0.05,0.22 v 0.29 l -0.02,0.26 -0.09,0.15 -0.34,0.15 -0.08,0.07 -0.05,0.14 -0.17,0.22 -0.21,0.22 -0.39,0.26 -0.45,0.11 -0.59,-0.01 -0.34,-0.06 -0.16,0.11 -0.2,0.31 -0.21,0.52 -0.07,0.38 -0.08,-0.1 -0.18,-0.38 -0.16,-0.04 -0.22,-0.02 -0.17,-0.04 -0.37,-0.2 -0.18,-0.06 h -0.21 l -0.19,0.15 -0.14,0.17 -0.46,0.04 -0.52,-0.04 -0.77,-0.47 -0.18,0.01 -0.21,0.04 -0.32,-0.1 -0.64,-0.3 -0.3,-0.06 -0.18,0.06 -0.16,0.09 -0.12,0.01 -0.07,-0.1 -0.24,-0.12 -0.23,-0.01 -0.06,0.09 -0.04,0.75 -0.06,0.28 h -0.32 l -0.1,0.14 -0.23,0.37 -0.03,0.36 -0.44,-0.05 -0.21,-0.05 -0.18,0.06 -0.19,0.2 -0.57,0.02 -0.45,-0.09 -0.21,-0.43 -0.21,-0.16 -0.26,-0.14 -0.09,-0.03 -0.16,-0.23 -0.28,-0.27 -0.45,-0.38 -0.33,0.03 -0.13,-0.1 -0.06,-0.14 -0.15,-0.25 -0.16,-0.17 -0.2,-0.06 -0.28,-0.22 -0.38,-0.47 -0.35,-0.33 -0.32,0.02 -0.21,-0.17 -0.22,-0.23 -0.16,-0.22 -0.25,-0.54 -0.18,-0.3 -0.14,-0.19 -0.15,-0.16 -0.06,-0.12 0.18,-0.3 0.06,-0.14 0.08,-0.11 0.04,-0.12 -0.01,-0.09 -0.17,-0.28 -0.23,-0.2 -0.34,-0.21 -0.22,-0.25 -0.08,-0.25 -0.03,-0.13 -0.15,-0.18 -0.12,-0.26 v -0.16 l 0.03,-0.04 h 0.11 l 0.12,0.1 0.18,0.21 0.15,0.3 0.08,-0.12 0.16,-0.33 0.27,-0.37 0.29,-0.22 0.27,-0.03 0.21,-0.06 0.18,-0.11 0.32,0.03 0.22,0.07 0.08,-0.05 0.08,-0.19 0.06,-0.17 0.5,-0.11 0.16,-0.33 h 0.09 l 0.11,-0.05 0.1,-0.13 0.1,-0.05 0.09,0.06 0.11,0.03 0.1,-0.08 0.15,-0.37 0.09,-0.06 0.44,-0.08 0.59,-0.24 0.29,-0.2 0.29,-0.12 0.31,-0.2 0.5,-0.21 0.02,-0.07 -0.25,-0.17 -0.08,-0.12 -0.06,-0.11 0.08,-0.14 0.1,-0.05 0.15,0.05 0.43,0.06 0.12,0.07 0.05,0.18 0.12,0.17 0.08,0.01 -0.01,0.29 0.14,0.1 0.2,0.08 0.13,-0.03 0.09,-0.12 z"
+         class="region CZE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="germany"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S58P1-2"
+         d="m 286.94,262.95 0.06,0.23 -0.12,-0.02 -0.35,0.08 -0.35,-0.06 -0.08,-0.29 0.04,-0.28 -0.14,-0.18 -0.14,-0.11 -0.02,-0.15 0.01,-0.17 0.61,0.42 0.51,0.38 z"
+         class="region DEU"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S58P2"
+         d="m 278.68,260.81 -0.43,0.01 -0.16,-0.19 -0.17,-0.05 0.09,-0.23 0.11,-0.09 0.42,0.15 0.13,0.3 z"
+         class="region DEU"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S58P3"
+         d="m 285.46,260.79 0.09,0.32 -0.07,0.17 -0.33,-0.26 -0.31,0.02 -0.18,0.42 -0.14,0.03 -0.5,-0.37 -0.08,-0.18 -0.03,-0.15 0.05,-0.54 -0.02,-0.17 0.15,-0.19 0.01,-0.27 0.26,-0.29 0.24,-0.02 0.08,0.23 0.12,0.16 0.41,0.17 0.07,0.08 0.04,0.12 -0.18,0.23 -0.06,0.12 0.07,0.18 z"
+         class="region DEU"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S58P4"
+         d="m 271.19,259.34 -0.11,0.11 -0.26,-0.02 -0.14,-0.11 0.05,-0.12 0.14,-0.09 0.11,-0.01 0.18,0.06 z"
+         class="region DEU"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S58P5"
+         d="m 273.05,258.92 0.24,0.01 0.44,-0.15 0.32,-0.07 0.13,0.1 0.17,0.04 h 0.04 l 0.02,0.09 0.4,0.13 0.17,0.21 0.19,0.31 0.01,0.44 -0.24,0.32 -0.21,0.2 0.77,-0.07 0.08,0.18 0.11,0.2 0.42,-0.14 1.03,0.58 0.63,-0.28 0.16,-0.02 0.15,0.47 -0.16,0.48 -0.55,0.51 0.13,0.31 0.17,0.07 0.53,-0.07 0.84,0.3 0.17,-0.1 0.66,-0.72 0.27,-0.16 0.88,-0.12 0.16,-0.28 0.35,-0.29 0.22,-0.31 0.53,-0.59 0.57,0.09 0.34,0.1 0.37,0.04 0.35,0.6 0.87,0.65 0.77,-0.09 0.31,0.63 0.16,0.79 0.25,0.23 0.22,0.16 0.64,0.14 0.03,0.01 0.03,0.1 0.06,0.39 0.07,0.33 0.4,1.29 0.01,0.32 v 0.08 l -0.1,0.46 -0.19,0.39 -0.28,0.22 -0.14,0.25 -0.02,0.26 0.38,0.44 0.8,0.62 0.33,0.54 -0.12,0.48 -0.02,0.34 0.07,0.22 0.13,0.17 0.2,0.12 0.08,0.2 -0.02,0.27 0.05,0.19 0.15,0.13 -0.01,0.05 -0.06,0.2 -0.07,0.35 -0.04,0.26 -0.2,0.36 0.08,0.29 0.19,0.34 0.14,0.17 0.05,0.16 -0.06,0.4 0.05,0.1 0.56,0.26 0.09,0.13 0.07,0.27 0.23,0.59 -0.11,0.76 -0.12,0.42 -0.27,0.68 -0.01,0.06 -0.03,0.08 -0.09,0.12 -0.13,0.03 -0.2,-0.08 -0.14,-0.1 0.01,-0.29 -0.08,-0.01 -0.12,-0.17 -0.05,-0.18 -0.12,-0.07 -0.43,-0.06 -0.15,-0.05 -0.1,0.05 -0.08,0.14 0.06,0.11 0.08,0.12 0.25,0.17 -0.02,0.07 -0.5,0.21 -0.31,0.2 -0.29,0.12 -0.29,0.2 -0.59,0.24 -0.44,0.08 -0.09,0.06 -0.15,0.37 -0.1,0.08 -0.11,-0.03 -0.09,-0.06 -0.1,0.05 -0.1,0.13 -0.11,0.05 h -0.09 l -0.16,0.33 -0.5,0.11 -0.06,0.17 -0.08,0.19 -0.08,0.05 -0.22,-0.07 -0.32,-0.03 -0.18,0.11 -0.21,0.06 -0.27,0.03 -0.29,0.22 -0.27,0.37 -0.16,0.33 -0.08,0.12 -0.15,-0.3 -0.18,-0.21 -0.12,-0.1 h -0.11 l -0.03,0.04 v 0.16 l 0.12,0.26 0.15,0.18 0.03,0.13 0.08,0.25 0.22,0.25 0.34,0.21 0.23,0.2 0.17,0.28 0.01,0.09 -0.04,0.12 -0.08,0.11 -0.06,0.14 -0.18,0.3 0.06,0.12 0.15,0.16 0.14,0.19 0.18,0.3 0.25,0.54 0.16,0.22 0.22,0.23 0.21,0.17 0.32,-0.02 0.35,0.33 0.38,0.47 0.28,0.22 0.2,0.06 0.16,0.17 0.15,0.25 0.06,0.14 0.13,0.1 0.33,-0.03 0.45,0.38 0.28,0.27 0.16,0.23 -0.04,0.1 v 0.29 l 0.02,0.31 -0.04,0.17 -0.19,0.22 -0.09,0.05 -0.06,0.05 -0.61,-0.26 -0.04,0.05 -0.04,0.04 -0.13,0.82 -0.1,0.17 -0.16,0.15 -0.34,0.15 -0.24,0.07 -0.18,0.07 -0.58,0.36 -0.26,0.22 -0.16,0.26 v 0.15 l 0.3,0.43 0.35,0.44 0.01,0.4 -0.13,0.3 -0.04,0.11 0.1,0.04 0.19,0.01 0.16,0.05 0.07,0.21 -0.01,0.36 -0.04,0.34 -0.05,0.15 -0.15,0.01 -0.29,-0.13 -0.23,-0.17 -0.09,-0.1 -0.01,-0.13 0.04,-0.08 -0.08,-0.15 -0.28,-0.13 -0.3,0.07 -0.21,0.1 h -0.14 l -0.16,-0.14 -0.24,-0.1 -0.3,-0.06 -0.2,-0.07 -0.04,0.05 0.03,0.3 -0.05,0.13 -1.52,0.2 -0.46,0.17 -0.33,0.21 -0.25,0.1 -0.06,0.13 -0.24,0.17 -0.28,0.05 -0.07,-0.05 -0.18,0.08 -0.3,0.08 -0.2,-0.03 -0.1,-0.13 -0.19,-0.21 -0.07,-0.14 v -0.1 l -0.42,-0.01 -0.27,-0.11 -0.57,0.02 -0.14,-0.05 -0.03,0.06 -0.09,0.59 -0.11,0.24 -0.18,0.25 -0.24,0.14 -0.19,0.03 0.01,-0.18 0.05,-0.23 -0.13,-0.05 -0.21,-0.02 -0.09,-0.07 0.02,-0.17 -0.04,-0.1 -0.09,-0.12 -0.2,-0.15 -0.43,-0.23 -0.29,-0.11 -0.11,0.12 -0.06,0.03 -0.17,-0.11 -0.41,-0.29 -0.46,-0.25 -0.45,-0.28 -0.32,-0.24 -0.06,0.05 0.22,0.49 -0.18,-0.01 -0.8,0.06 -0.02,-0.04 -0.13,-0.19 -0.13,-0.07 -0.07,0.03 -0.05,0.06 -0.09,-0.02 -0.35,-0.32 -0.14,-0.05 -0.2,0.04 -0.25,0.16 -0.11,0.21 0.03,0.12 0.12,0.05 0.33,-0.02 0.05,0.03 0.01,0.07 -0.04,0.07 -0.27,0.04 -0.08,0.08 -0.07,0.02 -0.05,0.01 -0.28,-0.09 -0.42,-0.02 -0.34,0.14 -0.55,0.04 -0.73,-0.06 -0.27,-0.12 -0.16,-0.07 -0.1,-0.32 0.05,-0.48 0.2,-0.63 0.06,-0.46 -0.06,-0.3 0.12,-0.44 0.3,-0.58 0.22,-0.61 0.11,-0.65 0.15,-0.43 0.28,-0.29 0.67,-0.81 0.05,-0.06 v -0.42 l -0.17,-0.07 -0.25,-0.12 -0.63,-0.18 -0.59,-0.11 -0.26,-0.13 -0.22,-0.33 -0.15,-0.01 -0.29,0.1 -0.36,0.06 -0.25,-0.07 h -0.17 l -0.09,0.06 -0.04,-0.06 -0.05,-0.27 -0.14,-0.08 -0.2,-0.07 -0.14,0.02 -0.09,0.13 -0.15,0.09 -0.12,-0.04 -0.37,-0.65 -0.1,-0.14 -0.02,-0.13 -0.08,-0.24 -0.23,-0.24 -0.23,-0.09 -0.12,0.02 0.03,-0.28 0.11,-0.41 0.1,-0.22 0.13,-0.17 0.13,-0.11 0.04,-0.23 -0.01,-0.21 -0.14,-0.04 -0.35,-0.17 -0.2,-0.18 -0.15,-0.22 -0.19,-0.29 -0.07,-0.29 0.02,-0.29 0.03,-0.13 0.02,-0.09 0.19,-0.43 0.6,-0.37 -0.04,-0.41 0.01,-0.24 -0.14,-0.17 -0.27,-0.08 -0.07,-0.12 -0.02,-0.11 0.22,-0.24 -0.24,-0.2 -0.09,-0.21 -0.33,-0.28 -0.03,-0.09 0.2,-0.73 -0.11,-0.22 -0.15,-0.12 -0.18,-0.06 -0.07,-0.11 -0.02,-0.12 0.03,-0.07 0.22,0.03 0.07,-0.07 0.53,-0.4 0.03,-0.09 -0.07,-0.05 -0.09,-0.03 -0.02,-0.09 0.01,-0.12 0.31,-0.61 0.09,-0.26 0.03,-0.19 v -0.19 l -0.14,-0.3 -0.14,-0.24 0.01,-0.19 -0.1,-0.1 -0.28,-0.52 0.01,-0.2 0.18,-0.13 0.25,-0.09 0.09,-0.07 0.15,-0.04 0.38,0.17 0.16,0.13 0.05,-0.02 0.17,-0.13 0.27,0.04 0.68,-0.24 0.1,-0.13 0.08,-0.13 0.01,-0.06 -0.24,-0.29 v -0.1 l 0.04,-0.11 0.07,-0.08 0.16,-0.05 0.16,-0.11 0.38,-0.32 0.14,-0.28 0.05,-0.31 0.02,-0.24 -0.09,-0.19 -0.09,-0.12 -0.14,0.01 -0.26,-0.02 -0.24,-0.12 -0.12,-0.18 -0.03,-0.15 0.07,-0.09 0.02,-0.11 -0.03,-0.12 0.02,-0.09 0.11,-0.08 0.77,0.04 0.07,-0.08 0.07,-0.44 0.22,-0.68 0.2,-0.37 0.04,-0.16 0.04,-0.9 0.04,-0.45 -0.12,-0.22 -0.27,-0.25 0.09,-0.48 0.11,-0.38 0.3,-0.45 0.23,-0.12 0.98,-0.04 1.08,0.07 0.42,0.73 -0.18,0.35 0.26,0.18 0.13,-0.06 0.11,-0.31 0.07,-0.35 0.1,-0.1 0.32,0.27 0.12,0.18 -0.01,0.58 0.14,-0.78 -0.07,-0.55 0.07,-0.52 0.15,-0.28 0.12,-0.17 0.79,0.21 0.87,-0.08 0.33,0.21 0.73,1.03 0.25,0.17 0.31,0.06 -0.43,-0.23 -0.89,-1.25 -0.27,-0.16 -0.41,-0.05 -0.26,-0.13 -0.15,-0.19 -0.05,-0.17 0.04,-1.25 -0.15,-0.19 -0.2,-0.07 -0.13,0.09 -0.25,-0.01 -0.05,-0.28 0.07,-0.21 0.52,-0.13 0.34,-0.18 0.02,-0.34 -0.21,-0.27 -0.24,-0.5 -0.28,-0.46 -0.02,-0.54 0.51,0.02 0.13,0.03 0.77,0.26 z"
+         class="region DEU"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S58P6"
+         d="m 270.43,258.96 -0.07,0.09 0.05,-0.67 0.33,-0.71 0.12,0.02 -0.13,0.19 -0.04,0.13 -0.06,0.27 0.02,0.15 0.68,0.05 -0.08,0.13 -0.7,0.06 z"
+         class="region DEU"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       id="denmark"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 278.87,258.54 0.5,0.29 0.33,-0.03 0.22,0.12 0.06,0.19 0.03,0.43 -0.24,0.12 -0.26,-0.04 -0.36,0.17 -1.17,-0.68 0.01,-0.57 0.05,-0.23 0.55,-0.06 z"
+         id="polyF1S61P1-2" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 276.45,258.76 -0.18,0.05 -0.22,-0.1 -0.34,-0.4 -0.04,-0.1 0.18,0.06 0.22,0.21 0.19,0.04 0.25,0.18 z"
+         id="polyF1S61P2" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 282.14,258.12 -0.1,0.07 -0.43,-0.04 -0.47,0.34 -0.18,-0.1 0.06,-0.21 0.05,-0.08 0.16,-0.09 0.1,-0.14 0.04,-0.21 0.1,0.11 0.3,0.04 0.14,0.06 0.13,0.1 z"
+         id="polyF1S61P3" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 275.28,258.57 -0.28,0.07 -0.15,-0.12 -0.27,-0.05 -0.09,-0.74 0.03,-0.04 0.13,0.05 0.46,0.35 0.16,0.38 z"
+         id="polyF1S61P4" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 277.14,259.22 -0.12,0.03 -0.17,-0.39 -0.02,-0.12 0.2,-0.25 0.12,-0.28 0.33,-0.43 0.18,-0.51 0.07,0.01 -0.08,0.45 -0.42,1.26 z"
+         id="polyF1S61P5" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 289.1,257.53 -0.09,0.09 -0.46,-0.11 -0.58,-0.3 0.05,-0.65 0.12,-0.29 1.05,0.67 0.03,0.27 z"
+         id="polyF1S61P6" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 276.89,255.11 0.11,0.25 0.14,0.53 0.23,0.6 -0.09,0.25 0.06,0.32 -0.06,0.33 -0.44,0.39 -0.5,0.02 -0.52,-0.19 -0.73,-0.37 -0.05,-0.2 -0.1,-0.11 -0.19,-0.62 0.01,-0.76 0.36,-0.09 0.8,-0.35 0.18,0.05 0.19,0.19 0.22,0.01 0.32,-0.26 z"
+         id="polyF1S61P7" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 282.37,255.09 -0.25,0.21 -0.06,-0.01 -0.09,-0.28 0.13,-0.17 0.07,-0.15 0.06,0.01 0.08,0.15 z"
+         id="polyF1S61P8" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 276.78,254.28 -0.04,0.09 -0.17,-0.09 -0.02,-0.31 0.06,-0.28 -0.07,-0.25 0.08,-0.16 0.24,0.37 0.07,0.18 -0.09,0.21 z"
+         id="polyF1S61P9" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 282.08,254.19 0.02,0.48 -0.07,0.14 -0.1,0.1 -0.27,0.1 -0.23,0.15 -0.2,0.24 -0.07,0.34 0.17,0.25 0.3,0.13 0.09,0.47 -0.24,0.24 -0.63,0.25 -0.05,0.57 0.03,0.45 -0.01,0.32 -0.04,0.45 -0.51,0.21 -0.35,-0.67 -0.01,-0.28 -0.1,-0.31 -0.03,-0.28 -0.12,-0.43 -0.49,-0.11 -0.19,-0.01 -0.27,0.08 -0.06,-0.03 -0.32,-0.59 0.04,-0.66 -0.17,-0.33 -0.02,-0.15 v -0.16 l -0.14,-0.14 -0.17,-0.07 -0.08,-0.37 0.19,-0.09 0.47,0.04 0.14,-0.03 0.13,-0.07 0.37,-0.62 -0.01,-0.13 0.03,-0.17 0.41,-0.07 0.19,0.23 -0.03,0.37 0.03,0.48 0.26,0.13 0.09,0.02 0.1,-0.36 0.07,-0.17 0.1,-0.1 0.03,-0.33 -0.07,-0.19 -0.12,-0.15 0.45,-0.41 0.47,-0.33 0.28,-0.02 0.29,0.07 0.26,0.1 0.14,0.09 0.09,0.15 -0.17,0.35 -0.04,0.2 z"
+         id="polyF1S61P10" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 277.93,247.25 -0.11,0.12 -0.35,-0.16 0.15,-0.22 0.39,-0.11 0.23,0.04 -0.25,0.22 z"
+         id="polyF1S61P11" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 DNK"
+         d="m 276.33,247.64 -0.26,0.72 -0.11,0.11 -0.02,0.84 0.02,0.2 -0.04,0.77 0.27,0.31 0.28,0.17 0.94,-0.01 0.1,0.14 0.12,0.23 -0.09,0.41 -0.1,0.3 -0.27,0.26 -0.35,0.19 -0.22,0.01 -0.3,-0.37 -0.14,0.12 -0.15,0.19 -0.25,0.99 -0.12,0.67 -0.06,0.05 -0.14,-0.1 -0.24,-0.01 -0.31,0.16 0.15,0.14 0.17,0.25 -0.07,0.12 -0.27,0.14 -0.24,0.27 -0.11,0.2 -0.3,0.24 -0.2,0.3 0.09,0.39 0.04,0.33 0.08,0.37 -0.08,0.3 -0.39,0.42 -0.14,0.36 h 0.32 l 0.2,0.09 0.12,0.11 0.12,0.15 -0.08,0.19 0.09,0.49 h -0.04 l -0.17,-0.04 -0.13,-0.1 -0.32,0.07 -0.44,0.15 -0.24,-0.01 -0.19,-0.18 -0.77,-0.26 -0.13,-0.03 -0.51,-0.02 -0.02,-0.4 -0.05,-0.28 -0.17,-0.43 0.27,-0.1 -0.03,-0.83 -0.09,-0.43 -0.72,-0.46 -0.56,-0.44 0.18,-1.44 0.07,-0.39 -0.19,-0.76 0.05,-0.86 0.14,-1.36 0.18,-0.05 0.13,0.01 0.5,0.26 0.21,0.03 0.13,0.22 0.17,0.09 0.13,-0.22 0.06,-0.4 0.41,-0.51 0.29,-0.18 0.19,-0.09 0.19,0.21 0.14,0.24 0.04,-0.51 0.14,-0.97 -0.37,-0.16 -0.31,0.13 -0.32,0.61 -0.29,0.76 -0.45,0.06 -0.36,0.21 -0.32,-0.23 -0.2,-0.21 0.01,-0.29 0.05,-0.18 0.4,-0.62 0.51,-0.59 0.5,0.02 0.38,-0.19 0.22,-0.01 0.68,0.05 0.35,-0.13 0.32,-0.27 0.69,-1.17 0.38,-0.48 0.77,-0.17 0.7,-0.56 0.2,-0.01 -0.33,0.42 -0.06,0.16 -0.04,0.25 0.24,0.55 -0.05,0.33 0.02,0.64 z"
+         id="polyF1S61P12" />
+    </g>
+    <g
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       id="gFRO"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region DN1 FRO"
+         d="m 237.62,222.77 0.01,0.15 -0.05,-0.03 -0.1,-0.19 -0.15,-0.44 -0.01,-0.33 0.03,-0.15 0.06,0.03 0.01,0.14 0.23,0.15 0.04,0.07 -0.04,0.16 0.03,0.2 z"
+         id="polyF1S74P1-6" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region DN1 FRO"
+         d="m 238.24,221.16 -0.09,0.16 -0.06,-0.01 -0.14,-0.27 -0.13,-0.15 -0.03,-0.11 v -0.18 h 0.1 l 0.1,0.06 0.24,0.22 0.03,0.18 z"
+         id="polyF1S74P2" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region DN1 FRO"
+         d="m 237.45,219.34 0.14,0.23 0.04,0.14 -0.15,0.09 h -0.14 l -0.16,-0.07 -0.22,-0.2 -0.01,-0.32 0.18,0.05 h 0.23 z"
+         id="polyF1S74P3" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region DN1 FRO"
+         d="m 238.75,219.23 -0.22,0.6 -0.09,-0.03 -0.11,-0.2 -0.1,-0.07 -0.06,0.09 -0.03,0.11 0.04,0.08 0.08,0.46 -0.02,0.12 -0.04,0.05 -0.15,-0.16 -0.29,-0.64 -0.09,-0.96 0.49,-0.02 0.27,0.31 z"
+         id="polyF1S74P4" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region DN1 FRO"
+         d="m 239.27,219.2 -0.19,0.31 -0.14,-0.09 -0.03,-0.05 -0.01,-0.09 0.08,-0.24 0.09,-0.36 0.1,0.34 z"
+         id="polyF1S74P5" />
+      <circle
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         class="region DN1 FRO"
+         cx="238.04454"
+         cy="219.23727"
+         id="pointF2S51P1"
+         r="0.25" />
+    </g>
+    <g
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+       id="gGRL"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 GRL"
+         d="m 192.48,179.38 -0.21,-0.18 0.18,-0.34 0.3,-0.28 0.32,0.1 -0.07,0.32 -0.32,0.27 z"
+         id="polyF1S87P2" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         inkscape:connector-curvature="0"
+         class="region DN1 GRL"
+         d="m 229.8,168.92 0.1,0.13 0.36,0.23 -0.2,0.19 -0.69,0.3 -0.29,0.05 -0.11,0.08 -0.09,0.18 -0.17,0.29 -0.26,0.57 0.4,-0.44 0.21,-0.2 0.13,-0.03 0.09,0.03 0.4,-0.09 0.2,0.25 -0.27,0.6 -0.29,0.53 -0.3,0.44 -0.39,0.72 -0.16,0.23 -0.06,0.24 -0.44,0.88 -0.09,0.29 -0.28,0.17 -0.49,-0.12 -0.1,-0.19 -0.45,-0.18 0.13,-0.2 0.12,-0.24 0.1,-0.16 0.06,-0.16 0.5,-0.85 -0.25,0.15 -0.11,0.16 -0.14,0.16 -0.63,0.87 -0.25,0.16 -0.31,-0.22 -0.35,-0.14 -0.16,-0.13 -0.35,-0.74 v -0.49 l 0.16,-0.66 0.21,-0.59 0.27,-0.5 0.12,-0.47 -0.03,-0.42 -0.12,-0.39 -0.19,-0.36 -0.11,-0.4 c -2.21637,-4.26084 -0.36072,-0.64294 -0.86,0.21 l -0.31,0.26 -0.59,0.16 -0.29,0.05 -0.75,0.01 -0.22,-0.04 -0.45,-0.23 -0.31,-0.23 c -1.22484,-1.38785 -0.68386,-0.74536 -1.12,-0.06 l -0.29,0.27 -0.22,0.18 -0.21,0.11 -0.57,0.09 -0.22,0.01 -0.87,-0.08 -0.09,0.04 0.15,0.08 0.49,0.14 0.11,0.08 0.45,0.69 0.54,0.31 1.27,0.39 0.08,0.06 0.04,0.08 0.01,0.14 -0.04,0.2 -0.2,0.1 h -0.35 l -0.49,-0.09 h -0.24 l -0.27,0.05 -0.55,0.17 -0.36,0.31 0.22,0.33 0.27,-0.09 0.45,-0.29 0.31,-0.14 0.47,0.05 0.38,0.34 0.41,0.1 0.96,0.01 0.14,0.05 0.87,0.8 0.65,0.95 0.4,0.43 0.6,0.45 1.24,0.58 0.07,0.12 -0.14,0.14 -0.16,0.1 -0.32,0.09 H 225 l -0.18,-0.04 -0.18,0.02 -0.35,-0.06 -0.12,0.03 -0.09,0.36 -0.08,0.02 -0.26,-0.13 -0.57,-0.02 -0.34,-0.21 -0.1,-0.01 0.02,0.12 -0.02,0.18 -0.06,0.25 -0.14,0.13 -0.22,0.01 -0.14,-0.04 -0.33,-0.35 -0.08,-0.02 v 0.13 l -0.06,0.15 -0.11,0.2 -0.21,0.1 -0.3,0.01 -0.63,0.13 h -0.24 l -0.42,-0.12 h -0.11 l -0.02,0.35 -0.09,0.1 -0.44,0.14 -0.5,-0.03 -0.12,0.07 -0.21,0.24 -0.1,0.08 -0.2,0.1 -0.55,0.07 h -0.35 l -0.21,0.04 -0.29,0.1 -0.26,-0.02 -0.25,-0.12 -0.27,-0.07 -0.52,-0.01 -0.3,-0.09 -1.06,-0.14 -0.42,-0.18 -0.42,-0.08 -0.91,-0.1 -0.4,-0.1 -0.32,-0.02 -0.26,-0.12 -0.33,-0.33 -0.21,-0.14 -0.17,-0.04 -0.19,0.02 -0.41,0.14 -0.18,-0.09 -0.37,-0.58 -0.07,0.11 -0.04,0.33 -0.14,0.16 -0.45,-0.05 -0.21,-0.08 -0.2,-0.24 -0.19,-0.42 -0.12,-0.67 -0.05,-0.94 -0.09,-0.37 -0.13,0.2 -0.09,0.21 -0.05,0.25 -0.08,0.14 -0.13,0.03 -0.1,-0.01 -0.1,-0.07 -0.05,0.03 -0.07,0.39 -0.11,0.36 -0.23,0.26 -0.35,0.15 -0.25,0.05 -0.14,-0.03 -1.13,0.17 -0.24,-0.05 -0.15,0.02 -0.16,0.07 -0.61,0.38 -0.21,0.1 -0.31,0.09 -0.09,-0.01 -0.09,0.07 -0.09,0.15 -0.22,0.19 -0.37,0.23 -1.08,0.56 -0.96,0.56 -0.35,0.16 -0.19,0.03 -0.03,-0.08 -0.16,-0.1 -0.19,0.09 -0.28,0.2 -0.24,0.13 -0.19,0.07 -1.08,0.09 -0.25,-0.02 -0.08,-0.17 -0.18,-0.11 -0.08,-0.56 0.04,-0.16 v -0.41 l -0.1,0.13 -0.03,0.1 -0.06,0.12 -0.03,0.19 -0.42,0.79 -0.25,0.03 -0.26,0.06 -0.53,0.01 -0.72,0.16 -0.23,0.02 0.29,-0.37 0.11,-0.1 -0.03,-0.32 -0.11,0.12 -0.12,0.1 -0.54,0.35 -0.11,0.05 -0.05,-0.08 -0.22,-0.03 -0.11,-0.17 0.06,-0.31 0.05,-0.15 -0.5,0.1 -0.1,-0.1 -0.24,0.23 -0.32,0.13 -0.23,-0.02 -0.19,-0.18 -0.24,0.03 -0.13,-0.37 0.19,-0.32 0.55,-0.18 0.2,-0.1 0.13,-0.22 0.28,-0.2 1.1,-0.41 0.62,-0.16 0.05,-0.08 -0.28,-0.39 -0.19,-0.41 -0.26,-0.31 -0.18,-0.07 0.01,0.4 0.1,0.48 -0.34,0.08 -0.33,0.1 -0.69,0.47 -0.32,0.16 -0.07,-0.57 -0.07,-0.23 -0.19,0.39 0.02,0.55 -0.07,0.11 -0.33,0.35 -0.85,-0.2 -0.63,-0.48 -0.5,-0.3 -0.79,-0.55 -0.27,-0.25 -0.14,0.09 0.17,1.17 v 0.19 l -0.27,0.09 -0.25,-0.02 0.0228,-8.14341 z"
+         id="polyF1S87P17"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+    </g>
+    <g
+       id="gDZA"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S63P1-5"
+         d="m 269.12,343.92 0.07,0.25 0.01,0.23 -0.37,0.21 -0.24,0.11 -0.3,0.59 -0.54,0.39 -0.1,0.12 0.01,0.11 0.35,0.2 0.12,0.17 0.05,0.24 -0.18,0.82 -0.12,0.64 -0.15,0.83 v 0.32 l 0.13,0.38 0.13,0.31 0.03,0.33 -0.07,0.83 0.16,0.48 0.13,0.45 -0.34,0.54 -0.15,0.48 -0.1,0.69 -0.04,0.44 -0.22,0.39 -0.29,0.37 -0.31,0.23 -0.38,0.19 -0.45,0.25 -0.38,0.7 -0.78,0.57 -0.17,0.2 -0.09,0.47 v 0.66 l -36.16,-0.24 -0.23,-0.55 -0.14,-0.64 0.33,-1.09 -0.2,-0.73 v -0.3 l 0.04,-0.35 0.16,-0.59 0.05,-0.85 -0.22,-0.93 0.19,-0.27 0.09,-0.14 v -0.13 l -0.27,-0.33 -0.09,-0.25 0.09,-0.21 0.19,-0.28 0.01,-0.14 -0.44,-0.46 -0.72,-0.76 -0.2,-0.3 -0.06,-0.36 0.76,0.22 0.41,0.03 0.97,-0.25 0.8,-0.43 0.6,-0.19 0.57,-0.52 0.5,-0.31 0.7,-0.3 1.98,-0.6 0.29,0.04 0.59,0.29 0.55,0.02 0.4,-0.26 0.48,-0.69 0.67,-0.37 0.82,-0.35 1.09,-0.3 0.74,-0.31 1.12,-0.21 2.75,0.11 1.42,-0.04 0.96,0.15 1.01,-0.53 0.5,-0.16 2.1,0.15 1.02,-0.37 3.73,0.31 0.45,0.2 0.43,0.28 0.74,0.67 0.37,0.16 0.5,-0.09 1.19,-0.5 1.31,-0.22 0.72,-0.3 0.33,-0.49 0.61,-0.15 0.33,0.41 1.33,0.45 0.83,-0.07 0.36,-0.1 -0.11,-0.58 0.87,0.19 0.66,0.31 0.69,0.58 0.45,0.13 0.84,-0.23 z"
+         class="region DZA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+    </g>
+    <g
+       id="spain"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S67P8"
+         d="m 243.26,333.9 -0.09,0.05 -0.24,-0.09 -0.37,-0.04 v -0.19 l 0.07,-0.13 0.09,-0.12 0.2,0.29 0.34,0.09 z"
+         class="region ESP"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S67P9"
+         d="m 242.82,332.68 -0.16,0.27 -0.55,-0.17 -0.11,-0.13 0.15,-0.31 0.17,-0.02 0.03,-0.23 0.19,-0.21 0.82,-0.09 0.16,0.18 0.02,0.23 -0.53,0.44 z"
+         class="region ESP"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S67P10"
+         d="m 249.45,329.31 0.33,0.19 0.38,-0.1 0.2,0.06 0.19,0.09 0.02,0.3 -0.2,0.32 -0.27,0.31 -0.23,0.35 -0.22,0.4 -0.35,0.22 -0.31,0.12 -0.61,-0.38 -0.36,-0.12 -0.1,-0.13 -0.05,-0.47 -0.15,-0.17 -0.24,-0.09 -0.23,0.1 -0.3,0.21 -0.13,-0.26 -0.23,-0.07 -0.07,-0.16 0.02,-0.19 1.61,-0.97 0.46,-0.21 0.96,-0.19 0.13,0.06 -0.13,0.16 v 0.07 l 0.11,0.1 -0.04,0.13 -0.13,0.11 z"
+         class="region ESP"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S67P11"
+         d="m 253.67,329.45 -0.07,0.05 -1.09,-0.64 -0.36,-0.09 -0.09,-0.09 0.04,-0.28 0.03,-0.12 0.76,0.01 0.59,0.25 0.29,0.57 0.02,0.09 z"
+         class="region ESP"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S67P12"
+         d="m 214.47,304.11 0.3,0.26 0.32,0.02 0.3,0.29 0.35,0.58 0.62,0.35 0.57,-0.01 0.94,0.19 0.46,0.18 0.86,0.08 0.47,0.15 0.83,-0.05 0.54,0.43 1.15,0.39 0.66,0.4 1.88,0.82 0.7,0.15 1.05,-0.02 0.45,-0.09 0.37,0.18 0.61,-0.08 0.27,0.09 0.31,0.35 1.19,0.61 0.39,-0.25 0.26,-0.03 0.87,0.37 0.86,0.56 0.47,0.11 0.72,0.01 0.59,-0.16 0.13,-0.01 -0.02,0.16 0.1,0.25 0.12,0.1 0.28,0.17 0.22,0.05 0.3,0.11 0.19,0.16 -0.02,0.2 -0.08,0.22 -0.16,0.19 -0.1,0.14 0.06,0.11 0.1,0.09 0.12,0.03 0.08,-0.01 0.08,-0.11 0.14,-0.14 h 0.06 l -0.01,0.08 0.04,0.12 0.35,0.24 0.78,0.47 0.33,0.06 0.26,0.08 0.05,0.15 0.47,0.6 0.12,0.01 0.24,0.05 h 0.29 l 0.22,-0.07 0.13,0.04 0.14,0.12 0.16,0.11 0.21,0.21 0.17,0.24 0.14,0.09 0.85,-0.02 0.18,0.15 0.2,0.03 0.22,-0.01 0.48,0.14 0.4,0.04 0.04,-0.05 0.09,-0.47 0.09,-0.16 0.1,-0.03 0.23,0.07 0.82,0.39 0.33,0.22 0.32,0.18 0.29,0.05 0.19,0.12 0.23,0.48 -0.08,0.22 0.02,0.08 0.01,0.16 -0.02,0.17 0.06,0.12 0.13,0.03 0.17,-0.01 0.19,-0.04 0.34,-0.16 0.1,-0.02 0.51,0.28 0.23,0.18 0.06,0.17 0.11,0.17 0.16,0.04 0.25,-0.12 0.37,-0.13 0.6,0.22 0.66,0.28 0.29,0.06 0.02,-0.1 0.07,-0.14 0.11,-0.06 0.17,-0.01 0.24,-0.05 0.28,-0.1 0.28,-0.02 0.28,0.12 0.35,0.11 0.2,0.02 0.08,0.31 0.16,0.13 0.04,0.27 -0.32,0.1 h -0.19 l -0.09,0.44 0.08,0.13 0.16,0.14 0.04,0.14 -0.03,0.66 -0.39,0.35 -0.54,0.39 -2.6,1.16 -0.65,0.61 -0.24,0.14 -1.89,0.21 -1.33,0.3 -0.64,0.08 -0.86,0.7 -0.4,0.28 0.28,0.12 0.3,0.43 -0.14,0.16 -0.52,0.19 -0.23,0.05 -0.11,-0.06 -0.12,0.02 -1,1.27 -0.85,0.89 -0.47,0.37 -0.51,0.59 -1.11,1.52 -0.07,0.48 0.25,1.72 0.21,0.47 0.32,0.42 0.66,0.4 0.14,0.33 -0.28,0.26 -0.75,0.42 -1.3,0.51 -0.58,0.48 -0.18,0.51 -0.38,0.18 -0.23,0.72 -0.28,0.46 -0.06,0.16 -0.27,0.33 -0.07,0.27 0.33,0.43 -0.2,0.13 -0.2,0.04 -0.44,-0.02 -1.46,-0.19 -1.27,0.61 -0.68,0.61 -0.71,1.24 -0.75,0.66 -0.3,0.1 -0.4,-0.42 -0.54,-0.15 -0.55,0.01 -0.32,0.22 -0.46,0.07 -0.41,-0.21 -0.92,-0.24 -0.41,-0.07 -0.67,0.1 -0.53,-0.25 -0.92,-0.26 -2.03,-0.23 -0.27,0.03 -0.3,0.27 -0.73,0.42 -0.98,-0.18 -0.94,0.16 -0.26,0.18 -0.47,0.55 -0.2,0.43 -0.07,-0.01 -0.08,-0.13 -0.14,0.01 -0.13,0.33 -0.36,0.08 h -0.29 l -0.63,-0.44 -0.49,-0.55 -0.29,-0.1 -0.37,-0.77 -0.13,-0.47 -0.06,-0.49 0.06,-0.17 -0.01,-0.15 -0.4,-0.29 -0.02,-0.44 0.41,-0.47 0.29,-0.17 0.17,-0.03 -0.39,-0.07 -0.34,0.29 -0.25,-0.65 -1.23,-1.44 0.14,-0.22 0.01,-0.14 -0.29,0.23 -0.18,0.03 -0.72,-0.22 -0.87,-0.08 v -1.19 l -0.02,-0.46 0.03,-0.29 0.35,-0.59 0.28,-0.21 0.42,-0.47 0.48,-0.36 h 0.43 l 0.19,-0.03 0.22,-0.31 0.14,-0.28 -0.06,-0.05 -0.48,-0.05 -0.6,-1.48 0.07,-0.19 0.16,-0.28 0.15,-0.36 0.08,-0.29 0.27,-0.2 0.39,-0.18 0.35,-0.29 0.21,-0.33 0.1,-0.32 -0.12,-0.27 -0.43,-0.24 -0.28,-1.05 0.01,-0.61 -0.08,-0.08 -0.24,-0.34 -0.18,-0.57 -0.02,-0.08 0.3,-0.02 1.19,0.29 0.27,-0.05 0.04,-0.03 0.3,-0.33 0.35,-0.58 0.13,-0.38 -0.04,-0.18 -0.31,-0.49 0.01,-0.12 0.1,-0.17 0.27,-0.14 0.36,-0.15 0.21,-0.16 -0.01,-0.16 -0.06,-0.18 0.02,-0.15 0.09,-0.17 0.15,-0.62 0.07,-0.16 0.05,-0.58 0.02,-0.48 -0.12,-0.67 0.07,-0.12 0.14,-0.08 0.41,-0.12 0.4,-0.42 0.51,-0.31 0.63,-0.2 0.46,-0.28 0.21,-0.24 0.13,-0.05 -0.01,-0.14 -0.04,-0.21 -0.18,-0.24 -0.27,-0.17 -0.32,-0.07 -0.19,-0.09 -0.02,-0.16 0.1,-0.39 0.06,-0.39 -0.02,-0.2 -0.12,-0.17 -0.3,-0.03 -0.23,-0.17 -0.19,-0.08 -0.12,0.06 -0.56,-0.16 -0.22,-0.12 -0.15,-0.12 -0.11,0.02 -0.08,0.06 -0.03,0.12 -0.07,0.15 -0.23,0.09 -0.49,0.03 -0.37,-0.11 -0.32,-0.19 -0.09,-0.1 -0.15,-0.11 -0.71,-0.09 -0.07,-0.08 -0.27,0.08 -0.39,0.08 -0.2,-0.04 -0.06,-0.05 -0.01,-0.09 -0.09,-0.31 0.07,-0.13 0.38,-0.35 -0.01,-0.11 -0.09,-0.16 -0.06,-0.23 v -0.1 l -0.18,-0.07 -0.21,0.05 -0.78,0.02 -0.19,0.03 -0.36,0.12 -0.39,0.22 h -0.26 l -0.07,-0.12 0.14,-0.73 0.5,-0.38 0.34,-0.22 -0.12,-0.09 -0.29,-0.08 0.07,-0.22 0.16,-0.07 0.19,-0.21 -0.13,-0.15 -0.08,-0.19 0.11,-0.43 0.07,-0.16 v -0.2 l -0.64,0.09 -0.14,-0.07 0.06,-0.32 0.44,-0.39 0.07,-0.14 -0.36,-0.18 -0.23,-0.31 -0.12,-0.26 -0.11,-0.35 0.06,-0.27 0.34,-0.59 0.32,-0.11 0.26,-0.05 0.6,-0.3 0.67,0.27 0.44,0.02 0.44,-0.12 h 0.23 l 0.39,-0.1 0.05,-0.27 -0.07,-0.23 0.15,-0.16 0.44,-0.12 0.51,-0.19 0.51,0.07 z"
+         class="region ESP"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="estonia"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S68P1-5"
+         d="m 306.55,238.25 0.2,0.09 0.15,-0.07 0.15,-0.1 0.36,0.01 0.92,0.43 0.1,0.14 -0.47,0.16 -0.07,0.19 -0.1,0.14 -0.12,0.07 -0.19,0.28 -0.27,0.29 -0.04,0.16 -0.58,0.07 -0.3,0.14 -0.2,0.3 -0.02,0.53 -0.11,0.43 -0.17,0.18 -0.19,0.05 -0.08,-0.14 v -0.15 l 0.31,-0.64 0.06,-0.19 -0.22,-0.05 -0.21,-0.17 -0.42,-0.17 -0.1,-0.17 0.09,-0.03 0.07,-0.07 0.08,-0.17 0.01,-0.18 -0.38,-0.48 0.13,-0.1 0.2,-0.01 0.22,0.12 0.18,-0.21 0.09,-0.04 0.16,0.04 0.09,-0.37 0.34,-0.17 0.16,-0.14 z"
+         class="region EST"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S68P2"
+         d="m 308.39,238.28 -0.19,0.08 -0.55,-0.25 0.07,-0.24 0.12,-0.11 0.43,0.06 0.13,0.34 z"
+         class="region EST"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S68P3"
+         d="m 307.12,237.16 -0.16,0.27 -0.13,-0.07 -0.08,-0.1 -0.17,0.56 -0.27,0.14 -0.19,-0.07 -0.02,-0.2 -0.26,-0.49 -0.28,-0.11 -0.35,0.04 -0.29,-0.17 0.95,-0.3 0.06,-0.26 0.15,-0.29 0.15,-0.05 0.14,0.04 0.06,0.19 0.04,0.07 0.47,0.04 0.24,0.3 0.14,0.39 z"
+         class="region EST"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S68P4"
+         d="m 312.49,232.21 h 0.26 l 0.41,-0.12 1.65,0.03 0.39,-0.09 0.62,0.26 0.31,0.03 0.85,-0.19 1.34,-0.15 0.19,-0.31 v -0.08 l 0.17,0.12 0.22,0.19 0.07,0.12 -0.03,0.09 -0.14,0.1 -0.01,0.08 -0.04,0.14 -0.18,0.07 -0.07,0.11 -0.01,0.42 -0.04,0.7 -0.12,0.37 -0.38,-0.03 -0.52,0.18 -0.4,0.3 -0.23,0.39 0.07,0.37 0.64,0.62 0.42,0.86 0.27,0.19 0.36,0.4 0.22,0.37 0.1,0.14 0.51,0.71 0.04,-0.02 0.01,0.01 0.16,0.35 0.16,0.1 0.13,0.08 0.04,0.05 0.02,0.07 -0.04,0.08 -0.47,0.32 -0.02,0.18 -0.01,0.19 -0.16,0.33 v 0.26 l 0.03,0.3 0.02,0.11 -0.06,0.02 -0.36,0.03 -0.43,-0.1 -0.2,-0.11 -0.16,0.04 -0.18,0.14 -0.64,0.43 -0.19,-0.02 -0.47,-0.18 -0.27,-0.24 -0.59,-0.47 -0.07,-0.13 -0.09,-0.09 -0.52,-0.04 -0.22,-0.17 h -0.16 l -0.24,-0.06 -0.67,-0.33 -0.15,-0.02 -0.02,0.09 0.03,0.1 -0.02,0.07 -0.07,0.01 -0.17,-0.14 -0.19,-0.11 -0.43,0.37 -0.16,0.11 -0.16,0.05 -0.7,0.51 -0.2,0.25 -0.1,-0.01 -0.02,-0.18 0.14,-0.98 -0.1,-0.74 0.1,-0.12 0.01,-0.11 -0.1,-0.22 -0.36,-0.09 -0.13,0.05 -0.07,0.27 -0.09,0.21 -0.28,0.16 -0.29,-0.14 -0.65,-0.14 -0.22,-0.31 -0.1,-0.33 -0.38,-0.28 -0.21,-0.36 v -0.28 l 0.25,-0.23 0.05,-0.17 -0.35,0.09 -0.08,-0.02 -0.04,-0.14 -0.25,-0.44 0.1,-0.21 0.02,-0.19 -0.14,-0.14 -0.01,-0.18 0.06,-0.19 -0.14,-0.4 0.31,-0.28 0.31,-0.22 0.7,-0.21 -0.15,-0.36 0.28,-0.07 0.4,-0.55 0.49,-0.01 0.63,-0.45 1.33,-0.26 0.14,-0.22 -0.07,-0.17 z"
+         class="region EST"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="greece"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S85P1-5"
+         d="m 328.17,345.8 0.27,-0.01 0.35,-0.07 0.08,-0.04 0.18,-0.31 0.28,-0.06 0.16,0.24 -0.27,0.17 -0.04,0.08 0.06,0.05 0.22,0.07 0.29,-0.1 0.04,0.21 0.09,0.15 0.16,0.08 0.16,-0.01 0.34,-0.1 0.33,-0.13 0.33,-0.2 0.35,-0.14 1.08,-0.15 0.42,0.21 0.74,-0.11 0.7,0.01 0.34,-0.18 0.59,-0.22 0.11,0.08 0.03,0.67 0.06,0.18 0.19,0.05 0.17,-0.08 0.18,-0.26 0.48,-0.27 0.53,-0.12 0.37,-0.52 0.13,-0.06 -0.05,0.23 0.02,0.51 -0.05,0.31 v 0.24 l -0.28,0.19 -0.45,0.11 -0.83,0.13 -0.82,0.26 -1.5,0.54 -1.53,0.42 -0.22,-0.03 -0.05,-0.29 -0.06,-0.19 -0.12,-0.12 -0.5,-0.03 -0.48,-0.12 -1.83,0.06 -0.44,-0.03 -0.68,0.19 -0.25,0.03 -0.19,-0.07 -0.14,-0.15 -0.13,-0.54 0.01,-0.56 0.13,-0.17 0.09,0.15 0.19,0.05 0.14,-0.2 -0.04,-0.25 0.05,-0.24 0.14,0.07 0.14,0.34 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P2"
+         d="m 340.77,343.5 -0.1,0.29 -0.18,-0.18 0.02,-0.26 -0.24,-0.36 0.21,-0.65 -0.04,-0.29 0.22,-0.2 0.02,0.5 -0.11,0.43 0.25,0.27 0.15,0.34 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P3"
+         d="m 324.74,343.35 -0.02,0.21 -0.41,-0.07 -0.13,-0.19 -0.08,-0.45 0.07,-0.24 0.06,-0.08 0.21,0.23 0.42,0.3 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P4"
+         d="m 342.87,340.81 -0.25,0.16 -0.09,0.01 -0.15,-0.18 0.06,-0.55 -0.2,-0.29 -0.04,-0.14 0.18,-0.24 0.1,-0.32 0.31,-0.4 0.87,-0.6 0.22,-0.09 0.05,0.29 -0.18,0.8 -0.21,0.44 0.13,0.27 -0.44,0.19 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P5"
+         d="m 333.72,340.68 -0.13,0.28 -0.26,-0.04 0.09,-0.11 0.03,-0.13 -0.02,-0.17 -0.08,-0.09 0.04,-0.05 0.25,0.13 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P6"
+         d="m 337.21,339.02 -0.27,0.17 -0.15,0.27 -0.25,-0.11 -0.04,-0.22 0.26,0.01 0.15,-0.16 -0.07,-0.13 0.2,0.03 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P7"
+         d="m 342.41,337.96 -0.07,0.09 -0.22,-0.16 -0.03,-0.11 0.16,-0.17 0.09,-0.05 0.05,0.08 0.03,0.18 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P8"
+         d="m 329.93,339.7 0.04,0.27 -0.01,0.1 -0.74,0.28 0.02,-0.33 0.03,-0.1 0.28,0.09 0.08,-0.09 0.03,-0.09 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P9"
+         d="m 333.14,339.48 -0.05,0.08 -0.33,-0.23 -0.13,-0.15 0.11,-0.16 0.46,0.24 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P10"
+         d="m 338.91,337.97 -0.12,0.03 0.1,-0.25 0.34,-0.4 0.52,-0.39 0.18,-0.08 0.34,0.09 -0.53,0.41 -0.13,0.18 -0.43,0.13 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P11"
+         d="m 334.83,338.57 -0.32,0.11 -0.11,-0.01 0.18,-0.13 0.13,-0.11 0.05,-0.11 0.3,-0.25 0.18,-0.28 0.26,0.1 -0.28,0.17 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P12"
+         d="m 330.5,338.84 -0.06,0.03 -0.13,-0.17 -0.05,-0.18 0.03,-0.11 0.12,-0.04 0.23,0.31 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P13"
+         d="m 338.98,336.85 -0.36,0.15 v -0.38 l -0.23,-0.25 0.32,0.1 0.21,0.15 0.1,0.02 v 0.12 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P14"
+         d="m 332.47,337.75 -0.24,0.41 -0.25,0.02 -0.13,-0.15 0.1,-0.36 0.3,-0.25 0.15,0.01 0.03,0.25 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P15"
+         d="m 333.53,338.01 -0.3,0.24 -0.27,-0.2 -0.19,-0.37 0.51,-0.71 0.16,0.03 0.11,0.13 0.07,0.52 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P16"
+         d="m 329.63,338.05 -0.13,0.1 -0.24,-0.06 0.02,-0.26 0.14,-0.14 0.18,0.05 0.04,0.11 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P17"
+         d="m 329.15,337.11 -0.19,0.18 0.02,-0.34 -0.13,-0.14 0.07,-0.16 0.12,-0.14 0.08,0.1 0.15,0.17 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P18"
+         d="m 330.92,336.05 0.05,0.48 -0.1,0.02 -0.06,-0.06 -0.04,-0.19 v -0.29 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P19"
+         d="m 332.66,336.05 -0.34,0.1 -0.04,-0.36 0.12,-0.11 0.45,0.08 v 0.12 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P20"
+         d="m 334.88,335.05 -0.17,0.06 0.03,-0.2 0.27,-0.38 0.46,-0.12 0.38,-0.25 0.1,-0.03 -0.16,0.3 -0.29,0.31 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P21"
+         d="m 331.99,335.33 -0.09,0.33 h -0.24 l -0.43,-0.24 -0.16,-0.12 -0.09,-0.13 0.15,-0.05 0.22,0.11 0.5,-0.02 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P22"
+         d="m 328.69,336.09 -0.21,0.28 -0.1,-0.33 0.11,-0.38 0.21,-0.07 0.1,0.14 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P23"
+         d="m 337.56,333.12 0.48,0.05 0.12,-0.05 0.22,0.01 0.11,0.26 -0.28,0.11 -0.44,0.36 -0.21,-0.01 -0.29,-0.16 -0.4,0.06 -0.12,-0.03 0.16,-0.31 0.36,-0.22 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P24"
+         d="m 315.67,337.19 0.45,0.4 -0.33,-0.07 -0.3,0.36 -0.47,-0.3 -0.3,-0.34 -0.07,-0.14 0.22,-0.38 0.3,0.32 0.3,0.02 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P25"
+         d="m 330.9,334.79 -0.06,0.33 -0.34,-0.3 -0.36,-0.18 -0.15,-0.19 -0.21,-0.09 -0.1,-0.28 0.22,-0.17 0.09,-0.03 0.3,0.31 0.37,-0.04 0.01,0.22 0.16,0.26 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P26"
+         d="m 325.48,335.04 -0.13,0.14 -0.17,0.02 -0.12,-0.02 -0.07,-0.08 0.07,-0.05 0.06,-0.2 0.07,-0.07 0.12,0.01 0.08,0.06 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P27"
+         d="m 314.34,334.66 0.11,0.53 0.27,0.06 0.41,0.43 -0.01,0.26 -0.06,0.09 -0.6,-0.15 -0.13,0.13 -0.17,-0.02 -0.14,-0.26 0.01,-0.09 -0.12,-0.15 -0.08,-0.06 -0.21,0.24 -0.14,0.06 -0.02,-0.19 0.15,-0.56 0.09,-0.11 0.19,0.16 0.14,-0.09 0.07,-0.3 -0.02,-0.29 0.03,-0.09 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P28"
+         d="m 314.91,334.83 -0.17,0.08 -0.29,-0.41 -0.12,-0.3 0.1,-0.03 0.1,0.02 0.11,0.1 0.01,0.12 0.05,0.12 0.12,0.14 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P29"
+         d="m 334.58,331.84 -0.31,0.34 -0.45,-0.29 -0.08,-0.11 0.25,-0.21 0.1,-0.27 -0.16,-0.26 -0.47,-0.34 -0.07,-0.3 0.58,-0.25 0.4,0.18 0.19,-0.02 -0.03,0.27 0.05,0.07 0.16,0.75 -0.15,0.15 0.01,0.21 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P30"
+         d="m 314.5,333.57 -0.14,0.06 -0.13,-0.01 -0.11,0.04 -0.09,0.1 -0.03,-0.37 0.07,-0.47 0.13,-0.29 0.2,-0.16 0.12,0.2 0.07,0.75 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P31"
+         d="m 328.97,330.19 -0.37,0.19 h -0.1 l 0.06,-0.16 v -0.06 l -0.42,-0.19 -0.01,-0.34 0.03,-0.1 0.31,0.12 0.11,0.28 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P32"
+         d="m 324.29,330.36 0.28,0.46 0.22,0.14 0.43,0.12 0.2,-0.01 0.74,0.24 0.82,-0.08 0.12,0.08 0.14,0.26 0.2,0.19 0.06,0.16 -0.05,0.21 0.2,0.55 0.29,0.51 0.35,0.21 h 0.39 l 0.37,-0.08 0.11,0.09 0.03,0.49 -0.12,0.21 -0.12,0.07 -0.12,-0.03 -0.11,-0.09 -0.12,-0.03 -0.21,0.03 -0.18,-0.16 -0.43,-0.19 -0.1,-0.15 -0.04,-0.24 -0.2,-0.15 -0.2,-0.31 -0.16,-0.06 -0.1,-0.16 -0.02,-0.07 -0.57,0.05 -0.47,0.09 -0.42,-0.12 -0.2,-0.49 -0.25,-0.09 -0.2,-0.11 -0.17,-0.18 -0.43,-0.3 -0.45,-0.23 -0.42,-0.13 -0.44,-0.06 -0.32,0.21 h -0.2 l -0.06,-0.1 0.4,-0.28 0.52,-0.51 0.39,-0.2 0.2,-0.05 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P33"
+         d="m 325.51,329.39 -0.14,0.19 -0.26,-0.02 -0.34,-0.48 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P34"
+         d="m 325.87,329.12 -0.16,0.08 0.11,-0.4 0.27,-0.24 -0.06,0.33 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P35"
+         d="m 334.81,326.48 -0.02,0.29 0.58,0.34 0.22,0.25 0.11,0.27 -0.02,0.09 -0.22,-0.11 -0.16,-0.02 0.09,0.19 0.19,0.14 -0.27,0.16 -0.28,0.05 -0.87,-0.05 -0.23,-0.22 0.42,-0.49 0.08,-0.17 -0.35,0.09 -0.29,0.53 -0.63,-0.07 -0.21,-0.14 -0.06,-0.09 0.16,-0.45 0.42,-0.08 0.21,-0.14 0.25,-0.19 -0.03,-0.19 0.64,-0.19 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P36"
+         d="m 311.84,330.04 0.1,0.25 -0.47,-0.1 -0.36,-0.2 -0.33,-0.54 -0.66,-0.58 -0.02,-0.19 0.2,-0.18 0.47,-0.16 0.2,0.08 0.14,0.1 0.05,0.12 -0.24,0.29 -0.05,0.12 0.24,0.2 v 0.09 l 0.14,0.43 0.12,0.15 0.28,0.1 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P37"
+         d="m 330.81,324.21 -0.11,0.18 -0.05,0.29 0.01,0.4 -0.2,0.05 -0.14,-0.05 -0.07,-0.14 -0.04,-0.18 -0.09,0.02 -0.04,0.22 -0.05,0.1 -0.2,0.06 -0.25,-0.07 -0.04,-0.27 -0.09,-0.3 v -0.11 l 0.62,-0.16 0.22,0.19 0.2,-0.17 0.07,-0.16 0.25,-0.15 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P38"
+         d="m 331.33,321.97 -0.38,0.21 -0.5,-0.29 0.4,-0.25 0.21,0.07 0.17,0.1 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P39"
+         d="m 327.97,321.75 -0.43,0.26 -0.51,-0.22 -0.03,-0.19 0.18,-0.43 0.12,-0.14 0.34,-0.03 0.23,0.22 0.07,0.11 -0.03,0.23 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S85P40"
+         d="m 333.53,317.08 -0.62,0.64 0.06,0.45 0.05,0.21 0.04,0.15 0.1,0.11 0.04,0.18 -0.05,0.22 -0.25,0.4 -0.17,0.31 -0.18,0.41 -0.13,0.07 -0.1,0.09 -0.13,-0.18 -0.61,-0.23 -1.29,0.06 -0.64,-0.13 -0.26,0.1 -0.56,-0.18 -0.33,0.2 -0.66,0.66 -0.41,0.02 -0.48,-0.22 -0.29,-0.01 -0.3,0.23 -0.43,0.69 -0.49,0.39 -0.5,-0.02 -0.65,0.12 -0.02,0.34 0.16,0.21 0.42,0.32 -0.12,0.32 0.17,0.27 0.24,0.02 0.35,-0.08 0.7,0.26 0.35,0.34 0.25,0.4 -0.44,-0.23 -0.31,-0.26 -0.39,-0.04 -0.55,-0.16 -0.32,0.02 -0.31,0.24 V 324 l 0.43,0.31 0.37,0.16 0.2,0.16 0.19,0.4 -0.05,0.15 -0.1,0.16 -0.44,-0.19 -0.75,-0.83 -0.88,-0.03 -0.12,0.22 0.24,0.47 0.15,0.17 0.83,0.4 -0.05,0.12 -0.1,0.07 -0.87,-0.16 -0.31,-0.42 -0.15,-0.58 -0.82,-0.27 -0.79,-0.32 -0.22,-0.4 0.13,-0.18 0.06,-0.33 -0.39,0.13 -0.22,0.23 -0.37,0.26 0.02,0.32 0.11,0.28 -0.08,0.44 -0.02,0.75 0.13,0.37 1.03,0.95 0.42,0.75 0.25,0.27 0.5,0.25 0.56,0.54 0.25,0.29 0.22,0.5 -0.35,0.4 -0.23,0.05 -0.15,-0.12 0.13,-0.39 -0.06,-0.22 -0.66,-0.23 -0.24,0.16 -0.27,0.27 0.23,0.38 0.23,0.24 0.15,0.36 0.36,-0.1 -0.44,0.51 -0.43,0.29 -0.46,0.09 -0.29,0.09 -0.09,0.12 0.25,0.04 0.2,-0.03 0.35,0.18 0.93,0.11 0.48,0.27 0.43,-0.04 0.51,0.55 0.76,0.04 0.51,0.55 0.58,0.02 0.51,0.15 0.18,0.2 0.13,0.38 0.16,0.85 0.19,0.61 0.04,0.2 0.02,0.3 -0.11,0.18 -0.18,0.03 -0.42,-0.4 -0.6,-0.39 -0.65,-0.48 -0.17,-0.07 -0.13,0.01 -0.28,0.25 -0.81,0.3 -0.36,0.28 -0.14,0.08 -0.03,0.12 0.2,0.08 0.26,0.23 0.05,0.36 0.25,0.41 0.26,0.07 0.31,-0.06 0.2,0.05 0.07,0.17 0.21,0.17 0.14,0.13 0.01,0.11 -0.84,0.45 -0.16,0.16 -0.15,0.1 -0.25,-0.1 -0.06,-0.35 -0.33,-0.14 -0.3,-0.12 -0.34,-0.01 -0.31,-0.19 -0.16,0.22 0.24,0.67 0.38,0.41 0.71,1.18 0.35,0.7 0.1,0.35 -0.04,0.62 0.32,0.4 0.25,0.43 -0.21,0.02 -0.19,-0.13 -0.32,-0.14 -0.66,-0.64 -0.26,-0.42 -0.24,0.01 -0.4,0.13 -0.33,1.05 0.08,0.55 -0.25,-0.09 -0.22,-0.14 -0.06,-0.61 -0.05,-0.26 -0.65,-0.74 -0.26,-0.05 -0.16,-0.27 -0.23,-0.26 -0.25,0.1 -0.2,0.15 v 0.46 l 0.03,0.41 -0.12,0.33 -0.66,-0.49 -0.7,-0.91 -0.08,-0.55 0.36,-0.57 -0.09,-0.35 -0.49,-0.65 -0.64,-0.37 -0.34,-0.09 -0.21,-0.46 -0.34,-0.21 -0.26,-0.08 -0.07,-0.16 0.06,-0.14 0.55,-0.59 0.26,-0.84 0.17,-0.06 0.38,0.13 0.4,-0.11 0.28,-0.51 0.25,-0.3 0.48,-0.04 1.15,0.44 1.2,0.16 0.61,0.21 0.37,0.25 0.18,0.03 h 0.28 l -0.04,-0.22 -0.12,-0.19 0.21,-0.15 0.62,-0.1 0.1,-0.13 0.09,-0.19 -0.16,-0.17 -0.21,-0.06 -0.22,0.01 -0.16,-0.04 -0.22,0.11 -0.38,-0.09 -0.21,-0.1 -0.12,-0.11 -0.67,-0.15 -0.65,-0.33 -0.1,0.27 -0.22,0.17 -0.34,0.07 -1,-0.12 -0.57,0.3 -0.32,0.11 -0.24,0.04 -0.29,0.14 -0.35,0.11 -0.35,-0.35 -0.17,-0.29 -0.1,-0.05 0.04,0.29 -0.07,0.25 -0.44,0.2 -0.27,-0.14 -0.27,-0.53 -0.33,-0.66 -0.5,-0.5 -0.37,-0.1 -0.07,-0.31 v -0.25 l 0.42,-0.12 0.7,0.16 0.13,-0.07 0.13,-0.14 -0.06,-0.26 -0.12,-0.22 -0.18,0.01 -0.13,0.05 -0.41,0.01 -0.51,0.2 -0.26,-0.09 -0.1,-0.14 -0.48,-0.31 -0.43,-0.45 -0.65,-0.25 -0.52,-0.97 -0.38,-0.4 -0.39,-0.27 0.07,-0.01 0.14,0.03 0.28,0.14 h 0.28 l 0.14,-0.13 0.08,-0.12 0.03,-0.18 v -0.21 l 0.04,-0.07 0.21,-0.01 0.06,-0.06 -0.02,-0.18 -0.16,-0.21 -0.15,-0.27 -0.02,-0.13 0.1,-0.07 0.15,-0.14 0.07,-0.16 0.16,-0.1 0.26,-0.05 0.28,-0.11 0.16,-0.19 0.01,-0.16 0.06,-0.46 0.05,-0.23 0.1,-0.21 0.04,-0.28 0.1,-0.26 0.26,-0.15 0.23,-0.16 0.14,-0.35 0.07,-0.29 -0.02,-0.17 -0.18,-0.25 -0.15,-0.25 -0.01,-0.36 0.48,-0.1 0.16,-0.06 0.63,-0.11 0.26,-0.23 0.2,-0.01 0.44,0.1 0.16,-0.16 0.51,-0.33 0.44,-0.82 0.21,-0.15 0.51,-0.12 0.15,-0.11 0.19,-0.02 0.59,0.06 0.34,-0.03 0.37,-0.17 0.4,-0.25 0.02,-0.65 0.09,-0.1 0.26,-0.07 0.2,-0.03 0.39,-0.02 0.46,-0.06 0.26,-0.35 0.46,-0.1 0.21,-0.08 0.36,-0.01 0.35,-0.07 0.43,-0.2 0.38,-0.28 0.33,-0.04 0.13,-0.06 0.06,-0.06 0.04,-0.28 0.61,-0.13 0.21,-0.02 0.34,-0.05 0.33,-0.22 0.11,-0.01 0.24,0.36 0.11,0.1 0.21,0.07 0.48,0.21 0.06,-0.09 0.16,-0.14 0.54,0.04 0.53,0.13 0.46,0.25 0.44,-0.19 0.48,-0.27 0.32,-0.12 0.35,-0.1 0.2,-0.11 0.5,-0.02 0.46,-0.29 0.21,-0.21 0.03,-0.25 -0.12,-0.39 -0.18,-0.38 -0.15,-0.12 -0.06,-0.14 0.04,-0.16 0.05,-0.12 0.31,-0.15 0.44,0.03 0.33,0.03 0.2,0.11 0.14,0.12 0.2,0.08 h 0.13 l 0.17,0.39 0.15,0.5 -0.03,0.24 z"
+         class="region GRC"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="croatia"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S94P1-7"
+         d="m 301.47,315.37 0.51,0.28 -1.44,-0.29 0.16,-0.06 0.15,-0.02 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P2"
+         d="m 298.05,314.59 0.65,0.08 0.47,-0.1 0.43,0.04 0.28,0.13 0.07,0.07 -0.34,0.04 -0.4,-0.03 -0.43,0.19 -0.4,-0.04 -0.15,-0.09 -0.12,-0.12 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P3"
+         d="m 300.02,314.28 1.83,0.66 -0.22,-0.2 0.25,-0.11 0.22,0.04 0.16,0.26 0.29,0.15 0.46,0.27 0.3,0.21 0.67,0.36 0.16,0.05 0.32,0.09 0.03,0.17 0.15,0.19 0.16,0.21 -0.69,-0.38 -0.65,-0.44 -1.24,-0.65 -0.85,-0.11 -1.19,-0.51 -0.76,-0.15 0.27,-0.08 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P4"
+         d="m 299.89,313.82 -0.24,0.07 -1.55,0.1 -0.46,-0.06 -0.52,-0.22 -0.11,-0.07 0.5,-0.11 0.48,0.03 0.15,0.18 1.28,0.03 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P5"
+         d="m 298.42,313.26 -0.55,0.06 -0.48,-0.05 -0.25,-0.13 0.01,-0.12 0.06,-0.22 0.53,-0.02 0.82,0.08 0.21,0.16 -0.06,0.08 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P6"
+         d="m 293.3,310.29 0.25,0.34 -0.22,-0.06 -0.24,-0.2 -0.15,-0.23 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P7"
+         d="m 292.79,309.9 0.07,0.17 -0.45,-0.29 -0.17,-0.2 -0.04,-0.1 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P8"
+         d="m 292.69,310.58 0.05,0.06 v 0.05 l -0.18,-0.05 -0.05,0.02 -0.9,-0.99 -0.1,-0.19 0.31,0.22 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P9"
+         d="m 292.57,308.61 -0.08,0.13 -0.23,-0.22 -0.22,-0.15 -0.15,-0.19 -0.3,-0.22 -0.11,-0.28 -0.45,-0.55 -0.08,-0.15 0.23,0.22 0.18,0.14 0.15,0.02 0.39,0.35 0.39,0.44 0.45,0.38 -0.08,0.02 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P10"
+         d="m 291.24,306.67 0.1,0.21 -0.33,-0.17 -0.29,-0.06 -0.07,-0.14 0.04,-0.12 0.05,-0.12 0.22,0.01 0.04,0.11 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P11"
+         d="m 290.1,307.21 -0.02,0.19 -0.22,-0.23 -0.12,-0.41 -0.29,-0.66 -0.05,-0.19 0.13,-0.2 -0.02,-0.19 -0.21,-0.58 0.15,-0.11 0.09,-0.02 0.06,0.42 0.09,0.23 0.27,0.28 -0.03,0.48 0.08,0.68 0.06,0.15 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P12"
+         d="m 291.12,305.64 -0.42,0.12 -0.2,-0.17 -0.06,-0.15 -0.35,-0.02 -0.22,-0.2 -0.04,-0.09 0.28,-0.25 0.14,-0.38 0.21,0.21 0.26,0.41 0.13,0.11 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S94P13"
+         d="m 297.13,298.31 0.43,0.33 0.26,0.39 0.34,0.29 0.4,0.19 0.33,0.28 0.26,0.36 0.34,0.18 0.41,0.01 0.27,0.11 0.12,0.2 0.24,0.18 0.35,0.14 0.53,0.04 1,-0.08 h 0.09 l 0.23,0.03 0.26,-0.1 0.3,-0.17 0.1,-0.09 0.28,-0.49 0.19,0.02 0.36,-0.1 0.22,-0.12 h 0.01 v 0.11 0.21 l -0.17,0.16 0.22,0.3 0.23,0.51 -0.07,0.27 0.14,0.19 0.35,0.11 0.04,0.05 -0.1,0.08 -0.06,0.18 0.02,0.32 0.33,0.26 0.63,0.21 0.2,0.02 0.08,0.1 0.11,0.06 0.07,0.08 0.01,0.11 -0.03,0.08 -0.28,0.06 -0.33,0.04 -0.24,-0.11 -0.01,0.1 0.01,0.11 -0.22,0.1 0.21,0.76 -0.03,0.23 -0.07,0.08 -0.09,-0.02 h -0.09 l -0.04,0.08 0.06,0.16 -0.22,0.05 -0.36,-0.05 -0.18,-0.13 -0.05,-0.15 -0.01,-0.14 -0.14,-0.23 -0.3,-0.21 -0.59,0.03 -0.23,-0.05 -0.23,-0.07 -0.25,-0.04 -0.22,0.03 -0.27,0.1 -0.48,-0.06 -0.15,0.16 -0.23,0.19 -0.21,0.01 -0.44,-0.34 -0.13,-0.01 -0.34,0.23 -0.15,0.02 -0.12,-0.05 -0.5,-0.1 -0.22,-0.01 -0.15,0.09 -0.3,-0.05 -0.73,-0.44 -0.4,0.42 -0.88,-0.02 -0.24,0.28 -0.26,0.52 -0.23,0.25 -0.22,-0.07 -0.26,-0.2 -0.47,-0.52 -0.23,-0.09 h -0.25 l -0.22,0.08 -0.11,0.12 -0.04,0.82 -0.03,0.73 0.03,0.43 0.51,0.36 0.62,0.65 0.19,0.06 0.11,0.22 0.17,0.57 0.2,0.64 0.32,0.4 0.29,0.29 0.35,0.25 0.43,0.39 0.37,0.43 0.11,0.17 0.69,0.56 0.68,0.57 0.59,0.17 0.09,0.11 0.05,0.48 0.08,0.17 0.42,0.47 0.83,0.67 0.11,0.16 0.03,0.12 -0.04,0.1 -0.19,0.13 -0.18,-0.1 -0.78,-0.65 -0.74,-0.4 -0.85,-0.79 -1.07,-0.25 -0.75,-0.31 -0.42,0.09 -0.47,0.15 -0.3,0.03 -0.21,-0.05 -0.17,-0.22 0.01,-0.19 -0.04,-0.23 -0.44,-0.35 -0.59,-0.31 -0.57,-0.43 -1.15,-1.18 -0.24,-0.39 0.21,-0.09 h 0.16 l 0.17,-0.1 0.3,-0.02 0.35,0.06 -0.33,-0.25 -0.39,-0.23 -1.05,-0.99 -0.32,-0.47 -0.06,-0.53 0.03,-0.74 -0.2,-0.51 -0.79,-0.63 -0.29,-0.34 -0.57,-0.18 -0.24,0.03 -0.14,0.27 -0.08,0.59 -0.46,0.8 -0.15,0.34 -0.24,0.45 -0.22,0.04 -0.13,-0.03 -0.43,-0.72 -0.41,-0.54 -0.06,-0.26 -0.05,-0.32 -0.34,-1.18 0.2,-0.18 0.13,0.19 0.9,0.19 0.19,-0.11 0.11,-0.16 -0.01,-0.1 0.08,-0.03 0.31,0.13 0.26,-0.05 0.41,-0.02 0.29,0.01 0.19,-0.13 0.24,-0.44 0.08,-0.25 0.11,-0.06 0.08,0.02 0.07,0.2 0.14,0.17 0.3,0.29 0.21,0.13 0.18,0.04 0.17,-0.13 0.19,-0.04 0.53,0.2 0.45,0.01 0.32,-0.14 -0.06,-0.16 -0.13,-0.18 -0.03,-0.18 0.01,-0.16 0.21,-0.17 -0.01,-0.07 -0.29,-0.26 0.01,-0.07 0.57,-0.35 0.56,-0.21 0.08,-0.14 0.04,-0.21 v -0.38 l -0.05,-0.31 -0.25,-0.27 -0.02,-0.15 0.04,-0.15 0.08,-0.14 0.23,-0.08 0.25,-0.12 0.21,-0.13 0.27,-0.11 0.22,-0.15 0.19,-0.33 0.13,-0.06 0.4,0.01 0.08,-0.08 -0.09,-0.45 0.07,-0.12 0.13,-0.08 0.06,-0.07 0.36,0.02 0.3,0.1 0.18,0.05 z"
+         class="region HRV"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="hungary"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S96P1-1"
+         d="m 313.3,286.74 0.29,-0.08 h 0.02 l 0.07,0.01 0.09,0.21 0.01,0.02 0.09,0.13 0.1,0.18 0.12,0.13 0.24,0.02 0.33,0.13 0.25,0.31 0.32,0.09 h 0.02 l 0.06,-0.03 0.2,-0.05 0.06,0.07 0.19,0.13 0.09,0.14 -0.01,0.16 0.06,0.16 0.08,0.06 -0.06,0.13 -0.46,0.67 -0.19,0.19 -0.14,0.06 -0.24,-0.02 -0.22,0.08 -0.19,0.16 -0.19,0.07 -0.12,0.17 -0.14,0.35 -0.19,0.31 -0.21,0.2 -0.1,0.17 0.06,0.52 -0.1,0.17 -0.16,0.18 -0.07,0.15 -0.16,0.83 -0.16,0.28 -0.17,0.23 -0.01,0.18 0.04,0.2 -0.17,0.44 -0.23,0.46 -0.03,0.18 0.1,0.22 -0.24,0.31 -0.14,0.16 -0.13,0.08 -0.06,0.18 -0.08,0.43 0.06,0.17 0.03,0.17 -0.23,0.13 -0.04,0.2 -0.03,0.24 -0.08,0.11 -0.25,0.23 -0.67,0.01 -0.24,0.1 -0.06,0.15 v 0.11 l -0.07,0.12 -0.13,0.15 -0.15,0.08 -0.37,-0.12 -0.72,0.27 -0.11,0.13 -0.12,-0.07 -0.17,-0.05 h -0.75 l -0.29,0.11 -0.4,0.03 -0.37,-0.04 -0.26,0.1 -0.21,0.35 -0.1,0.12 -0.09,0.09 -0.2,0.12 -0.15,0.14 -0.22,0.12 -0.21,0.01 -0.21,-0.11 -0.07,0.04 -0.04,0.13 -0.1,0.12 -0.27,0.17 -0.08,0.01 h -0.01 l -0.22,0.12 -0.36,0.1 -0.19,-0.02 -0.28,0.49 -0.1,0.09 -0.3,0.17 -0.26,0.1 -0.23,-0.03 h -0.09 l -1,0.08 -0.53,-0.04 -0.35,-0.14 -0.24,-0.18 -0.12,-0.2 -0.27,-0.11 -0.41,-0.01 -0.34,-0.18 -0.26,-0.36 -0.33,-0.28 -0.4,-0.19 -0.34,-0.29 -0.26,-0.39 -0.43,-0.33 -0.61,-0.28 -0.18,-0.05 -0.05,-0.11 -0.31,-0.38 -0.14,-0.14 v -0.2 l -0.07,-0.11 -0.11,-0.07 -0.07,-0.29 -0.05,-0.21 -0.09,-0.14 -0.63,0.02 0.48,-0.56 0.25,-0.16 h 0.3 l 0.1,-0.05 0.01,-0.08 0.04,-0.17 0.02,-0.17 0.01,-0.15 -0.04,-0.08 -0.14,-0.01 -0.1,-0.37 0.06,-0.14 0.07,-0.11 -0.13,-0.44 0.02,-0.16 0.23,-0.04 0.18,-0.11 0.15,-0.12 0.03,-0.15 0.11,-0.29 -0.15,-0.34 -0.68,-0.17 -0.04,-0.08 0.15,-0.11 0.15,-0.16 0.09,-0.12 0.12,-0.02 0.19,0.04 0.34,0.22 0.13,0.03 0.11,-0.08 0.13,-0.03 0.35,-0.02 0.3,-0.09 -0.09,-0.26 -0.02,-0.19 -0.06,-0.16 0.01,-0.17 0.11,-0.14 0.01,-0.31 0.17,-0.22 0.09,-0.03 h 0.33 l 0.08,0.05 0.05,0.01 0.57,0.44 0.53,0.32 0.42,0.15 0.6,-0.04 0.63,-0.05 1.05,-0.18 0.79,-0.13 0.04,-0.1 0.09,-0.24 -0.11,-0.17 -0.02,-0.23 0.1,-0.3 0.36,-0.29 1.11,-0.24 0.61,-0.25 0.07,-0.26 0.18,-0.27 0.19,-0.07 0.28,0.08 0.34,0.17 0.3,0.08 0.15,-0.1 0.52,-0.43 0.6,-0.43 0.32,-1.01 0.03,-0.16 0.46,-0.17 0.71,-0.08 0.37,0.07 0.28,0.02 0.4,-0.08 0.55,-0.29 0.22,-0.02 0.18,0.12 0.2,0.09 0.15,0.14 0.12,0.2 0.07,0.07 0.09,0.1 0.17,0.12 0.15,0.02 1.04,-0.43 z"
+         class="region HUN"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="ireland"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S102P1-19"
+         d="m 219.91,255.29 -0.05,0.13 -0.15,-0.23 -0.04,-0.2 -0.52,-0.24 0.28,-0.12 0.1,0.09 0.37,0.12 0.09,0.1 z"
+         class="region IRL"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S102P2"
+         d="m 228.01,252.07 -0.23,0.42 -0.05,0.13 -0.19,0.21 -0.2,0.23 -0.18,0.07 -0.24,0.02 -0.14,0.05 -0.15,-0.08 -0.2,-0.04 -0.12,0.06 -0.02,0.07 0.04,0.1 0.14,0.16 0.17,0.16 -0.05,0.1 -0.13,0.08 -0.74,0.1 -0.24,0.11 -0.1,0.09 0.02,0.2 0.39,0.69 0.07,0.08 v 0.34 l 0.43,0.25 0.14,0.25 0.16,0.09 0.36,0.07 0.13,0.11 0.1,-0.03 0.07,-0.09 0.37,-0.2 0.13,-0.09 -0.02,-0.18 -0.03,-0.14 0.25,-0.21 0.28,-0.19 0.11,0.04 0.16,0.2 0.1,0.24 -0.02,0.17 v 0.13 l 0.09,0.29 0.07,0.11 0.25,0.11 0.04,0.11 -0.14,0.36 0.01,0.13 0.27,0.07 0.3,0.04 0.1,0.04 0.12,-0.05 0.18,-0.05 0.23,0.09 0.07,0.19 0.01,0.18 -0.21,0.02 -0.2,-0.09 -0.13,0.09 -0.06,0.21 0.01,0.29 0.09,0.23 v 0.47 l -0.02,0.51 0.07,0.33 -0.05,0.37 -0.07,0.18 -0.05,0.33 -0.09,0.1 -0.02,0.32 0.02,0.67 v 0.36 l -0.13,0.78 -0.19,0.26 -0.23,0.24 -0.19,0.29 -0.16,0.33 -0.18,0.55 -0.52,0.58 -0.19,0.13 -0.2,0.06 0.28,0.55 -0.37,0.13 -0.36,-0.02 -0.35,-0.21 -0.25,-0.04 -0.25,0.1 -0.11,0.07 -0.05,-0.06 -0.06,-0.42 -0.2,0.37 -0.25,0.07 -0.37,-0.12 -0.65,-0.06 -0.27,0.05 -0.15,0.15 -0.12,0.18 -0.13,0.09 -0.13,0.04 -0.52,0.02 -0.12,0.04 -0.3,0.26 -0.35,0.11 -0.26,-0.01 -0.17,-0.24 -0.06,-0.14 -0.08,-0.08 -0.34,-0.08 0.09,0.08 0.03,0.15 -0.03,0.27 -0.1,0.23 -0.2,0.09 -0.2,-0.03 -0.38,0.17 -0.43,-0.04 -0.29,0.18 -1.47,0.02 -0.07,-0.01 -0.16,-0.16 -0.19,-0.1 -0.22,-0.03 -0.63,0.07 -0.26,-0.13 0.51,-0.45 0.55,-0.15 0.07,-0.06 -0.15,-0.08 -0.94,-0.06 -0.36,0.07 -0.32,-0.04 0.21,-0.21 0.5,-0.23 0.26,-0.1 0.15,-0.03 0.21,-0.16 0.48,-0.11 -1.48,0.08 -0.34,-0.16 -0.05,-0.16 -0.29,-0.02 -0.01,-0.35 0.55,-0.36 0.3,-0.14 0.31,-0.04 0.32,-0.08 0.15,-0.17 -0.1,-0.1 -0.83,-0.19 -0.37,-0.15 0.06,-0.15 0.13,-0.16 0.48,-0.18 0.23,0.02 0.19,0.08 0.17,0.13 0.12,0.15 0.47,0.07 -0.13,-0.24 0.07,-0.4 -0.1,-0.17 0.23,-0.13 0.25,-0.05 0.46,-0.27 0.14,-0.02 0.72,0.11 0.81,0.01 0.83,-0.06 -0.35,-0.26 -0.13,-0.25 -0.4,0.32 -0.26,0.1 -0.62,-0.09 -0.18,-0.09 -0.23,-0.21 -0.1,0.03 -0.1,0.07 -0.45,0.09 -0.43,-0.08 0.59,-0.22 0.78,-0.44 0.2,-0.15 0.28,-0.28 -0.01,-0.17 -0.1,-0.12 0.63,-0.57 0.19,-0.09 0.29,0.06 0.24,-0.05 0.09,0.03 0.1,-0.02 0.23,-0.16 -0.24,-0.21 -0.27,-0.15 -0.91,-0.18 -0.11,-0.05 -0.1,-0.09 -0.04,-0.11 0.01,-0.25 -0.05,-0.08 -0.2,-0.05 -0.22,0.01 -0.13,-0.05 -0.11,-0.14 0.29,-0.18 -0.27,-0.13 -0.29,-0.04 -0.21,-0.14 0.03,-0.15 0.15,-0.12 -0.09,-0.18 0.02,-0.19 0.18,-0.05 0.15,0.08 0.37,-0.04 0.44,0.06 -0.33,-0.24 -0.11,-0.15 0.05,-0.18 0.07,-0.14 0.49,-0.13 0.47,0.02 0.02,-0.18 0.08,-0.17 -0.43,-0.18 h -0.48 l 0.15,-0.32 0.19,-0.28 0.08,-0.2 0.05,-0.22 -0.24,0.03 0.07,-0.31 -0.03,-0.23 -0.34,0.05 0.09,-0.27 0.14,-0.17 0.18,-0.04 0.15,0.08 0.29,0.09 0.33,-0.07 0.42,0.08 0.63,0.23 0.33,0.54 0.14,-0.05 0.25,-0.21 h 0.1 l 0.64,0.3 0.38,0.26 0.12,-0.02 0.02,-0.3 -0.09,-0.24 0.26,-0.21 0.27,-0.12 0.17,-0.05 0.37,-0.02 0.17,-0.06 0.19,-0.32 0.24,-0.24 -0.89,-0.08 -0.72,-0.55 0.2,-0.2 0.2,-0.08 0.32,-0.03 0.07,-0.11 0.17,-0.06 0.32,-0.21 0.01,-0.37 0.12,-0.24 0.22,-0.12 0.12,-0.23 0.12,-0.15 0.38,0.03 0.38,-0.08 0.12,0.05 0.42,0.07 0.12,0.1 0.04,-0.3 0.26,0.03 0.08,0.08 -0.01,0.22 0.08,0.16 -0.03,0.23 -0.12,0.16 -0.16,0.1 0.08,0.17 -0.25,0.21 0.22,-0.06 0.35,-0.18 0.03,-0.2 0.02,-0.26 -0.01,-0.25 0.1,-0.24 0.19,-0.12 0.43,0.02 -0.09,-0.32 0.15,0.01 0.15,0.1 0.18,0.28 0.2,0.23 0.23,0.2 -0.32,0.22 -0.36,0.12 -0.17,0.18 -0.49,0.19 z"
+         class="region IRL"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="iceland"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S105P1-2"
+         d="m 227.83,196.19 0.19,0.09 0.39,-0.02 0.18,-0.05 0.48,-0.21 0.24,-0.02 0.3,0.14 0.16,0.03 -0.02,0.03 -0.24,0.07 -0.17,-0.01 -0.31,0.12 -0.41,0.38 -0.25,0.17 -0.04,0.1 0.11,0.25 0.16,0.18 0.23,-0.03 0.06,0.07 0.02,0.16 -0.01,0.15 -0.05,0.13 -0.15,0.26 -0.23,0.23 -0.26,0.17 -0.01,0.08 0.11,0.08 0.66,0.07 0.05,0.03 0.01,0.09 -0.06,0.14 -0.02,0.13 0.02,0.14 -0.07,0.1 -0.41,0.27 0.4,-0.12 0.27,0.03 0.37,0.26 0.12,0.19 v 0.27 l 0.18,-0.03 0.06,0.03 0.04,0.16 -0.05,0.14 -0.16,0.18 -0.09,0.17 -0.11,0.05 -0.16,0.01 -0.06,0.05 v 0.16 l 0.03,0.17 0.13,0.05 -0.01,0.07 -0.03,0.08 -0.05,0.08 -0.07,0.05 -0.08,0.01 -0.12,0.07 0.23,0.32 0.01,0.1 -0.05,0.12 -0.07,0.12 -0.12,0.12 -0.13,0.05 -0.23,-0.07 -0.18,0.04 -0.02,0.17 -0.08,0.19 -0.14,0.21 -0.32,0.28 -0.25,0.12 -0.22,0.06 -0.28,-0.15 -0.13,-0.15 -0.1,0.3 -0.25,0.12 -0.03,0.17 0.03,0.09 -0.11,0.19 -0.16,0.16 -0.23,0.16 -0.2,0.08 -0.37,0.04 -0.37,0.17 -0.22,0.04 -0.44,-0.17 h -0.52 l -0.79,0.11 -0.55,0.12 -0.48,0.19 -0.67,0.35 -0.42,0.09 -0.22,-0.02 -0.38,-0.1 -0.37,0.02 -1.13,-0.15 h -0.41 l -0.11,0.11 -0.24,0.14 -0.04,0.07 0.04,0.08 -0.02,0.08 -0.24,0.18 -0.33,0.06 -0.12,-0.05 -0.07,-0.21 -0.07,-0.02 -0.03,0.01 -0.03,0.04 v 0.21 l -0.19,0.02 -0.76,-0.08 -1.04,-0.64 -0.36,-0.35 -0.41,-0.49 -0.29,-0.22 -0.45,-0.22 -0.19,-0.51 -0.06,-0.3 0.04,-0.09 0.07,-0.09 0.07,-0.05 0.08,-0.01 0.12,0.05 0.03,-0.02 v -0.21 l -0.12,0.01 -0.36,0.13 -0.1,-0.06 -0.08,-0.18 0.06,-0.12 -0.25,-0.17 -0.15,-0.26 -0.12,-0.32 0.01,-0.09 0.17,-0.07 -0.01,-0.03 -0.07,-0.06 -0.19,-0.04 -0.4,0.14 h -0.14 l -1.68,-0.75 -0.43,-0.18 -0.11,-0.01 0.03,-0.2 0.15,-0.41 0.12,-0.26 0.08,-0.11 0.14,-0.11 0.07,0.06 0.02,0.16 -0.01,0.2 0.04,0.13 0.68,0.08 0.31,-0.01 0.17,-0.08 0.23,-0.16 0.19,-0.05 0.11,-0.07 0.3,-0.28 0.17,-0.11 0.15,-0.07 0.15,-0.02 0.28,0.07 -0.12,-0.16 -0.15,-0.07 -0.73,0.08 -0.18,-0.09 0.04,-0.05 0.13,-0.06 0.27,-0.08 -0.11,-0.07 -0.01,-0.1 0.09,-0.17 0.24,-0.21 0.62,-0.13 0.18,0.02 0.08,-0.04 -0.03,-0.09 -0.07,-0.07 -0.63,0.13 -0.38,-0.03 -0.08,-0.07 -0.09,-0.22 -0.02,-0.09 0.02,-0.19 0.06,-0.09 0.31,-0.2 0.01,-0.06 -0.09,-0.08 -0.13,-0.39 -0.45,-0.2 -0.98,-0.7 -0.26,-0.05 -0.49,0.03 -0.26,-0.05 -0.07,-0.1 -0.02,-0.16 v -0.2 l 0.05,-0.23 0.11,-0.12 h 0.19 l 0.12,0.02 0.26,0.2 0.43,0.05 0.24,0.08 0.08,0.02 0.21,-0.08 h 0.09 l 0.07,0.1 -0.01,0.12 0.45,0.04 0.16,-0.02 0.04,-0.04 0.09,-0.03 0.13,0.18 0.14,0.07 0.21,0.04 0.33,0.13 0.72,0.34 0.18,-0.07 0.11,-0.09 0.22,-0.25 v -0.07 l -0.59,0.04 -0.09,-0.05 -0.44,-0.4 -0.09,-0.24 0.13,-0.1 0.42,-0.13 0.4,-0.07 0.54,-0.03 0.15,-0.04 0.07,-0.1 -0.16,-0.33 -0.55,-0.2 v -0.29 l -0.34,-0.35 -0.33,-0.06 -0.07,-0.21 h -0.48 l -0.95,-0.15 -0.43,0.02 -0.21,-0.03 -0.11,-0.26 -0.23,-0.35 -0.34,-0.26 0.03,-0.11 0.41,-0.19 0.18,0.02 0.13,0.11 0.16,0.37 0.16,0.18 -0.06,-0.45 0.08,-0.12 0.1,-0.19 -0.03,-0.12 0.04,-0.24 0.08,-0.05 0.11,0.03 0.16,0.17 0.26,0.6 0.28,0.07 0.2,-0.07 h 0.24 l -0.02,-0.07 -0.41,-0.23 -0.18,-0.19 -0.05,-0.16 0.01,-0.22 0.08,-0.06 0.15,-0.01 0.34,0.21 -0.05,-0.42 -0.05,-0.26 0.03,-0.09 0.08,-0.1 0.06,-0.06 0.06,-0.02 0.29,0.39 0.08,0.05 -0.01,-0.16 -0.07,-0.26 0.03,-0.06 0.1,-0.01 0.1,-0.08 0.05,-0.08 h 0.16 l 0.12,0.06 0.09,0.13 0.19,0.52 v 0.12 l -0.06,0.13 -0.1,0.14 -0.02,0.07 0.18,0.03 0.08,0.12 0.07,0.02 0.28,-0.15 0.08,0.1 v 0.14 l -0.04,0.11 -0.07,0.13 -0.19,0.27 -0.01,0.04 0.2,-0.1 0.18,0.08 0.07,-0.07 0.18,-0.29 0.12,-0.25 0.01,-0.06 -0.39,-0.63 -0.05,-0.14 -0.03,-0.23 0.07,-0.07 0.16,-0.01 0.19,0.05 0.4,0.21 0.06,-0.01 -0.03,-0.13 -0.15,-0.15 -0.01,-0.07 0.03,-0.11 -0.25,-0.06 -0.24,-0.12 -0.2,-0.18 0.04,-0.08 0.16,-0.06 0.3,-0.09 H 216 l 0.25,0.17 0.3,0.09 0.17,0.17 0.07,0.26 0.05,0.45 0.22,0.37 -0.01,0.08 0.08,0.25 0.09,0.63 0.22,0.44 -0.03,0.07 -0.1,0.05 -0.19,0.03 v 0.07 l 0.15,0.15 0.03,0.24 -0.04,0.09 -0.43,0.49 -0.13,0.09 -0.11,0.03 -0.27,-0.27 -0.02,0.22 0.13,0.3 v 0.13 l -0.1,0.09 0.02,0.04 0.12,-0.02 v 0.08 l -0.11,0.17 -0.12,0.12 -0.12,0.09 -0.01,0.05 0.1,0.03 0.07,0.08 0.06,0.22 -0.16,0.54 -0.03,0.18 0.12,-0.12 0.25,-0.32 0.15,-0.16 0.04,0.01 0.08,-0.04 0.09,-0.09 0.28,-0.36 0.39,-0.19 0.16,-0.04 0.11,0.03 0.03,0.06 0.01,0.39 0.07,0.1 0.07,0.01 0.18,-0.17 0.32,-0.37 0.26,-0.44 0.22,-0.52 0.22,-0.34 0.22,-0.17 0.18,0.01 0.13,0.16 0.06,0.19 -0.01,0.61 0.07,0.35 0.03,0.37 0.05,0.13 0.15,0.12 0.06,0.01 0.06,-0.05 0.07,-0.11 0.34,-0.73 0.17,-0.2 0.15,-0.12 0.37,0.05 0.22,-0.03 0.25,-0.09 0.19,-0.02 0.11,0.03 0.09,0.12 0.05,0.19 0.05,0.35 0.01,0.56 0.14,0.46 -0.11,0.61 -0.01,0.1 0.03,0.03 0.08,-0.05 0.07,-0.09 0.13,-0.24 0.07,-0.35 0.11,-0.91 0.07,-0.16 0.1,-0.1 0.2,0.07 0.43,0.27 0.09,0.19 0.08,0.62 0.03,0.15 0.04,0.05 0.05,-0.05 0.17,-0.04 0.14,-0.07 0.27,-0.21 0.55,-0.36 0.07,0.02 0.07,0.07 0.1,0.19 0.03,0.14 0.11,0.13 0.17,0.04 0.29,-0.09 h 0.29 l 0.2,-0.21 0.06,-0.11 0.15,-0.79 0.15,-0.11 0.5,-0.02 0.37,0.13 0.06,0.08 0.07,0.44 0.08,0.24 0.01,0.17 -0.12,0.32 0.04,0.15 z"
+         class="region ISL"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gISR"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S106P1-5"
+         d="m 373.35,347.77 -0.39,0.49 -0.07,0.61 0.02,0.26 -0.04,0.58 0.14,0.3 0.13,0.41 0.12,0.32 0.01,0.22 -0.07,0.15 0.05,0.06 h 0.09 l 0.23,-0.18 0.3,-0.01 c 0.65847,0.12403 0.0922,0.43805 -0.19,0.75 l -0.24,0.42 -0.01,0.31 -0.07,0.68 0.06,0.12 0.12,0.04 0.0277,0.96372 -2.05766,0.0163 -0.07,-0.31 0.49,-0.93 -0.02,-0.07 -0.22,-0.13 0.02,-0.04 0.41,-1.57 0.15,-1.48 v -1.97 l 0.08,-1.04 0.11,-0.71 -0.02,-0.55 0.41,-0.19 0.33,-0.06 0.38,-0.11 z"
+         class="region ISR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccc" />
+      <g
+         id="gPSX"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+        <path
+           id="polyF1S180P1-2"
+           d="m 371.51,354.28 -0.3,0.5 -0.21,-0.32 -0.09,-0.12 0.55,-0.94 0.23,-0.56 0.22,0.13 0.02,0.07 -0.49,0.93 z"
+           class="region ISR PSX"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+        <path
+           id="polyF1S180P2"
+           d="m 374.25,352.98 -0.71,0.32 -0.12,-0.04 -0.06,-0.12 0.07,-0.68 0.01,-0.31 0.24,-0.42 0.38,-0.42 0.17,-0.14 -0.05,-0.1 -0.31,-0.09 -0.3,0.01 -0.23,0.18 h -0.09 l -0.05,-0.06 0.07,-0.15 -0.01,-0.22 -0.12,-0.32 -0.13,-0.41 -0.14,-0.3 0.04,-0.58 -0.02,-0.26 0.07,-0.61 0.39,-0.49 0.43,-0.05 0.22,-0.06 0.11,0.03 0.1,0.17 0.35,0.1 z"
+           class="region ISR PSX"
+           inkscape:connector-curvature="0"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+           sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
+        <circle
+           r="0.25"
+           id="pointF2S46P1"
+           cy="349.57925"
+           cx="374.05371"
+           class="region ISR PSX"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25" />
+        <circle
+           r="0.25"
+           id="pointF2S70P1"
+           cy="353.66626"
+           cx="371.48285"
+           class="region ISR PSX"
+           style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25" />
+      </g>
+    </g>
+    <g
+       id="italy"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S107P1-5"
+         d="m 282.46,344.79 -0.18,0.05 -0.25,-0.15 -0.02,-0.22 0.05,-0.07 0.29,0.09 0.1,0.21 z"
+         class="region ITA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S107P2"
+         d="m 295.61,337.37 -0.22,0.55 -0.12,0.21 -0.84,1.36 -0.09,0.3 -0.04,0.33 -0.08,0.29 -0.12,0.28 -0.1,0.35 0.04,0.38 0.06,0.19 0.11,0.12 0.19,0.1 0.15,0.17 -0.21,0.18 0.26,0.31 0.21,0.18 0.03,0.2 0.01,0.19 -0.4,0.39 -0.15,0.21 -0.09,0.25 -0.04,0.26 0.06,0.22 v 0.23 h -0.42 l -0.44,-0.12 -0.44,0.09 -0.63,-0.22 -0.23,-0.04 -0.21,-0.09 -0.55,-0.78 -0.42,-0.32 -0.46,-0.25 -0.45,0.01 -0.46,0.05 -0.4,-0.14 -0.84,-0.52 -0.87,-0.4 -0.38,-0.28 -0.17,-0.18 -0.2,-0.13 -0.5,-0.11 -0.45,-0.28 -0.2,-0.01 -0.43,0.05 -0.22,-0.02 -0.23,-0.1 -0.44,-0.33 -0.28,-0.48 -0.08,-0.22 0.18,-0.56 0.22,-0.54 0.2,-0.15 0.24,-0.12 0.14,-0.16 0.11,-0.2 0.46,0.55 0.2,0.13 0.19,-0.04 0.35,-0.21 0.02,-0.22 0.39,-0.29 0.49,-0.03 0.23,0.05 0.13,0.24 0.19,0.07 0.22,0.03 0.73,0.44 0.21,0.07 0.2,0.01 0.55,-0.23 0.43,-0.1 0.9,0.07 0.48,-0.15 0.33,-0.03 0.49,-0.21 0.36,-0.33 0.2,-0.08 0.21,-0.04 0.51,-0.01 0.52,0.04 0.21,-0.09 0.17,-0.21 0.2,-0.1 0.24,0.04 0.57,-0.38 0.26,-0.04 0.26,0.11 z"
+         class="region ITA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S107P3"
+         d="m 268.97,333.95 -0.23,0.46 -0.22,-0.33 v -0.28 l 0.03,-0.08 0.27,0.12 z"
+         class="region ITA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S107P4"
+         d="m 289,326.06 -0.16,0.04 -0.1,-0.05 -0.05,-0.07 0.05,-0.18 0.34,0.09 v 0.1 z"
+         class="region ITA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S107P5"
+         d="m 268.48,324.65 -0.12,0.21 -0.17,-0.02 0.07,-0.16 0.16,-0.31 0.2,-0.11 0.08,0.1 -0.1,0.18 z"
+         class="region ITA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S107P6"
+         d="m 273.35,325.5 0.17,0.3 0.4,1.24 0.04,0.27 -0.08,0.27 -0.11,0.19 -0.41,0.62 0.05,0.52 0.15,0.32 0.02,0.35 -0.08,0.43 -0.28,2.68 -0.13,0.47 -0.08,0.41 -0.29,0.12 -0.36,-0.13 -0.46,-0.24 -0.21,0.01 -0.22,0.07 -0.17,-0.07 -0.17,-0.13 -0.14,0.92 -0.22,0.37 -0.32,0.23 -0.3,0.01 -0.31,-0.09 -0.26,-0.01 -0.19,-0.18 -0.15,-0.31 -0.24,-0.39 -0.25,-0.45 -0.01,-0.41 -0.03,-0.89 0.08,-0.19 0.11,-0.18 0.06,-0.4 -0.03,-0.35 0.08,-0.12 0.14,0.12 0.11,-0.04 v -0.18 l 0.04,-0.32 -0.18,-0.28 -0.33,-0.11 -0.02,-0.28 0.04,-0.28 0.18,-0.19 0.06,-0.24 0.02,-0.77 -0.22,-0.28 -0.08,-0.43 -0.11,-0.28 -0.2,-0.28 -0.23,-0.23 -0.14,-0.22 -0.02,-0.56 0.09,-0.47 0.08,-0.2 0.08,0.03 0.23,0.24 0.19,0.06 0.38,0.07 0.38,-0.07 0.46,-0.2 0.45,-0.25 0.65,-0.74 0.4,-0.15 0.21,-0.19 0.07,-0.27 0.17,-0.07 0.19,0.27 0.24,0.03 0.38,0.22 0.16,0.21 0.14,0.25 0.13,0.11 0.14,0.07 0.02,0.06 -0.11,0.05 -0.14,0.29 0.08,0.08 z"
+         class="region ITA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S107P7"
+         d="m 276.13,316.15 0.11,0.19 0.02,0.11 -0.08,0.12 0.03,0.27 -0.29,-0.23 -0.45,0.12 -0.27,-0.03 -0.08,-0.2 0.06,-0.12 0.43,-0.03 0.13,-0.05 0.26,0.02 z"
+         class="region ITA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S107P8"
+         d="m 281.83,296.41 0.09,0.24 0.38,0.46 0.21,0.36 0.2,0.27 0.3,0.14 0.4,0.07 0.33,0.03 0.35,0.09 1.21,0.21 0.6,0.05 0.46,-0.01 0.7,0.14 -0.06,0.28 -0.14,0.07 -0.23,0.17 -0.28,0.23 -0.25,0.26 -0.06,0.27 0.08,0.17 0.07,0.06 0.1,-0.06 0.14,0.03 0.18,0.09 0.29,0.08 0.01,0.09 -0.05,0.12 -0.22,0.22 -0.2,0.25 -0.01,0.14 0.02,0.11 0.08,0.06 0.3,-0.04 0.05,0.08 -0.12,0.62 0.05,0.1 0.27,0.09 0.2,0.13 0.38,0.37 0.16,0.31 -0.1,0.11 -0.23,0.06 -0.19,-0.02 0.21,-0.19 -0.55,-0.67 -0.23,0.01 -0.3,0.31 -0.88,-0.26 -0.16,0.12 -0.11,0.24 -0.3,0.3 -0.42,0.14 -0.47,0.33 -0.49,0.24 -0.38,0.18 -0.22,-0.02 0.34,-0.38 h -0.15 l -0.46,0.27 -0.26,0.22 -0.08,0.38 -0.06,0.61 0.2,0.15 0.38,0.79 0.45,0.33 -0.07,0.33 -0.11,0.27 -0.27,0.23 -0.22,-0.16 h -0.14 l -0.09,0.53 0.22,1.39 0.34,0.97 0.32,0.42 0.72,0.65 0.75,0.32 1.38,1.07 0.75,0.33 0.21,0.18 0.48,0.85 0.42,0.97 0.49,1.55 0.33,0.75 0.65,0.84 1.32,1.17 1.2,0.84 1.11,0.5 0.84,0.04 1.98,-0.26 0.35,0.03 0.38,0.12 0.11,0.38 -0.11,0.27 -0.41,0.31 -0.4,0.41 -0.01,0.51 0.42,0.34 2,0.8 2.04,0.63 0.65,0.35 0.77,0.57 1.8,0.7 0.33,0.4 1.14,0.8 0.55,0.65 0.14,0.53 -0.18,0.58 -0.07,0.4 -0.15,0.41 -0.47,-0.1 -0.55,-0.34 -0.91,-1.53 -1.43,-0.03 -0.3,-0.09 -0.52,-0.23 -0.05,-0.18 -0.14,-0.22 -0.13,-0.06 h -0.54 l -0.36,0.29 -0.39,0.66 -0.44,0.93 -0.42,1.35 0.01,0.52 0.31,0.49 0.85,0.21 0.68,0.4 0.46,0.44 0.12,1.14 0.24,0.63 -0.26,0.39 -0.55,-0.05 -0.71,0.3 -0.49,0.46 -0.19,0.42 0.13,1.03 -0.08,0.4 -0.94,0.83 -0.47,0.8 -0.11,0.32 -0.17,0.38 -1.26,0.1 -0.32,-0.42 -0.05,-0.66 0.2,-0.42 0.44,-0.22 0.26,-0.87 -0.13,-0.6 0.16,-0.29 0.16,-0.2 0.34,-0.14 0.48,-0.14 v -0.86 l -0.41,-0.35 -0.17,-0.53 -0.24,-0.99 -0.7,-1.24 -0.4,-1.12 -0.3,-0.54 -0.41,-0.27 -0.71,0.05 -0.36,-0.06 -1.29,-0.72 -0.1,-0.11 v -0.21 l 0.19,-0.33 -0.16,-0.43 -0.17,-0.4 -0.26,-0.33 -0.28,-0.17 -0.56,0.15 -0.19,0.09 -0.35,-0.01 -0.28,0.17 -0.15,0.02 0.41,-0.64 -0.13,-0.14 -0.44,-0.23 h -0.59 l -0.16,-0.03 -0.09,0.16 -0.12,-0.08 v -0.27 l -0.73,-1.19 -0.47,-0.48 -0.23,-0.08 -0.41,0.12 -0.71,-0.19 -0.41,-0.03 -0.23,0.06 -0.34,0.17 -0.17,-0.1 -0.07,-0.16 -0.64,-0.49 -0.79,-0.26 -1.56,-1.59 -0.48,-0.59 -0.97,-0.65 -0.62,-0.97 -0.49,-0.35 -0.72,-0.28 -0.17,0.04 -0.21,0.11 -0.17,0.02 -0.14,-0.13 0.14,-0.13 0.15,-0.06 -0.06,-0.37 -0.82,-0.96 -0.48,-0.31 -0.13,-0.19 -0.1,-0.27 -0.1,-0.17 -0.23,-0.1 -0.19,0.02 -0.26,-0.07 0.01,-0.46 0.05,-0.36 -0.04,-0.3 -0.26,-0.79 -0.44,-0.68 -0.25,-1.61 -0.2,-0.46 -0.49,-0.35 -1.09,-0.39 -1.5,-1.06 -0.32,-0.02 -0.91,-0.43 -0.56,-0.08 -0.74,0.35 -0.92,0.97 -0.75,1.01 -0.27,0.19 -0.96,0.32 -0.83,0.14 v -0.27 l -0.02,-0.2 0.14,-0.21 0.25,-0.25 0.22,-0.32 0.1,-0.23 -0.04,-0.16 -0.09,-0.23 -0.13,-0.03 -0.79,0.17 -0.18,-0.06 -0.57,-0.33 -0.61,-0.4 -0.21,-0.28 -0.08,-0.27 0.07,-0.17 -0.04,-0.17 -0.11,-0.23 0.12,-0.25 0.21,-0.31 0.1,-0.21 0.17,-0.05 0.08,-0.13 -0.11,-0.53 -0.06,-0.09 -0.11,-0.07 -0.17,-0.02 -0.3,-0.12 -0.2,-0.2 -0.03,-0.24 -0.11,-0.25 -0.18,-0.22 -0.01,-0.24 0.22,-0.12 0.3,0.01 0.21,0.06 0.49,-0.36 0.17,-0.02 0.16,-0.08 0.15,-0.51 0.11,-0.15 0.02,-0.09 -0.08,-0.12 -0.37,-0.38 -0.15,-0.39 -0.25,-0.44 -0.25,-0.2 -0.04,-0.15 v -0.19 l 0.06,-0.16 0.47,-0.24 0.28,-0.26 0.11,0.11 0.24,0.12 0.67,-0.12 0.42,-0.14 0.29,-0.14 0.18,0.03 0.64,0.27 0.22,-0.12 0.48,-0.31 0.08,-0.17 0.38,-0.51 0.01,-0.12 -0.14,-0.34 0.05,-0.07 0.46,-0.32 0.23,-0.29 0.24,-0.19 h 0.18 l 0.04,0.07 0.02,0.14 -0.03,0.57 0.06,0.18 0.34,0.42 0.25,0.24 0.59,0.18 0.02,0.07 -0.17,0.31 0.35,0.38 0.06,0.27 0.16,0.16 0.24,-0.07 0.08,-0.14 -0.09,-0.26 -0.06,-0.26 0.02,-0.15 0.06,-0.18 0.17,-0.24 0.45,-0.55 0.16,-0.32 0.04,-0.5 0.01,-0.4 0.14,-0.09 0.32,0.07 h 0.09 l 0.04,0.24 0.13,0.4 0.15,0.2 0.17,0.06 h 0.2 l 0.5,-0.24 0.32,-0.1 0.18,0.03 0.1,0.17 0.23,0.43 0.13,0.05 0.16,-0.05 0.06,-0.07 -0.05,-0.17 -0.07,-0.36 -0.09,-0.28 -0.12,-0.13 -0.02,-0.17 0.08,-0.3 0.08,-0.25 0.17,-0.07 0.19,-0.03 0.25,0.27 0.3,0.08 0.23,-0.01 0.04,-0.16 -0.02,-0.17 -0.13,-0.22 0.03,-0.34 0.15,-0.62 0.09,0.05 0.33,0.01 0.36,0.03 0.23,0.25 0.23,0.09 0.32,0.03 0.22,-0.04 0.1,-0.1 0.12,-0.3 0.23,-0.37 0.36,-0.19 0.62,-0.04 0.31,-0.07 0.32,-0.01 0.24,0.06 0.25,-0.01 0.63,-0.27 0.65,-0.22 0.09,0.03 0.02,0.07 -0.12,0.16 z"
+         class="region ITA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S107P9"
+         d="m 283.05,310.95 0.11,0.19 0.2,-0.04 0.09,-0.25 -0.04,-0.17 -0.21,0.04 z"
+         class="region ITA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="kosovo"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S120P1-51"
+         d="m 315.56,316.11 h -0.01 l -0.58,0.22 -0.18,0.18 -0.09,0.29 -0.02,0.14 -0.1,0.02 -0.2,-0.11 -0.25,-0.18 -0.28,0.06 -0.93,0.61 -0.07,0.26 0.04,0.54 -0.05,0.15 -0.09,0.11 h -0.42 l -0.04,-0.03 0.03,-0.21 -0.08,-0.45 -0.27,-0.72 -0.16,-0.23 -0.3,-0.2 -0.23,-0.13 -0.39,-0.09 -0.24,-0.39 -0.34,-0.42 -0.15,-0.09 0.01,-0.05 0.03,-0.36 -0.11,-0.25 -0.15,-0.2 0.07,-0.14 0.26,-0.03 0.22,-0.01 0.06,-0.22 0.43,-0.19 0.41,-0.2 0.05,-0.11 -0.12,-0.2 0.04,-0.15 0.47,-0.45 0.06,-0.18 0.02,-0.15 -0.09,-0.13 -0.12,-0.21 0.03,-0.1 0.25,-0.17 0.2,-0.18 0.12,-0.03 0.1,0.09 0.01,0.12 0.1,0.18 0.17,0.08 0.29,0.13 0.32,0.07 0.27,0.19 0.38,0.36 0.08,0.2 0.32,0.13 0.3,0.17 0.01,0.38 0.98,0.18 0.21,-0.03 0.11,0.04 0.01,0.09 -0.04,0.27 -0.28,0.87 -0.01,0.17 -0.25,0.22 -0.03,0.11 0.11,0.21 z"
+         class="region KOS"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gLBN"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S123P1-9"
+         d="m 374.12,343.96 -0.05,0.18 -0.12,-0.1 -0.14,0.15 v 0.63 l -0.25,0.3 -0.38,0.11 -0.33,0.06 -0.41,0.19 0.09,-0.4 0.07,-0.49 0.03,-0.65 0.18,-0.6 0.21,-1.88 0.19,-0.8 -0.12,-0.99 0.35,-1.04 0.35,-0.4 0.14,-0.31 -0.1,-0.36 z"
+         class="region LBN"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         sodipodi:nodetypes="ccccccccccccccccccccc" />
+    </g>
+    <g
+       id="liechtenstein"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S127P1-49"
+         d="m 273.49,296.1 -0.26,-0.03 -0.04,0.01 -0.03,-0.17 0.02,-0.36 0.15,-0.47 0.03,0.08 0.01,0.09 0.03,0.11 0.02,0.13 0.05,0.13 0.09,0.13 0.03,0.12 -0.05,0.14 z"
+         class="region LIE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <circle
+         r="0.25"
+         id="pointF2S64P1"
+         cy="295.77374"
+         cx="273.36237"
+         class="region LIE"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="lithuania"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S130P1-9"
+         d="m 305.07,254.3 -0.14,0.37 -0.17,-0.02 0.23,-0.59 0.06,-0.37 v -0.51 l 0.05,-0.17 0.04,0.23 0.03,0.38 z"
+         class="region LTU"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S130P2"
+         d="m 314.53,247.93 0.45,0.52 0.37,0.04 1.03,0.02 0.23,0.07 0.67,0.4 0.38,0.19 0.26,0.15 0.41,0.33 0.26,0.24 0.36,0.15 0.4,0.07 0.14,-0.01 0.04,0.21 0.02,0.37 -0.01,0.49 -0.05,0.38 v 0.15 l 0.12,0.09 0.51,-0.06 0.22,0.02 0.06,0.08 -0.08,0.15 -0.13,0.14 -0.05,0.11 -0.04,0.37 -0.83,0.14 -0.09,0.1 -0.02,0.17 0.01,0.19 -0.06,0.25 -0.18,0.24 -0.32,0.14 -0.25,0.19 -0.12,0.45 -0.04,0.57 0.09,0.38 0.07,0.21 0.01,0.13 -0.08,0.16 -0.1,0.39 -0.06,0.42 -0.01,0.22 0.05,0.09 0.16,-0.03 0.25,0.03 0.16,0.13 0.09,0.17 0.04,0.2 -0.02,0.11 -0.17,0.12 -0.29,0.06 -0.19,-0.05 -0.05,-0.07 0.04,-0.2 -0.11,-0.22 -0.15,-0.11 -0.2,0.25 -0.24,0.05 -0.24,0.23 -0.13,0.31 -0.16,0.14 -0.49,0.04 -0.09,0.15 0.01,0.59 -0.03,0.12 -0.41,0.05 -0.35,0.3 -0.4,0.27 -0.25,-0.08 -0.15,-0.12 -0.24,0.07 -0.25,0.11 h -0.18 l -0.19,0.05 -0.36,0.18 -0.49,0.05 -0.22,-0.05 -0.04,-0.09 -0.03,-0.22 -0.06,-0.35 -0.14,-0.29 -0.27,-0.23 -0.28,-0.14 -0.34,-0.14 -0.24,-0.05 h -0.13 l -0.05,-0.11 -0.06,-0.08 -0.12,-0.07 -0.25,-0.08 -0.19,0.01 -0.13,0.21 -0.15,-0.21 -0.2,-0.39 -0.04,-0.33 0.01,-0.34 0.16,-1.03 -0.05,-0.15 -0.28,-0.23 -0.33,-0.15 -0.24,-0.39 -0.6,0.07 -0.55,0.11 -0.18,0.01 -0.57,-0.09 -0.56,-0.2 -0.37,-0.11 -0.32,-0.14 -0.18,-0.18 -0.24,0.09 -0.17,0.03 v -0.03 l -0.15,-0.33 0.02,-0.54 -0.3,-0.75 -0.43,-0.88 -0.18,-0.99 -0.05,-0.22 0.62,-0.66 0.79,-0.73 0.19,-0.09 0.76,-0.48 0.1,-0.04 0.74,-0.06 0.59,-0.01 0.48,-0.09 0.25,-0.14 0.26,0.04 0.24,0.23 0.19,-0.07 0.17,-0.2 1.11,-0.04 0.24,-0.05 0.28,-0.02 0.54,0.07 0.32,0.09 0.62,-0.21 0.28,-0.06 0.13,-0.09 0.35,-0.48 0.18,-0.11 0.16,-0.1 0.17,0.03 z"
+         class="region LTU"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="luxembourg"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S131P1-0"
+         d="m 263.02,281.03 -0.03,0.13 -0.02,0.29 0.07,0.29 0.19,0.29 0.15,0.22 0.2,0.18 0.35,0.17 0.14,0.04 0.01,0.21 -0.04,0.23 -0.13,0.11 -0.13,0.17 -0.1,0.22 -0.11,0.41 -0.03,0.28 -0.2,-0.13 -0.11,-0.08 -0.19,-0.04 -0.19,0.06 -0.15,0.14 -0.2,0.03 -0.16,-0.06 -0.09,-0.11 -0.08,-0.07 -0.23,-0.08 -0.1,-0.17 0.08,-0.07 0.08,-0.11 0.07,-0.16 0.08,-0.15 -0.21,-0.44 -0.04,-0.13 -0.18,-0.25 0.01,-0.12 0.06,-0.11 -0.02,-0.09 0.04,-0.2 0.15,-0.2 0.11,-0.24 0.17,-0.32 0.36,-0.39 0.24,0.08 0.1,0.01 0.06,0.15 z"
+         class="region LUX"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <circle
+         r="0.25"
+         id="pointF2S59P1"
+         cy="282.74252"
+         cx="262.84204"
+         class="region LUX"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25" />
+    </g>
+    <g
+       id="latvia"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S132P1-2"
+         d="m 319.3,241.01 0.29,-0.05 0.12,0.05 0.16,0.34 0.41,0.21 0.37,0.16 0.1,0.09 0.08,0.21 0.05,0.25 -0.01,0.14 -0.09,0.18 -0.02,0.4 0.08,0.35 -0.02,0.66 h 0.04 l 0.35,-0.2 0.12,0.04 0.12,0.11 0.13,0.38 0.16,0.15 0.2,0.24 0.1,0.2 0.3,0.19 0.06,0.15 0.3,0.54 0.15,0.32 0.09,0.25 0.01,0.34 -0.01,0.24 h -0.08 l -0.2,0.11 -0.28,0.35 -0.36,0.75 -0.1,0.17 -0.01,0.51 -0.02,0.06 -0.31,0.05 -0.09,0.01 -0.3,0.08 -0.69,0.03 -0.24,0.14 -0.22,0.56 -0.12,0.1 -0.37,0.16 -0.06,0.07 -0.14,0.01 -0.4,-0.07 -0.36,-0.15 -0.26,-0.24 -0.41,-0.33 -0.26,-0.15 -0.38,-0.19 -0.67,-0.4 -0.23,-0.07 -1.03,-0.02 -0.37,-0.04 -0.45,-0.52 -0.18,-0.31 -0.17,-0.03 -0.16,0.1 -0.18,0.11 -0.35,0.48 -0.13,0.09 -0.28,0.06 -0.62,0.21 -0.32,-0.09 -0.54,-0.07 -0.28,0.02 -0.24,0.05 -1.11,0.04 -0.17,0.2 -0.19,0.07 -0.24,-0.23 -0.26,-0.04 -0.25,0.14 -0.48,0.09 -0.59,0.01 -0.74,0.06 -0.1,0.04 -0.76,0.48 -0.19,0.09 -0.79,0.73 -0.62,0.66 -0.22,-0.88 -0.23,-1.79 -0.04,-0.9 0.4,-0.59 0.18,-0.43 0.05,-0.56 -0.04,-0.5 0.03,-0.42 0.49,-1.28 0.52,-0.21 0.67,-0.44 0.76,-0.4 0.22,0.32 0.13,0.24 1.16,0.79 0.31,0.28 0.59,1.03 1.02,0.39 0.69,-0.3 0.26,-0.33 0.47,-0.61 0.18,-0.41 -0.02,-0.36 -0.41,-1.48 -0.29,-0.62 -0.03,-0.42 0.1,0.01 0.2,-0.25 0.7,-0.51 0.16,-0.05 0.16,-0.11 0.43,-0.37 0.19,0.11 0.17,0.14 0.07,-0.01 0.02,-0.07 -0.03,-0.1 0.02,-0.09 0.15,0.02 0.67,0.33 0.24,0.06 h 0.16 l 0.22,0.17 0.52,0.04 0.09,0.09 0.07,0.13 0.59,0.47 0.27,0.24 0.47,0.18 0.19,0.02 0.64,-0.43 0.18,-0.14 0.16,-0.04 0.2,0.11 0.43,0.1 0.36,-0.03 z"
+         class="region LVA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="gMAR"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S135P1-4"
+         d="m 226.96,348.21 0.06,0.36 0.2,0.3 0.72,0.76 0.44,0.46 -0.01,0.14 -0.19,0.28 -0.09,0.21 0.09,0.25 0.27,0.33 v 0.13 l -0.09,0.14 -0.19,0.27 0.22,0.93 -0.05,0.85 -0.16,0.59 -0.04,0.35 v 0.3 l 0.2,0.73 -0.33,1.09 0.14,0.64 0.23,0.55 -33.33,0.08 0.76,-1.11 1.58,-1.3 0.37,-0.62 0.35,-1.05 0.09,-0.38 1.86,-1.11 1.14,-0.94 0.37,-0.2 0.91,-0.33 3.03,-0.46 1.74,-0.46 1.04,-0.39 0.68,-0.6 2.04,-2.54 2.2,-3.75 0.21,-0.44 0.68,0.01 0.48,0.05 0.4,-0.07 0.52,-0.2 0.43,0.22 -0.26,0.16 -0.09,0.51 0.22,0.66 0.44,0.79 0.88,1.06 0.73,0.51 1.1,0.44 1.38,-0.1 0.74,0.14 0.38,-0.09 0.36,0.31 0.73,0.22 0.74,0.01 0.59,-0.25 0.41,-0.35 0.02,0.22 -0.01,0.22 0.08,0.14 0.15,0.57 0.08,0.22 0.42,0.04 0.35,0.17 0.82,0.1 z"
+         class="region MAR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+    </g>
+    <g
+       id="monaco"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S136P1-7"
+         d="m 265.89,311.69 -0.22,0.08 0.01,-0.1 0.06,-0.06 0.07,-0.02 0.07,0.05 z"
+         class="region MCO"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <circle
+         r="0.25"
+         id="pointF2S67P1"
+         cy="311.6907"
+         cx="265.74738"
+         class="region MCO"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="moldova"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S137P1-49"
+         d="m 335.19,296.68 -0.23,-0.25 -0.22,-0.22 -0.15,-0.11 0.04,-0.07 0.11,-0.11 0.08,-0.11 -0.08,-0.3 -0.15,-0.34 -0.1,-0.15 -0.07,-0.27 -0.14,-0.41 -0.11,-0.78 0.04,-1.04 0.03,-0.52 -0.13,-0.25 -0.09,-0.63 -0.18,-0.27 -0.26,-0.36 -0.44,-0.81 -0.37,-0.23 -0.45,-0.24 -0.22,-0.21 -0.17,-0.25 -0.28,-0.22 -0.32,-0.19 -0.44,-0.56 -0.22,-0.25 -0.07,-0.06 -0.44,-0.32 -0.26,-0.33 -0.16,-0.27 -0.11,-0.27 -0.36,-0.49 -0.31,-0.37 -0.28,-0.24 -0.14,-0.19 -0.3,-0.2 -0.39,-0.13 -0.24,0.01 -0.29,0.09 0.04,-0.18 0.54,-0.58 0.18,0.03 0.33,-0.05 0.67,-0.18 0.26,-0.36 0.23,0.03 0.13,-0.17 0.24,-0.22 0.05,0.02 0.04,0.02 0.45,-0.03 0.35,0.08 0.27,0.18 0.26,0.1 h 0.24 l 0.15,0.08 0.07,0.18 0.24,0.03 0.4,-0.1 0.2,0.08 -0.01,0.25 0.06,0.07 0.13,-0.12 0.12,0.05 0.1,0.16 0.09,0.07 0.13,-0.33 0.23,-0.03 0.55,-0.02 0.42,0.51 0.22,0.16 0.18,0.04 0.17,-0.14 0.14,-0.15 0.11,0.03 0.31,0.32 0.17,0.49 0.05,0.2 0.01,0.36 -0.02,0.39 -0.03,0.25 0.08,0.18 0.12,0.14 0.14,0.02 0.48,0.21 0.21,0.18 0.26,0.11 0.17,-0.04 0.12,0.07 0.05,0.1 0.05,0.29 -0.03,0.3 0.06,0.16 0.2,0.17 0.07,0.23 0.05,0.15 0.11,0.09 0.44,0.16 0.55,0.11 0.18,0.19 0.14,0.25 0.1,0.46 0.06,0.41 0.78,0.36 -0.05,0.12 -0.07,0.13 -0.59,0.25 -0.12,0.08 -0.37,-0.33 -0.15,-0.01 -0.1,0.18 -0.13,0.13 -0.2,0.01 -0.23,-0.07 -0.12,-0.06 -0.09,0.01 -0.1,0.12 -0.18,0.01 -0.13,-0.08 -0.07,0.39 -0.08,0.1 h -0.06 l -0.16,-0.58 -0.06,-0.07 -0.13,0.02 -0.27,0.21 -0.24,0.26 -0.06,0.18 0.07,0.29 0.13,0.33 0.32,0.47 -0.06,0.25 0.01,0.38 -0.23,0.41 -0.31,0.29 0.06,0.4 -0.13,0.32 -0.27,0.36 -0.15,0.38 0.1,0.21 0.07,0.2 -0.01,0.16 0.02,0.11 -0.08,0.07 -0.51,0.17 -0.13,0.11 z"
+         class="region MDA"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="north_macedonia"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S142P1-2"
+         d="m 318.23,315.37 0.64,0.61 0.33,0.23 0.38,0.15 0.42,0.09 0.16,0.13 0.36,0.7 0.17,0.26 0.18,0.05 0.05,0.08 0.02,0.1 -0.11,0.56 0.1,1.18 -0.04,0.1 -0.2,0.03 -0.26,0.07 -0.09,0.1 -0.02,0.65 -0.4,0.25 -0.37,0.17 -0.34,0.03 -0.59,-0.06 -0.19,0.02 -0.15,0.11 -0.51,0.12 -0.21,0.15 -0.44,0.82 -0.51,0.33 -0.16,0.16 -0.44,-0.1 -0.2,0.01 -0.26,0.23 -0.63,0.11 -0.16,0.06 -0.48,0.1 -0.04,-0.1 -0.1,-0.13 -0.24,-0.04 -0.45,0.13 -0.13,-0.1 -0.26,-0.59 -0.16,-0.08 -0.19,-0.19 -0.36,-0.64 -0.05,-0.3 -0.01,-0.26 -0.22,-0.59 0.07,-0.17 0.14,-0.11 -0.03,-0.25 -0.09,-0.37 0.09,-0.75 0.04,-0.06 0.04,0.03 h 0.42 l 0.09,-0.11 0.05,-0.15 -0.04,-0.54 0.07,-0.26 0.93,-0.61 0.28,-0.06 0.25,0.18 0.2,0.11 0.1,-0.02 0.02,-0.14 0.09,-0.29 0.18,-0.18 0.58,-0.22 h 0.01 l 0.19,-0.01 0.41,-0.18 0.24,-0.21 0.13,-0.05 0.17,-0.09 0.26,-0.03 0.26,0.03 0.32,-0.15 0.3,-0.2 0.14,0.01 0.16,0.11 z"
+         class="region MKD"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="malta"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S144P1-8"
+         d="m 292.3,348.61 -0.12,0.16 -0.38,0.01 -0.33,-0.22 -0.03,-0.49 0.38,0.08 0.36,0.31 z"
+         class="region MLT"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S144P2"
+         d="m 291.29,347.85 -0.23,0.09 -0.24,-0.13 -0.05,-0.08 0.31,-0.09 0.16,0.06 0.07,0.11 z"
+         class="region MLT"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <circle
+         r="0.25"
+         id="pointF2S30P1"
+         cy="348.50684"
+         cx="291.80273"
+         class="region MLT"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25" />
+    </g>
+    <g
+       id="montenegro"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S146P1-0"
+         d="m 306.63,311.16 v 0.06 l 0.03,0.17 0.1,0.15 0.29,0.14 0.44,0.29 0.54,0.56 0.23,0.15 0.2,0.02 0.41,0.21 0.28,0.03 0.3,0.03 0.84,0.43 0.36,0.11 0.28,0.17 0.05,0.19 v 0.12 l -0.43,0.19 -0.06,0.22 -0.22,0.01 -0.26,0.03 -0.07,0.14 0.15,0.2 0.11,0.25 -0.03,0.36 -0.01,0.05 -0.07,-0.01 -0.35,0.26 -0.26,0.13 -0.25,0.08 -0.13,-0.09 -0.07,-0.12 -0.03,-0.39 -0.06,-0.12 -0.09,-0.06 -0.16,0.12 -0.17,0.32 -0.15,0.37 -0.24,0.39 -0.19,0.38 -0.12,0.27 -0.21,0.14 -0.42,-0.01 -0.27,0.03 0.47,0.51 0.46,0.18 0.09,0.18 -0.01,0.22 0.05,0.12 -0.02,0.37 0.01,0.24 -0.59,-0.31 -0.28,-0.5 -0.89,-0.8 -0.98,-0.5 -0.05,-0.09 0.04,-0.12 0.03,-0.1 -0.19,0.02 -0.13,0.08 h -0.13 l -0.16,-0.21 -0.15,-0.19 -0.03,-0.17 0.06,-0.03 0.09,-0.08 0.17,-0.21 0.03,-0.11 -0.03,-0.15 -0.31,-0.46 -0.07,-0.31 -0.1,-0.58 0.05,-0.15 0.09,-0.08 0.46,-0.12 -0.05,-0.46 0.02,-0.14 0.07,-0.2 0.04,-0.18 0.24,-0.28 0.32,-0.34 0.15,-0.02 0.14,0.02 0.18,0.24 0.16,-0.05 0.01,-0.31 -0.26,-0.38 -0.14,-0.24 0.02,-0.15 0.07,-0.08 0.19,0.02 0.19,0.05 0.1,-0.06 0.18,-0.06 z"
+         class="region MNE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="norway"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S163P1-1"
+         d="m 263.64,232.26 -0.04,0.56 -0.21,-0.06 -0.08,-0.22 -0.02,-0.14 0.05,-0.33 -0.02,-0.34 0.07,-0.16 0.08,-0.01 0.12,0.3 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P2"
+         d="m 263.66,228.57 -0.21,0.04 -0.16,-0.06 0.09,-0.45 0.1,-0.06 0.12,-0.02 0.11,0.25 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P3"
+         d="m 271.33,218.35 h -0.21 l -0.25,-0.08 -0.15,-0.16 -0.01,-0.14 0.29,-0.15 0.29,-0.09 0.13,0.19 v 0.3 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P4"
+         d="m 272.18,216.83 -0.25,0.01 -0.14,-0.11 0.35,-0.2 0.56,-0.18 0.05,-0.13 0.07,-0.01 0.09,0.15 0.01,0.22 -0.07,0.1 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P5"
+         d="m 277.99,211.28 -0.11,0.13 -0.24,-0.1 -0.47,0.09 -0.19,-0.13 0.15,-0.25 0.42,-0.26 0.23,0.01 0.23,0.32 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P6"
+         d="m 279.4,207.72 -0.13,0.15 -0.24,-0.04 -0.03,-0.12 0.06,-0.25 0.15,-0.1 0.19,0.01 0.07,0.1 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P7"
+         d="m 280.43,206.42 -0.15,0.01 -0.01,-0.19 0.09,-0.17 0.13,-0.12 0.18,-0.04 0.21,-0.01 0.06,0.09 -0.11,0.13 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P8"
+         d="m 280.24,205.77 -0.18,0.03 0.02,-0.2 0.14,-0.2 0.05,-0.14 0.03,-0.15 0.12,-0.12 0.19,0.14 0.01,0.26 -0.08,0.23 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P9"
+         d="m 280.96,197.28 -0.26,0.26 0.08,-0.45 0.13,-0.45 0.19,-0.27 0.1,0.1 -0.04,0.22 0.01,0.21 -0.03,0.1 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P10"
+         d="m 282.49,195.43 0.11,0.07 0.27,-0.04 0.06,0.03 -0.03,0.13 -0.11,0.15 -0.25,0.1 -0.1,0.22 -0.08,0.08 -0.22,0.01 -0.13,0.05 -0.14,0.2 -0.14,-0.13 -0.03,0.1 -0.01,0.18 -0.07,0.06 -0.22,0.07 -0.07,-0.42 0.09,-0.15 0.07,-0.19 0.12,-0.03 0.11,0.01 0.18,-0.4 0.26,-0.13 0.17,-0.02 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P11"
+         d="m 284.6,192.2 0.26,0.45 0.13,0.26 -0.04,0.51 -0.2,0.27 -0.34,0.07 -0.24,-0.01 -0.16,-0.11 -0.03,-0.14 -0.09,-0.04 -0.21,0.19 -0.16,0.04 -0.21,-0.13 -0.07,-0.22 0.2,-0.29 0.08,-0.22 0.24,0.01 0.06,0.06 0.14,0.04 0.06,-0.27 -0.03,-0.17 0.05,-0.13 0.29,0.07 -0.04,-0.48 0.11,-0.04 0.05,0.01 0.09,0.1 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P12"
+         d="m 285.71,193.88 0.02,0.03 0.2,-0.46 0.25,-0.16 v -0.15 l 0.09,-0.15 -0.03,-0.24 0.03,-0.2 0.13,-0.07 0.07,-0.07 0.09,-0.04 0.18,0.14 0.11,0.17 0.16,0.38 -0.01,0.39 -0.28,0.32 -0.24,0.15 -0.22,0.37 -0.11,0.28 -0.1,0.07 -0.07,-0.01 -0.07,-0.07 -0.13,0.01 -0.12,0.25 -0.42,0.23 -0.17,-0.04 -0.03,-0.25 -0.1,0.03 -0.14,0.3 -0.15,0.11 -0.1,0.04 -0.21,-0.1 -0.49,0.52 -0.49,0.12 -0.17,-0.05 -0.02,-0.3 0.3,-0.4 0.24,-0.29 0.88,-0.24 0.49,-0.83 0.06,-0.87 0.1,-0.32 -0.07,-0.18 -0.15,-0.02 -0.03,-0.27 0.05,-0.3 0.25,-0.42 0.14,-0.19 0.21,-0.5 0.11,-0.12 0.14,-0.01 0.15,0.11 v 0.27 l -0.16,0.49 -0.27,0.42 0.06,0.29 0.15,0.23 0.07,0.4 0.04,0.39 -0.19,0.55 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P13"
+         d="m 288.18,188.92 0.24,0.24 0.08,-0.08 0.17,-0.05 0.14,0.08 0.13,0.15 0.13,-0.01 0.11,0.21 0.08,0.28 -0.07,0.21 -0.12,0.11 -0.01,0.25 0.1,0.34 -0.29,0.15 -0.34,0.09 -0.15,-0.15 -0.25,0.33 -0.22,0.49 -0.12,0.07 -0.03,-0.15 -0.21,-0.08 -0.26,0.01 v -0.11 l 0.04,-0.08 0.2,-0.14 0.02,-0.24 -0.09,-0.42 0.02,-0.21 -0.01,-0.15 0.12,-0.18 0.47,0.04 0.04,-0.17 -0.05,-0.09 -0.26,-0.16 0.03,-0.12 0.16,-0.12 0.16,-0.03 0.03,-0.18 -0.01,-0.08 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P14"
+         d="m 308.13,184.34 -0.25,0.21 -0.08,-0.09 0.01,-0.18 -0.03,-0.36 0.12,-0.02 0.17,0.1 0.15,0.12 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P15"
+         d="m 293.21,186.07 -0.07,0.11 -0.13,0.06 -0.08,-0.05 -0.11,-0.03 -0.11,0.04 -0.13,-0.18 -0.02,-0.16 0.1,-0.24 0.23,-0.16 0.22,0.02 0.07,0.06 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P16"
+         d="m 290.77,186.49 0.18,0.23 0.12,-0.04 0.02,-0.1 0.08,-0.05 0.2,0.11 0.01,0.22 -0.2,0.31 -0.12,0.42 -0.21,0.11 -0.11,-0.03 -0.17,0.25 -0.13,0.26 -0.12,0.32 0.01,0.16 -0.01,0.12 -0.6,0.19 -0.22,0.1 -0.25,-0.08 -0.14,-0.18 0.02,-0.12 0.23,-0.07 -0.01,-0.18 0.04,-0.12 0.07,-0.07 0.02,-0.24 0.09,-0.08 0.18,0.04 0.09,-0.18 0.07,-0.04 0.1,0.14 0.01,-0.2 -0.07,-0.18 0.01,-0.12 0.18,-0.34 0.06,-0.24 0.12,-0.16 0.13,0.01 0.01,-0.22 -0.07,-0.22 -0.01,-0.14 0.07,-0.36 0.12,-0.03 0.11,0.3 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P17"
+         d="m 291.48,185.71 0.09,0.05 0.08,-0.05 0.07,0.04 0.18,0.22 0.16,0.07 0.03,0.12 -0.12,0.14 -0.17,0.05 -0.19,-0.01 -0.08,-0.14 -0.1,-0.24 -0.19,-0.22 -0.06,-0.21 0.13,-0.05 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P18"
+         d="m 297.27,183.29 0.08,0.21 0.05,0.16 -0.09,0.28 -0.26,0.38 0.04,0.09 -0.1,0.1 -0.16,0.1 -0.11,-0.05 -0.05,-0.28 -0.04,-0.08 -0.11,0.14 -0.17,-0.12 -0.03,-0.15 0.01,-0.13 0.08,-0.21 0.19,-0.16 0.15,0.02 0.35,-0.58 0.07,0.1 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P19"
+         d="m 297.88,183.1 -0.25,0.23 -0.21,-0.12 -0.11,-0.14 -0.09,-0.35 -0.01,-0.22 0.11,-0.13 0.11,0.06 0.04,0.07 0.18,0.03 0.24,0.18 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P20"
+         d="m 296.73,182.16 v 0.15 l -0.02,0.14 -0.09,0.17 -0.24,0.63 -0.2,0.12 -0.05,0.11 -0.07,0.06 -0.29,-0.03 -0.06,0.13 -0.05,0.09 -0.19,0.06 h -0.12 l -0.35,-0.17 -0.22,-0.2 -0.13,-0.18 0.27,-0.04 0.09,-0.06 0.19,0.01 0.07,-0.22 0.23,-0.01 0.42,-0.21 0.18,0.04 0.27,-0.52 0.12,-0.01 0.15,-0.17 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P21"
+         d="m 303.7,181.33 0.17,0.02 0.28,-0.25 0.13,0.13 0.02,0.43 0.17,0.6 0.07,0.35 0.1,0.32 0.1,0.16 -0.08,-0.71 -0.01,-0.18 0.11,-0.3 -0.09,-0.53 -0.01,-0.66 0.1,-0.41 0.09,-0.13 0.41,-0.09 0.21,0.08 0.26,0.26 0.15,0.09 0.41,0.03 0.18,0.12 0.05,0.09 0.1,-0.01 0.16,-0.29 0.15,-0.08 0.38,0.28 0.04,0.27 0.04,0.08 0.31,-0.1 0.3,0.02 0.69,0.39 0.14,0.23 0.09,0.31 -0.61,0.53 -0.2,0.41 -0.48,0.27 -1.84,0.25 0.11,0.22 1.41,0.18 0.12,0.13 0.06,0.31 0.08,0.24 0.08,0.16 0.15,0.13 0.17,0.03 0.3,-0.12 0.18,0.04 0.07,-0.15 -0.11,-0.42 0.06,-0.12 0.21,0.07 0.24,0.42 0.06,0.03 -0.02,-0.34 0.18,-0.02 0.17,-0.08 0.26,-0.02 0.29,0.55 0.07,0.2 0.03,0.2 -0.02,0.12 -0.09,0.07 -0.28,0.06 -0.46,-0.12 -0.31,-0.14 -0.08,0.01 -0.02,0.03 0.13,0.2 0.04,0.17 0.03,0.19 0.01,0.17 -0.03,0.16 -0.09,0.22 -0.2,0.21 -0.62,0.46 -0.02,0.14 0.02,0.82 -0.03,0.13 -0.05,0.11 -0.21,0.19 -0.18,-0.14 -0.18,-0.23 -0.05,-0.26 0.13,-0.56 0.15,-0.41 0.04,-0.14 0.03,-0.39 -0.59,-0.78 -0.62,-0.13 -0.74,-0.24 -0.29,-0.16 -0.49,-0.35 -0.37,-0.33 -0.22,0.04 -0.22,0.15 -0.27,0.46 -0.17,0.23 -0.11,0.08 -0.03,0.02 -0.3,-0.04 -0.32,0.05 -0.23,0.08 -0.08,0.07 -0.18,0.67 -0.17,0.35 -0.1,0.13 -0.05,0.19 -0.01,0.3 0.09,1.03 -0.04,0.4 0.03,0.23 0.22,0.68 0.07,0.39 -0.09,0.35 -0.08,0.17 -0.15,0.06 -0.19,0.13 -0.13,0.22 -0.07,0.27 v 0.59 l -0.19,0.26 -0.25,-0.01 -0.22,-0.18 -0.4,-0.09 -0.3,-0.05 -0.35,-0.16 -0.3,-0.12 -0.25,0.01 -0.09,0.24 -0.07,0.22 -0.37,0.24 -0.21,0.17 -0.3,0.08 -0.16,-0.12 -0.46,-0.02 -0.55,-0.02 -0.16,0.03 -0.1,-0.25 -0.21,-0.33 -0.5,-0.56 -0.19,-0.19 -0.39,-0.47 -0.43,-0.47 h -0.05 l -0.22,0.01 -0.32,0.07 -0.19,0.15 -0.1,0.16 v 0.13 l 0.21,0.46 -0.01,0.12 -0.06,0.07 -0.32,-0.09 -0.36,0.06 -0.06,0.16 -0.22,0.05 -0.63,0.14 0.35,0.35 0.12,0.15 0.06,0.22 0.02,0.44 -0.07,0.38 -0.11,0.32 -0.27,0.34 0.52,0.23 -0.25,0.44 -0.13,0.17 H 293 l -0.33,-0.1 -0.8,-0.24 -0.38,-0.08 h -0.33 l -0.17,0.02 -0.72,-0.21 -0.12,0.05 -0.23,0.15 0.01,0.28 0.1,0.68 0.11,0.53 -0.05,0.31 -0.07,0.22 -0.21,0.59 -0.67,-0.32 -0.46,-0.21 -0.23,0.36 -0.63,0.68 -0.23,1.25 -0.02,0.04 -0.18,0.33 -0.26,0.17 -0.2,0.08 -0.08,0.38 0.33,0.5 0.17,0.26 0.18,0.44 0.01,0.28 -0.02,0.18 -0.27,0.39 -0.58,1 -0.53,1.05 -0.23,0.3 0.19,0.84 -0.19,0.26 -0.41,0.31 -0.21,0.13 -0.23,0.08 -0.72,0.15 0.19,0.91 0.08,0.4 0.01,0.24 -0.06,0.23 -0.06,0.46 -0.03,1.61 -0.1,0.17 -0.12,0.45 -0.41,1.07 -0.35,0.71 -0.51,1.03 0.48,0.29 0.43,0.22 0.11,0.35 0.09,0.59 0.01,0.41 -0.14,0.37 -0.11,0.26 -0.08,0.13 -0.62,-0.1 -0.78,-0.13 -0.2,0.01 -0.45,0.13 -0.4,0.25 -0.21,0.21 -0.06,0.08 -0.26,0.46 -0.46,0.82 -0.26,0.36 0.09,0.48 -0.43,0.95 0.32,0.95 0.02,0.03 0.17,0.38 -0.16,0.25 -0.07,0.13 0.03,0.44 0.06,0.49 -0.03,0.29 -0.01,0.32 0.46,1.43 v 0.34 l -0.01,0.22 -0.11,0.9 -0.14,1.21 0.32,0.31 0.45,0.37 0.26,0.14 0.38,0.45 0.3,0.43 -0.03,0.29 -0.07,0.33 -0.11,0.23 -0.1,0.31 -0.04,0.23 -0.05,0.06 -0.5,0.04 -0.27,0.1 -0.13,0.1 0.06,0.52 0.33,0.95 0.28,0.67 0.1,0.45 -0.07,0.46 -0.08,0.23 v 0.32 l -0.04,0.63 -0.2,0.32 -0.25,0.35 -0.29,0.26 -0.23,0.08 -0.2,0.04 -0.13,0.13 -0.12,0.39 -0.1,0.4 -0.37,0.51 0.02,0.17 0.15,0.59 0.15,0.67 -0.1,0.63 -0.09,0.66 -0.16,0.45 -0.25,0.16 -0.18,-0.08 -0.21,-0.6 -0.01,-0.14 -0.05,-0.18 -0.58,-0.18 -0.1,0.01 -0.23,-0.11 -0.13,-0.03 -0.27,-0.06 -0.23,-0.53 -0.24,-0.44 -0.04,-0.19 0.01,-0.83 -0.07,-0.37 -0.02,-0.4 -0.15,0.33 0.08,0.52 -0.18,0.21 -0.23,0.11 0.02,0.3 0.09,0.06 0.02,0.31 -0.05,0.47 -0.47,1.03 -0.09,0.11 -0.07,0.14 -0.23,-0.09 -0.31,0.28 -0.29,0.05 -0.1,-0.33 -0.41,-0.44 -0.19,0.02 0.17,0.22 0.17,0.28 -0.1,0.18 -0.1,0.12 -0.17,0.06 -0.6,0.35 0.21,0.25 -0.19,0.27 -0.21,0.04 -0.11,0.13 -0.04,0.17 -0.64,0.49 -1.05,1.26 -0.54,0.34 -0.39,0.37 -0.32,-0.02 -0.42,0.31 -1.05,0.24 -0.69,-0.16 -0.48,0.09 -0.25,-0.23 -0.02,-0.16 0.01,-0.08 0.05,-0.11 -0.08,-0.04 -0.19,-0.03 -0.09,0.11 -0.02,0.24 -0.09,0.06 -0.35,-0.16 -0.09,-0.13 0.15,-0.25 0.23,-0.21 -0.04,-0.05 -0.03,-0.14 -0.11,-0.02 -0.32,0.01 -0.25,-0.05 -0.81,-0.56 -0.18,-0.28 -0.64,-0.48 -0.27,-0.48 -0.13,-0.51 0.04,-0.46 0.14,-0.72 0.15,-0.17 0.58,0.3 0.58,0.46 0.09,-0.02 0.21,-0.32 0.39,-0.25 -0.1,-0.08 -0.57,0.28 -0.19,-0.18 -0.29,-0.37 0.01,-0.18 0.16,-0.16 0.07,-0.24 -0.07,-0.23 0.06,-0.31 0.27,-0.31 0.38,-0.31 0.28,-0.31 0.28,-0.18 -0.03,-0.07 -0.31,0.11 -0.3,0.2 -0.37,0.33 -0.44,0.27 -0.32,0.09 -0.15,0.08 -0.24,0.08 -0.27,0.39 -0.27,0.16 -0.46,-0.01 -0.08,-0.31 0.22,-1.07 0.18,-0.51 0.18,-0.36 0.24,-0.05 0.19,-0.26 0.14,0.01 0.11,0.14 0.46,0.15 0.25,-0.33 0.3,-0.04 0.57,-0.31 -0.01,-0.07 -0.37,0.06 h -0.22 l -0.33,0.06 -0.16,-0.07 -0.07,-0.27 0.15,-0.22 0.55,-0.53 0.19,-0.24 0.12,-0.22 -0.01,-0.16 0.11,-0.32 0.53,-0.53 0.41,-0.24 0.12,0.23 -0.15,0.69 -0.02,0.29 0.38,-1 0.15,-0.24 0.17,-0.16 0.39,-0.09 0.12,-0.16 -0.45,0.03 -1.11,0.33 -0.48,0.32 -0.14,0.26 -0.34,0.38 -0.17,0.25 -0.09,0.38 -0.2,0.19 -0.25,0.06 -0.38,0.46 -0.18,0.38 -0.36,0.29 -0.23,0.22 -0.08,0.08 -0.14,0.23 -0.1,0.01 -0.07,-0.15 0.01,-0.3 0.08,-0.48 0.19,-0.33 0.1,-0.34 -0.08,-0.32 0.09,-0.2 0.14,0.02 0.26,0.11 0.28,0.01 0.48,-0.22 -0.06,-0.15 -0.2,-0.04 h -0.37 l -0.29,-0.27 -0.21,-0.5 -0.05,-0.66 0.09,-0.18 0.94,-0.6 0.26,-0.28 -0.14,-0.04 -0.36,0.34 -0.49,0.2 -0.28,-0.34 -0.13,-0.35 -0.03,-0.72 0.07,-0.36 v -0.49 l 0.22,-0.14 0.21,0.1 0.22,0.05 0.51,-0.01 1.13,-0.22 0.7,0.22 h 0.29 l 0.46,-0.23 h 0.39 l 0.28,0.2 0.15,0.23 v 0.29 l 0.12,0.2 0.1,-0.06 -0.06,-0.23 v -0.36 l 1.19,-0.35 0.14,-0.16 -0.46,-0.07 -0.11,-0.38 0.27,-0.55 -0.02,-0.07 -0.27,0.29 -0.15,0.41 0.04,0.33 -0.06,0.15 -0.24,0.06 h -0.54 l -0.33,-0.15 -0.31,-0.1 -0.1,-0.11 0.05,-0.23 -0.06,-0.06 -0.14,0.21 -0.15,0.42 -0.26,0.08 -0.68,-0.2 -1.01,0.03 -0.47,0.19 -0.29,-0.05 -0.47,-0.41 -0.17,-0.31 -0.02,-0.61 0.05,-0.26 0.39,-0.08 0.2,0.02 0.2,-0.13 -0.16,-0.1 -0.21,-0.2 -0.13,-0.37 -0.22,-0.14 -0.13,-0.32 v -0.46 l 0.07,-0.32 0.14,-0.1 0.29,0.09 0.79,0.01 0.71,0.37 0.49,0.22 1.03,-0.03 0.61,-0.26 -0.1,-0.09 -0.66,0.13 -0.6,-0.04 -1.03,-0.4 -0.42,-0.13 -0.47,0.01 -0.23,-0.11 -0.11,-0.34 0.16,-0.62 0.22,-0.12 0.11,0.17 0.14,0.02 0.17,-0.25 0.15,-0.14 0.13,-0.33 0.44,-0.29 0.17,-0.02 0.26,-0.13 0.16,0.05 0.09,0.16 0.12,0.13 h 0.28 l 0.84,-0.21 0.09,-0.07 0.17,-0.2 -0.52,0.06 -0.45,0.13 -0.28,0.02 -0.02,-0.19 0.11,-0.16 0.17,-0.16 0.1,-0.3 0.19,-0.12 0.19,0.02 0.39,-0.03 0.29,-0.07 0.47,0.08 0.71,0.15 0.44,0.3 0.18,-0.02 0.18,-0.07 0.09,-0.1 -0.36,-0.13 -0.01,-0.16 0.05,-0.13 0.6,-0.2 0.64,-0.03 -0.1,-0.19 -1.41,0.23 -0.36,-0.21 -0.29,-0.01 -0.19,0.1 -0.55,0.1 -0.09,-0.1 0.12,-0.31 0.35,-0.52 0.04,-0.13 0.15,-0.12 0.85,-0.27 0.41,-0.34 0.18,-0.04 0.18,0.03 0.27,-0.03 0.51,0.12 0.23,0.46 0.21,0.14 0.66,0.58 -0.02,-0.16 -0.57,-0.77 -0.21,-0.2 -0.16,-0.38 0.07,-0.35 0.2,-0.22 0.67,-0.11 0.12,-0.13 0.02,-0.24 -0.1,-0.16 h -0.24 l -0.2,-0.1 -0.05,-0.25 0.09,-0.17 0.39,-0.3 0.21,-0.1 0.36,-0.1 0.62,0.26 0.05,0.13 -0.18,0.31 0.01,0.17 0.15,0.02 0.37,-0.51 0.42,-0.07 0.18,-0.11 0.2,-0.07 0.29,0.48 0.12,0.15 0.1,0.06 0.09,0.39 0.09,0.03 0.12,-0.2 0.24,-0.1 0.32,-0.07 0.54,0.1 0.24,-0.07 0.12,0.01 -0.11,-0.35 -0.07,-0.11 0.11,-0.31 0.11,-0.12 0.37,-0.22 0.35,-0.11 0.22,-0.21 0.31,-0.19 -0.05,-0.16 -0.09,-0.17 -0.2,-0.01 -0.08,-0.1 0.25,-0.23 0.34,-0.26 -0.06,-0.1 -0.26,-0.11 -0.2,0.09 -0.28,0.2 -0.34,0.31 0.11,0.09 0.17,0.27 -0.23,0.35 -1.27,0.93 -0.61,0.27 -0.28,-0.04 -0.06,-0.26 -0.13,-0.19 -0.13,-0.39 -0.24,0.01 -0.13,0.09 -0.06,-0.13 0.11,-0.42 0.2,-0.32 0.33,-0.25 0.16,-0.29 0.16,-0.48 0.47,-0.45 0.69,-1.11 0.56,-0.36 0.2,-0.39 0.32,-0.17 0.27,-0.31 0.22,-0.03 0.39,-0.28 0.22,-0.33 -0.15,-0.01 -0.34,0.21 -0.19,0.09 0.01,-0.35 0.08,-0.36 0.28,-0.33 1.34,-0.97 0.14,0.16 0.17,0.27 0.4,-0.07 0.45,-0.55 0.33,-0.59 -0.19,0.1 -0.2,0.25 -0.4,0.34 -0.18,0.06 -0.11,-0.04 -0.07,-0.22 -0.14,-0.07 -0.13,0.05 -0.14,-0.15 -0.03,-0.39 0.15,-0.58 0.12,-0.38 0.14,-0.29 0.53,-0.84 0.1,-0.44 0.24,-0.25 0.33,0.04 0.1,-0.07 -0.13,-0.28 -0.36,-0.22 -0.03,-0.15 1.16,-0.42 0.56,-0.01 0.15,-0.2 0.29,-0.13 0.22,-0.25 -0.12,-0.09 -0.55,0.23 -0.35,0.12 h -0.16 l -0.12,0.08 -0.45,0.05 -0.14,-0.93 0.05,-0.5 h 0.17 l 0.01,-0.48 0.18,-0.29 0.26,-0.07 0.13,-0.13 0.17,-0.25 0.32,0.04 0.32,-0.07 -0.08,-0.11 -0.41,-0.13 -0.12,-0.25 0.14,-0.15 0.15,-0.11 0.13,-0.03 0.24,-0.51 0.15,-0.22 0.18,0.03 0.23,-0.23 0.26,0.06 0.22,-0.16 0.32,-0.11 1.19,-0.11 0.01,-0.21 -0.25,-0.03 h -0.88 l -0.45,0.03 -0.19,0.07 -0.07,-0.07 v -0.12 l 0.15,-0.2 0.07,-0.22 0.28,-0.54 0.36,-0.37 0.29,0.07 0.34,0.31 0.22,0.03 0.11,0.1 0.2,0.44 0.08,0.01 -0.07,-0.43 0.18,-0.37 -0.06,-0.1 -0.31,0.15 -0.26,-0.11 -0.21,-0.26 -0.07,-0.24 0.09,-0.25 0.11,-0.13 -0.09,-0.13 -0.45,0.41 -0.33,0.1 -0.14,-0.04 0.05,-0.35 -0.06,-0.27 0.4,-0.7 0.15,-0.09 0.25,0.04 0.25,0.18 0.18,-0.05 0.2,-0.11 -0.04,-0.18 -0.45,-0.04 -0.13,-0.15 0.03,-0.15 0.29,-0.17 0.28,-0.31 0.34,-0.1 0.26,-0.24 0.05,0.05 0.06,0.08 0.17,0.78 0.32,0.63 0.09,0.01 -0.15,-0.54 0.07,-0.16 0.11,-0.13 0.02,-0.14 -0.14,-0.04 -0.12,-0.18 -0.21,-0.62 0.03,-0.16 0.29,-0.36 0.4,-0.11 0.46,0.19 0.15,-0.01 0.25,-0.08 0.4,-0.23 0.24,-0.1 0.13,-0.01 0.02,-0.1 -0.13,-0.05 -0.04,-0.06 -0.1,-0.02 -0.38,0.14 -1.09,0.06 -0.11,-0.1 -0.04,-0.19 0.09,-0.29 0.11,-0.16 0.37,-0.3 0.42,-0.08 0.4,-0.52 0.12,-0.38 0.03,-0.56 0.22,-0.48 0.64,-0.32 0.01,-0.12 -0.1,-0.22 -0.05,-0.42 0.12,-0.51 0.1,-0.18 0.05,-0.03 0.16,0.14 0.22,0.32 0.3,0.17 0.37,-0.01 0.08,-0.11 -0.31,-0.16 -0.24,-0.23 -0.06,-0.25 0.08,-0.14 0.16,-0.01 0.19,-0.05 0.15,-0.19 0.01,-0.12 -0.01,-0.17 0.02,-0.17 0.2,-0.42 0.76,-0.36 0.08,0.1 0.07,0.77 -0.01,0.5 0.06,0.36 0.1,-0.38 0.05,-1.01 0.08,-0.48 0.14,-0.29 0.11,-0.08 0.11,-0.15 0.15,-0.1 0.06,0.09 0.1,0.24 0.06,0.87 0.05,0.27 -0.04,0.38 -0.25,0.86 0.04,0.1 0.08,-0.05 0.13,-0.15 0.34,-0.84 0.44,0.04 -0.01,-0.06 -0.17,-0.21 -0.2,-0.19 -0.1,-0.26 -0.1,-0.72 0.07,-0.3 0.36,-0.02 0.21,-0.07 0.12,0.12 0.21,-0.04 0.05,-0.54 0.28,-0.08 0.32,0.29 0.35,0.18 0.31,0.29 0.05,-0.1 -0.28,-0.74 -0.2,-0.25 -0.34,-0.1 -0.4,-0.29 -0.11,-0.14 -0.01,-0.11 0.27,-0.15 0.41,0.06 0.29,-0.34 0.1,0.07 0.24,-0.19 0.2,0.17 0.09,-0.07 v -0.28 l 0.38,-0.24 0.3,0.11 0.17,0.14 0.13,0.29 0.24,0.58 0.28,0.29 0.16,0.14 0.17,0.01 0.03,-0.17 -0.18,-0.17 -0.08,-0.18 -0.04,-0.47 0.04,-0.19 0.29,-0.76 0.29,-0.41 0.21,-0.07 0.19,-0.86 0.08,-0.16 0.09,-0.06 -0.07,-0.18 -0.24,-0.08 -0.07,-0.24 0.2,-0.34 0.21,-0.55 0.16,-0.06 0.13,0.11 0.38,0.16 0.26,0.21 0.17,0.09 0.09,-0.04 0.03,-0.21 0.06,-0.1 h 0.22 l 0.15,0.1 h 0.1 l 0.11,0.05 0.06,0.16 -0.13,0.21 -0.18,0.52 -0.16,0.59 -0.02,0.3 0.09,0.75 -0.12,0.52 0.06,0.33 0.14,0.13 0.23,-0.17 0.22,-0.51 -0.05,-0.48 0.47,-1.42 0.18,-0.77 0.25,-0.67 0.2,-0.17 0.22,0.36 0.05,0.51 -0.08,0.36 0.17,0.11 0.08,0.38 0.02,0.22 0.03,0.22 0.06,0.19 0.11,-0.08 0.39,-0.5 v -0.46 l 0.02,-0.34 -0.03,-0.29 0.11,-0.31 0.36,-0.08 -0.02,-0.11 -0.54,-0.26 -0.1,-0.15 0.08,-0.25 0.27,-0.5 0.22,-0.01 0.15,0.07 0.51,-0.05 0.47,0.2 0.13,0.47 -0.02,0.21 -0.05,0.14 -0.37,0.47 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P22"
+         d="m 299.63,180.09 0.45,0.08 0.13,-0.03 0.29,0.27 0.09,-0.05 0.04,0.2 -0.18,0.13 -0.3,0.12 -0.04,0.05 -0.27,0.03 -0.22,-0.23 -0.27,-0.01 -0.02,-0.08 0.11,-0.23 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S163P23"
+         d="m 246.43,179.83 -0.14,-0.01 -0.05,-0.12 0.29,-0.21 0.83,-0.31 0.42,-0.41 0.56,-0.03 -0.05,0.28 -0.15,0.31 -0.53,0.15 -0.55,0.04 z"
+         class="region NOR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <circle
+         r="0.25"
+         id="pointF2S53P1"
+         cy="179.2318"
+         cx="247.51036"
+         class="region NOR"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="poland"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S175P1-0"
+         d="m 301.79,259.05 0.12,0.05 0.78,-0.04 0.79,-0.04 1.26,-0.1 1.32,-0.12 1.37,-0.13 1.47,-0.15 1.55,-0.21 0.09,-0.05 0.13,-0.21 0.19,-0.01 0.25,0.08 0.12,0.07 0.06,0.08 0.05,0.11 h 0.13 l 0.24,0.05 0.34,0.14 0.28,0.14 0.27,0.23 0.14,0.29 0.06,0.35 0.03,0.22 0.04,0.09 0.61,1.55 0.82,1.45 0.34,0.71 0.15,0.39 0.17,0.56 0.1,0.4 0.04,0.23 0.02,0.33 -0.13,0.21 -0.94,0.72 -0.16,0.2 -0.24,0.47 -0.2,0.48 -0.04,0.16 v 0.1 l 0.08,0.13 0.42,0.16 0.41,0.12 0.14,0.11 0.31,0.13 0.13,0.14 0.08,0.13 0.06,0.31 -0.05,0.47 0.12,0.32 -0.09,0.25 -0.06,0.26 0.06,0.44 0.28,0.44 0.21,0.3 0.11,0.24 -0.03,0.21 0.06,0.2 0.17,0.19 0.57,0.57 0.33,0.59 0.19,0.22 0.38,0.26 0.05,0.12 -0.11,0.15 -0.1,0.03 -0.08,0.05 -0.03,0.12 0.11,0.11 0.14,0.15 0.24,0.48 0.06,0.41 -0.09,0.12 -0.1,0.27 -0.05,0.24 -0.75,0.3 -0.15,0.27 -0.34,0.54 -0.25,0.31 -0.35,0.56 -0.55,0.94 -0.19,0.39 -0.14,0.31 -0.44,0.86 -0.12,0.34 0.08,0.26 0.28,0.58 0.08,0.27 0.01,0.27 -0.02,0.24 0.03,0.1 0.19,0.13 0.31,0.22 0.03,0.08 -0.02,0.12 -0.08,0.1 -0.35,-0.03 -0.4,-0.11 -0.12,0.04 -0.21,-0.01 -0.88,-0.2 -0.61,-0.18 -0.08,-0.17 -0.14,-0.23 -0.27,-0.17 -0.57,-0.1 -0.25,-0.11 -0.9,0.05 -0.38,0.06 -0.27,0.1 -0.17,0.02 -0.19,0.4 -0.15,0.14 -0.24,0.04 -0.22,-0.03 -0.24,-0.17 -0.37,-0.05 -0.24,0.08 -0.19,-0.02 -0.16,0.01 -0.05,0.05 -0.13,0.01 -0.17,0.12 -0.19,0.16 -0.21,0.13 -0.15,0.24 -0.1,0.45 -0.46,-0.13 -0.14,0.1 -0.19,0.08 -0.15,-0.04 0.01,-0.15 0.05,-0.18 -0.04,-0.23 -0.07,-0.25 -0.14,-0.06 -0.21,-0.01 -0.11,-0.03 -0.02,-0.09 -0.12,-0.09 -0.21,-0.26 -0.21,-0.32 -0.13,-0.08 -0.15,0.18 -0.24,0.22 -0.15,0.08 -0.25,0.57 -0.56,0.08 -0.06,-0.24 -0.09,-0.23 -0.33,-0.03 -0.02,-0.14 -0.11,-0.34 -0.73,-0.61 -0.11,-0.28 0.01,-0.11 -0.06,-0.18 -0.15,-0.1 -0.53,-0.07 -0.13,0.09 -0.12,-0.07 -0.21,-0.14 -0.34,-0.1 -0.04,-0.07 -0.13,-0.1 -0.06,-0.01 -0.04,0.08 -0.08,0.11 -0.32,0.16 -0.14,-0.04 -0.13,-0.1 -0.16,-0.23 -0.22,-0.19 -0.18,-0.06 -0.1,-0.1 -0.03,-0.08 0.35,-0.21 0.06,-0.18 -0.08,-0.32 -0.06,-0.04 -0.13,0.12 -0.29,0.13 -0.28,0.07 -0.15,0.02 -0.85,-0.52 -0.54,-0.13 -0.31,-0.03 -0.03,0.06 0.17,0.32 0.28,0.39 V 280 l -0.28,0.19 -0.16,0.09 -0.18,0.16 -0.14,0.21 -0.14,0.1 -0.12,-0.01 -0.14,-0.09 -0.38,-0.57 -0.46,-0.43 -0.05,-0.1 -0.14,-0.02 -0.19,-0.09 -0.07,-0.14 0.08,-0.15 0.12,-0.15 0.21,-0.1 0.07,-0.08 0.03,-0.12 0.07,-0.16 -0.03,-0.06 -0.17,-0.16 -0.25,-0.14 -0.64,0.17 -0.18,0.1 -0.11,-0.1 -0.09,-0.17 -0.16,-0.02 -0.24,-0.13 -0.28,-0.13 -0.26,-0.03 -0.56,-0.17 h -0.21 l -0.13,-0.07 -0.14,-0.15 -0.12,-0.17 -0.08,-0.36 -0.41,-0.14 -0.4,-0.08 -0.02,0.06 0.03,0.36 -0.01,0.2 -0.25,0.13 -0.26,0.03 0.01,-0.06 0.27,-0.68 0.12,-0.42 0.11,-0.76 -0.23,-0.59 -0.07,-0.27 -0.09,-0.13 -0.56,-0.26 -0.05,-0.1 0.06,-0.4 -0.05,-0.16 -0.14,-0.17 -0.19,-0.34 -0.08,-0.29 0.2,-0.36 0.04,-0.26 0.07,-0.35 0.06,-0.2 0.01,-0.05 -0.15,-0.13 -0.05,-0.19 0.02,-0.27 -0.08,-0.2 -0.2,-0.12 -0.13,-0.17 -0.07,-0.22 0.02,-0.34 0.12,-0.48 -0.33,-0.54 -0.8,-0.62 -0.38,-0.44 0.02,-0.26 0.14,-0.25 0.28,-0.22 0.19,-0.39 0.1,-0.46 v -0.08 l -0.01,-0.32 -0.4,-1.29 -0.07,-0.33 -0.06,-0.39 -0.03,-0.1 0.66,0.24 0.28,0.14 -0.04,-0.17 -0.06,-0.15 0.02,-0.23 -0.04,-0.33 -0.59,-0.14 -0.39,-0.03 -0.06,-0.23 0.03,-0.15 0.11,0.08 0.38,0.01 0.91,-0.5 1.57,-0.68 1.67,-0.66 0.4,-0.09 0.39,-0.15 0.13,-0.21 0.14,-0.15 0.2,-0.38 0.46,-0.6 0.88,-0.28 0.31,-0.29 0.67,-0.43 1.56,-0.57 0.65,-0.16 0.65,-0.08 0.62,0.26 0.66,0.34 0.14,0.23 -0.35,-0.12 -0.53,-0.31 -0.18,0.01 0.54,1.06 0.28,0.36 0.49,0.24 0.4,0.06 1.17,-0.32 0.39,-0.29 z"
+         class="region POL"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="portugal"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S178P9"
+         d="m 210.88,312.68 0.06,0.05 0.2,0.04 0.39,-0.08 0.27,-0.08 0.07,0.08 0.71,0.09 0.15,0.11 0.09,0.1 0.32,0.19 0.37,0.11 0.49,-0.03 0.23,-0.09 0.07,-0.15 0.03,-0.12 0.08,-0.06 0.11,-0.02 0.15,0.12 0.22,0.12 0.56,0.16 0.12,-0.06 0.19,0.08 0.23,0.17 0.3,0.03 0.12,0.17 0.02,0.2 -0.06,0.39 -0.1,0.39 0.02,0.16 0.19,0.09 0.32,0.07 0.27,0.17 0.18,0.24 0.04,0.21 0.01,0.14 -0.13,0.05 -0.21,0.24 -0.46,0.28 -0.63,0.2 -0.51,0.31 -0.4,0.42 -0.41,0.12 -0.14,0.08 -0.07,0.12 0.12,0.67 -0.02,0.48 -0.05,0.58 -0.07,0.16 -0.15,0.62 -0.09,0.17 -0.02,0.15 0.06,0.18 0.01,0.16 -0.21,0.16 -0.36,0.15 -0.27,0.14 -0.1,0.17 -0.01,0.12 0.31,0.49 0.04,0.18 -0.13,0.38 -0.35,0.58 -0.3,0.33 -0.04,0.03 -0.27,0.05 -1.19,-0.29 -0.3,0.02 0.02,0.08 0.18,0.57 0.24,0.34 0.08,0.08 -0.01,0.61 0.28,1.05 0.43,0.24 0.12,0.27 -0.1,0.32 -0.21,0.33 -0.35,0.29 -0.39,0.18 -0.27,0.2 -0.08,0.29 -0.15,0.36 -0.16,0.28 -0.07,0.19 0.6,1.48 0.48,0.05 0.06,0.05 -0.14,0.28 -0.22,0.31 -0.19,0.03 h -0.43 l -0.48,0.36 -0.42,0.47 -0.28,0.21 -0.35,0.59 -0.03,0.29 0.02,0.46 v 1.19 l -0.33,-0.03 -1.38,0.42 -0.39,-0.09 -0.65,-0.52 -1.24,-0.43 -0.39,-0.21 -0.55,0.07 -0.4,-0.11 -0.37,0.18 -0.21,-0.13 0.39,-0.54 0.66,-1.09 0.14,-0.73 0.23,-0.62 0.03,-0.66 -0.12,-0.45 0.49,-0.94 0.09,-0.54 -0.11,-0.74 0.74,0.31 -0.18,-0.33 -0.2,-0.22 -0.23,-0.03 -0.18,-0.06 -0.7,0.08 -0.34,-0.01 -0.08,-0.07 0.12,-0.4 -0.04,-0.58 0.28,-0.07 0.31,0.04 0.31,-0.16 0.21,-0.21 0.02,-0.48 0.31,-0.37 0.6,-0.23 -0.28,-0.01 -0.36,0.14 -0.66,0.69 -0.25,0.38 -0.44,0.02 -0.39,-0.04 -0.17,-0.09 -0.21,-0.17 0.05,-0.32 0.08,-0.24 0.26,-0.44 0.22,-0.68 0.35,-0.56 0.02,-0.17 v -0.26 l 0.24,-0.19 0.28,-0.09 0.48,-0.43 0.79,-1.13 0.88,-1.19 -0.01,-0.18 -0.1,-0.16 0.13,-0.35 0.7,-1.49 0.19,-0.17 0.27,-0.42 0.2,-0.75 0.18,-0.5 0.05,-0.26 0.02,-0.33 -0.08,-0.66 0.06,-1.32 0.07,-0.43 0.24,-0.16 -0.3,-0.12 -0.08,-0.31 0.11,-0.3 0.45,-0.41 0.39,-0.22 0.36,-0.12 0.19,-0.03 0.78,-0.02 0.21,-0.05 0.18,0.07 v 0.1 l 0.06,0.23 0.09,0.16 0.01,0.11 -0.38,0.35 -0.07,0.13 0.09,0.31 z"
+         class="region PRT"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="romania"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S183P1-5"
+         d="m 335.19,296.68 0.44,0.4 0.49,0.15 1.06,0.01 0.08,-0.05 v -0.05 l -0.09,-0.06 -0.03,-0.08 0.02,-0.13 0.14,-0.04 0.24,0.04 0.4,-0.25 0.53,-0.55 0.56,-0.23 0.58,0.09 0.33,0.19 0.23,0.21 0.02,0.32 0.02,0.2 0.05,0.83 -0.02,0.33 -0.08,0.37 -1.55,0.83 0.06,-0.22 -0.11,-0.32 -0.13,-0.24 0.1,-0.26 -0.39,0.01 -0.13,0.17 -0.08,0.25 0.23,0.47 -0.11,0.33 -0.04,0.17 0.08,0.37 -0.07,0.19 0.02,0.18 0.25,-0.11 -0.05,0.34 -0.35,0.74 -0.1,0.41 0.37,1.44 -0.03,0.92 0.04,0.26 -0.53,0.14 -0.17,0.02 h -0.53 l -0.62,-0.09 -0.43,-0.37 -0.28,-0.26 -0.45,0.26 -0.1,-0.02 -0.16,-0.12 -0.39,-0.02 -0.44,0.11 -1.13,-0.35 -0.13,-0.08 -0.77,0.28 -1.13,0.56 -0.84,0.56 -0.82,0.84 -0.29,0.57 -0.39,0.35 -0.6,0.32 -1.15,0.17 -1.22,-0.01 -1.32,-0.01 -0.66,0.27 -0.95,0.07 -1.45,-0.06 -1.06,0.09 -1,0.37 -0.2,-0.11 -0.06,-0.16 v -0.24 l 0.12,-0.21 0.23,-0.18 0.11,-0.16 -0.01,-0.15 -0.31,-0.19 -0.63,-0.22 -0.26,-0.16 -0.07,-0.04 -0.04,-0.17 -0.14,-0.13 -0.24,-0.06 -0.2,-0.16 -0.16,-0.25 -0.01,-0.26 0.14,-0.27 0.2,-0.14 0.28,-0.01 0.1,-0.09 -0.07,-0.16 -0.3,-0.17 -0.52,-0.18 -0.47,0.23 -0.42,0.62 -0.35,0.15 -0.27,-0.34 -0.43,-0.15 -0.57,0.02 -0.37,-0.09 -0.16,-0.19 -0.27,-0.13 -0.57,-0.09 -0.03,-0.16 0.09,-0.05 0.19,-0.05 0.25,-0.07 0.03,-0.1 -0.01,-0.09 -0.22,-0.08 -0.21,-0.04 -0.12,-0.06 -0.08,-0.07 -0.03,-0.08 0.06,-0.07 0.08,-0.02 0.07,-0.06 0.02,-0.21 0.09,-0.18 0.07,-0.07 -0.02,-0.12 -0.1,-0.1 -0.12,-0.08 -0.18,-0.04 -0.54,-0.09 -0.29,-0.2 -0.16,0.01 -0.27,-0.09 -0.3,-0.17 -0.27,-0.26 -0.28,-0.16 -0.08,-0.06 -0.01,-0.08 0.03,-0.09 -0.01,-0.09 -0.1,-0.28 v -0.31 l -0.05,-0.28 -0.02,-0.13 -0.05,-0.03 -0.04,0.05 -0.05,0.06 -0.06,0.02 -0.22,-0.18 -0.29,-0.4 -0.18,-0.12 -0.33,-0.15 -0.28,-0.13 -0.24,-0.33 -0.22,-0.25 0.11,-0.13 0.72,-0.27 0.37,0.12 0.15,-0.08 0.13,-0.15 0.07,-0.12 v -0.11 l 0.06,-0.15 0.24,-0.1 0.67,-0.01 0.25,-0.23 0.08,-0.11 0.03,-0.24 0.04,-0.2 0.23,-0.13 -0.03,-0.17 -0.06,-0.17 0.08,-0.43 0.06,-0.18 0.13,-0.08 0.14,-0.16 0.24,-0.31 -0.1,-0.22 0.03,-0.18 0.23,-0.46 0.17,-0.44 -0.04,-0.2 0.01,-0.18 0.17,-0.23 0.16,-0.28 0.16,-0.83 0.07,-0.15 0.16,-0.18 0.1,-0.17 -0.06,-0.52 0.1,-0.17 0.21,-0.2 0.19,-0.31 0.14,-0.35 0.12,-0.17 0.19,-0.07 0.19,-0.16 0.22,-0.08 0.24,0.02 0.14,-0.06 0.19,-0.19 0.46,-0.67 0.06,-0.13 0.1,-0.1 0.41,-0.28 0.08,-0.22 0.12,-0.21 0.2,-0.02 0.72,0.33 0.68,-0.15 0.13,-0.01 0.05,0.01 0.09,0.02 0.95,0.05 0.14,-0.05 0.03,-0.03 0.41,0.12 0.32,-0.09 0.28,-0.19 0.32,-0.1 0.31,0.02 0.27,0.21 0.68,0.43 0.22,0.17 0.26,-0.09 0.27,-0.16 0.23,-0.42 0.84,-0.6 0.68,-0.25 0.65,-0.31 0.76,-0.29 0.16,-0.39 0.08,-0.25 v -0.45 l 0.39,-0.21 0.38,-0.18 0.13,-0.08 0.29,-0.09 0.24,-0.01 0.39,0.13 0.3,0.2 0.14,0.19 0.28,0.24 0.31,0.37 0.36,0.49 0.11,0.27 0.16,0.27 0.26,0.33 0.44,0.32 0.07,0.06 0.22,0.25 0.44,0.56 0.32,0.19 0.28,0.22 0.17,0.25 0.22,0.21 0.45,0.24 0.37,0.23 0.44,0.81 0.26,0.36 0.18,0.27 0.09,0.63 0.13,0.25 -0.03,0.52 -0.04,1.04 0.11,0.78 0.14,0.41 0.07,0.27 0.1,0.15 0.15,0.34 0.08,0.3 -0.08,0.11 -0.11,0.11 -0.04,0.07 0.15,0.11 0.22,0.22 z"
+         class="region ROU"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="russia"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="path15293"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         d="m 1132.7969,-60.353516 c -3.228,0.04956 -5.2894,1.677172 -2.5332,6.339844 l 1.0175,2.904297 -1.8886,-0.943359 -0.291,11.476562 -0.7266,4.501953 -0.6172,0.34961 -1.5058,0.810547 -3.8028,0.792968 v 0.002 l -0.027,0.0059 -3.1953,2.326172 -1.7735,0.689453 -0.8594,0.302734 -0.7929,1.109375 -0.5645,2.488281 -0.2226,0.929688 -1.4766,1.425781 -0.5859,0.541016 v 0.02734 l -0.039,0.03906 -0.4375,4.140625 0.01,0.06836 v 0.01758 l 0.3145,4.259765 3.3086,4.882813 -0.2149,0.375 -0.7187,1.0781246 -1.2774,-0.40625 -2.1445,-0.7597656 h -1.2363 l -0.3125,0.9394531 -0.076,0.1777344 -0.5039,0.53125 -0.7832,0.7832031 -1.1094,1.109375 -0.4434,1.6289063 -0.033,0.1152343 -0.6328,0.3144532 -4.4336,1.9003906 -0.9511,0.9511719 -0.01,0.00391 -1.5664,0.625 -0.6211,-1.3808593 -0.059,-0.3183594 -0.1191,-0.8300782 0.5527,-0.859375 0.9336,-1.3339843 0.2187,-1.046875 0.1914,-0.7070313 1.6954,-0.4238281 -0.01,-0.048828 0.057,-0.015625 -0.1738,-1.1289063 -0.094,-0.914062 -2.3965,-2.542969 -0.459,-0.19336 -3.1953,-1.388671 -0.9219,-2.41211 -0.8242,-1.53125 -0.6465,-1.291015 v -0.396485 l 0.018,-0.123047 -0.291,-1.162109 -0.031,-0.0098 -0.012,-0.05078 -0.9961,-0.285156 -0.051,-0.01758 v 0.002 l -0.059,-0.01758 -1.2676,0.476562 -0.625,-0.626953 0.064,-0.226562 0.2441,-0.730469 1.625,-1.978516 2.0547,-2.417969 0.4375,-1.453124 v 0.002 -0.01367 l -1.6406,0.949219 -1.4102,0.80664 -3.2695,2.759766 -1.5078,4.148437 -0.25,0.681641 -0.1934,0.695312 -2.5527,8.9296878 -0.2402,2.6132812 -0.3399,2.9667969 0.074,-0.074219 v 0.013672 l 0.7988,-0.6542969 0.8555,-0.171875 0.6504,-0.064453 0.6836,0.3789063 2.0957,1.2382812 0.5371,0.033203 0.6426,0.091797 0.7734,1.8554688 -0.7871,2.05859372 -0.1445,0.36328126 v 0.0175781 0.009766 l -0.072,1.38085942 -0.4356,0.7988281 -0.873,0.1445313 -1.2344,-0.1445313 -0.5078,-1.453125 -0.291,-1.52539064 -0.066,-0.01757812 v -0.0039063 l -0.1836,-0.04882813 -2.8731,-0.80078125 -0.7871,0.19726563 -0.1152,0.0195312 -0.1973,0.19726563 -0.2812,0.24023437 -0.5449,0.98828126 -1.8282,3.16601565 -0.8339,2.984375 -0.2793,0.9238281 -0.9571,1.5410157 -0.7793,1.203125 -0.2148,0.214843 -1.752,1.689454 -0.7168,1.71875 -0.01,0.02148 v 0.002 l -0.793,4.589844 -0.6719,2.021484 -0.1328,0.363281 -0.8008,4.9375 -2.7109,7.177735 -1.2188,3.21875 -1.7343,1.734375 -1.4532,0.291016 -0.7304,-0.109376 -0.6836,-0.152343 -0.01,0.04687 -0.033,-0.0039 -0.1445,1.017578 0.029,0.01563 v 0.0332 l 1.584,0.791015 3.125,2.03125 0.25,0.71875 0.2675,0.892579 -2.0586,0.792968 v 0.002 l -0.068,0.02539 -2.9785,3.630859 -2.9687,4.417969 -0.01,0.01367 0.7344,0.955078 0.6992,0.933594 1.4258,1.583984 0.6055,1.513672 0.6035,1.695313 0.7988,2.6875 3.8496,6.972656 0.7852,2.210937 -0.1797,0.572266 -0.6778,1.867188 -6.8281,8.0625 -0.4004,0.300781 -1.0898,0.724609 -0.3067,0.921875 -0.8183,-0.205078 -2.1055,0.21875 -1.0469,0.570313 -1.4257,0.71289 -1.1075,0.316406 -1.9004,-0.474609 -3.3261,-2.058594 -5.7032,-4.435547 h -0.012 l -0.01,-0.0059 -6.5371,-0.363281 -2.6387,-0.5625 -0.7852,-0.177735 -0.072,-0.07227 -1.4434,-1.511719 -0.4922,-1.378906 -0.209,-0.679688 0.2285,-2.519531 0.6172,-6.171875 0.1739,-1.398437 0.2461,-1.472657 2.4257,-2.425781 3.3282,-3.203125 2.0429,-1.304687 0.5977,-0.351563 2.3769,-2.216797 -0.8066,-1.109375 -1.668,-2.425781 -5.5195,-2.6875 -6.1016,-3.341797 -3.9199,-2.386719 -2.418,-1.511718 -2.4785,0.154296 -2.6601,0.113282 -5.1582,1.597656 -3.6211,2.492187 -5.2461,3.560547 -0.7481,0.300782 -0.7714,0.255859 -8.42583,-0.726563 -0.0273,0.01172 h -0.006 l -0.0566,0.0293 -0.5625,0.25 -0.26172,0.236328 -0.54492,0.435547 0.95117,0.949219 0.94922,0.634765 13.30468,3.958985 1.584,1.90039 2.0585,2.851563 0.6348,1.267578 0.9492,1.107422 1.2676,2.21875 2.2891,6.296875 1.5136,4.21875 0.4688,1.748047 1.5898,6.109375 1.17,3.222656 0.1132,0.324219 0.1231,0.238281 0.9687,2.074219 1.9649,1.361328 0.1387,0.103515 2.832,-0.654296 0.7031,0.140625 2.9141,0.632812 2.457,1.681641 0.5371,0.378906 1.4512,1.814453 1.2383,1.908203 1.4453,2.294922 2.6914,3.167969 0.748,3.142579 0.7774,3.57812 0.209,2.62695 0.01,0.1543 1.584,5.86133 2.2617,2.66015 0.4414,0.53711 0.7265,1.52539 0.6309,1.75 -1.6855,-0.61328 -1.17,-0.63867 -0.6074,-0.35351 -1.9609,-0.65235 -1.5254,0.14453 -1.0899,1.01758 -0.1679,0.33594 -0.4414,0.77148 -0.7715,-1.4707 -0.1446,-2.90625 -0.037,-0.0273 v -0.0215 l -0.2598,-0.16211 -0.9355,-0.66015 -1.0039,-0.50391 -0.1758,-0.0996 -5.3867,-0.94922 -0.8028,0.37695 -1.9297,0.8125 -2.1777,1.45313 -1.2695,0.42383 -1.4219,0.41797 -2.6934,-0.95117 -2.2168,-0.15821 -1.2675,0.47461 -0.6328,2.37695 -0.1504,7.50782 -0.01,0.36718 -1.4434,5.7793 -3.1484,5.35156 -3.168,2.69336 -0.6328,1.26563 -0.3164,4.59375 -0.7851,3.76367 -0.01,0.0371 v 0.002 l -0.5566,1.07032 -3.4493,6.45898 0.1934,0.70117 0.3301,1.42969 0.9492,2.85156 1.1719,1.42188 0.9882,1.29492 2.7598,2.39648 6.1016,4.43164 2.7597,1.23438 2.8321,2.54297 1.9902,2.30273 0.7207,0.84766 -0.1582,0.94922 -3.0098,0.3164 -0.4843,0.38672 -1.1641,0.86133 -0.6699,1.71094 -0.8496,1.95117 0.3183,1.10937 0.1133,1.02735 0.1406,1.86133 -1.08,0.64843 -1.2422,0.69922 -8.9336,-1.59765 -6.22459,0.19726 -0.67188,0.0156 -0.95117,0.1582 -1.34765,-0.36914 -0.42969,-0.13672 -0.91406,-0.76172 -2.37696,1.10938 -0.8789,0.39062 -0.58594,0.19531 -0.70703,-0.0879 -0.9961,-0.18164 -9.66015,-4.59375 -4.45703,-0.44531 -1.83203,-0.21289 -1.23438,0.43555 -1.81445,1.59961 0.008,0.0351 -0.0156,0.0137 1.26758,6.17774 -1.10351,2.36328 -0.5625,0.17773 -1.02735,0.3086 1.26758,2.85156 1.42578,1.58398 0.625,0.46875 0.58399,0.54688 2.45703,1.13281 0.43555,0.21875 6.33203,4.67578 3.05078,1.74414 1.8164,0.43555 1.96094,-0.6543 3.83203,-2.38476 1.8711,0.4668 0.66015,0.23632 1.48047,0.5918 1.31836,2.33203 0.50195,0.95899 1.58985,1.76562 1.2911,1.45508 1.0781,2.00586 -0.3164,3.00976 -3.64265,3.48438 -1.5625,3.59375 -0.38086,0.10937 -0.59179,0.0977 -6.81055,-0.79102 -3.95898,0.31641 h -5.70313 l -1.26562,-0.63477 -0.86914,-0.83789 -3.33985,-3.28125 -6.68164,-2.83398 -0.006,-0.002 -0.0332,-0.0137 -2.69141,-0.63282 -2.53515,2.0586 -1.01758,0.14453 -1.19922,0.11719 -4.42969,-1.23438 -3.77734,-2.97852 -0.95899,-2.08203 -1.1289,-2.51953 0.3164,-1.26758 0.13282,-0.33398 0.18554,-0.40625 -0.0195,-0.008 0.0176,-0.043 -2.19336,-0.78516 -0.45703,-1.06836 -0.99219,-2.42383 -0.61523,-0.95703 -0.75196,-1.2539 -2.83593,-3.53125 -1.33985,-1.70118 -3.16797,-2.85156 -3.25976,-3.10547 1.08789,-2.53711 0.10156,-0.94726 0.16992,-1.01367 -0.63476,-5.38477 -0.47461,-1.74219 -0.1582,-1.74218 -0.47461,-1.74219 -0.63477,-1.42578 -2.37695,-2.37305 -1.7793,-1.1875 -4.3418,-2.99805 -4.53711,-1.66796 -0.42773,-0.16602 -5.9043,-0.45313 -2.27929,-0.18164 -0.0117,0.006 -0.041,-0.004 -1.88476,0.78515 -0.76368,-0.1914 1.22266,-1.06836 0.95117,-1.58399 0.002,-0.0215 0.0176,-0.0293 0.0156,-0.42969 0.12305,-1.73828 -2.21875,-0.3164 -0.32422,0.0332 -1.22852,0.0547 -1.81836,-0.40039 -1.20703,-0.31641 -0.89648,-1.17187 0.14648,-1.08985 -1.52539,-2.25195 -2,0.16797 -1.44141,0.0644 -0.5664,-0.0801 -0.56836,-0.15234 -0.29102,-0.875 -2.21094,-1.2168 -0.98437,-0.5957 -3.92383,-1.88867 -0.58008,-2.9043 -0.0566,-0.0293 -0.004,-0.0176 -2.69336,-1.42579 -0.52735,-0.17578 -1.80273,-0.67578 -2.90625,0.36328 -0.29688,-0.14062 -1.1914,-0.59571 4.35937,-1.12695 2.04883,-0.5 h 7.44336 l -0.0547,0.32813 -0.17773,0.58203 v 1.45312 l 3.33984,2.97657 0.0254,0.0137 0.0352,0.0312 0.32031,0.15039 2.30664,1.18554 3.42578,0.77149 1.70899,0.42773 0.63281,-0.1582 0.63477,-0.95117 0.72461,0.0898 1.73437,0.25586 2.25195,0.79883 3.26953,-0.94336 4.50391,0.29102 v 0.72461 l -0.0801,0.26562 -0.20898,0.41797 0.31641,0.24414 1.71484,1.39648 0.92773,-0.55664 0.52539,-0.29101 2.0586,-2.53516 2.1582,0.74414 7.04102,2.49414 1.56054,0.24414 0.80274,0.16016 12.19531,-1.10742 2.20703,-0.75782 2.8457,-0.93554 2.91407,-0.35547 0.0644,-0.008 h 0.0117 l 0.23633,-0.004 h 4.39257 l 5.54297,1.26758 3.96094,-0.31641 6.65235,-1.58398 3.16601,-1.42578 4.20313,-3.32422 2.63281,-2.02149 3.64258,-4.64453 3.77734,-4.74023 1.05859,-2.67774 1.68946,-4.13671 1.20703,-9.9961 0.63867,-5.04687 -0.41602,-2.76953 -0.0488,-0.34571 -0.006,-0.0176 -0.006,-0.0352 -0.26563,-0.69922 -2.19336,-5.92969 -1.45312,-2.61523 -1.1836,0.20703 -2.33593,-0.77735 -0.29492,-0.54687 -1.61719,-3.101559 -1.64063,-1.09375 -0.1914,-0.136719 -2.00586,-2.771484 -3.44727,-4.867188 -2.85156,0.158203 -1.74219,-0.316406 -1.74219,0.158203 -0.43359,-0.08594 -1.86719,-0.410157 -3.77734,-2.396484 -3.05078,-1.380859 -3.19531,-2.25 -1.5254,-0.654297 -0.43554,-0.0332 -0.44532,-0.07422 0.043,0.04297 -0.10742,-0.0078 1.3086,1.306641 1.23437,1.453125 -2.40625,0.671875 -0.70508,0.175781 -12.35547,-4.11914 h -1.74218 l -0.15821,0.947265 -0.15625,0.0039 h -2.85351 l -1.74219,-1.425781 -11.24414,-5.542969 -17.10547,-4.59375 -1.51562,-0.341797 -9.6836,-2.263671 -5.49219,-0.160157 -2,-0.08594 -0.4746,0.476562 -0.004,0.04102 -0.0195,0.01953 -0.14453,1.306641 -1.74414,0.943359 -1.74219,0.363282 -4.63867,-0.199219 -2.16016,-0.09961 -0.85352,0.09375 -0.6289,0.06055 -6.10156,2.179688 -0.0195,0.04102 -0.006,0.0098 -0.46876,0.783203 -0.1582,5.701172 -0.39062,0.882812 -0.26368,0.498047 -1.21484,1.076172 -0.66406,0.552735 v -0.19336 l 0.0625,-1.507812 0.57422,-0.861328 0.4707,-0.605469 -0.29883,-2.498047 -0.16601,-1.482422 -0.58008,-1.52539 -0.13477,-0.972657 -0.0859,-1.123047 -0.79297,-1.583984 -0.94922,-0.316406 -0.31641,0.27539 -0.99023,0.814454 -1.26953,1.58789 -1.06836,1.28125 -0.51758,-0.259766 -0.11524,-0.0625 0.15821,-2.21289 -0.0215,-0.02148 0.002,-0.02148 -0.58008,-0.654297 -0.83008,0.519532 -0.3125,0.177734 h -3.16797 l -2.81836,1.251953 -1.19922,-1.800781 -0.25781,-0.400391 -1.10937,-0.294922 -1.34571,-0.396484 -1.16211,-0.871094 0.32617,-1.197265 0.1211,-0.400391 0.67187,0.0059 6.61524,0.144532 1.90039,-0.47461 0.27734,-0.648437 0.25586,-0.480469 -0.13672,-0.679688 -0.0801,-0.726562 -0.57617,-1.15625 -0.22265,-0.488281 -0.48828,-0.292969 -0.61329,-0.4375 -4.91015,-0.316406 -1.36914,-0.644532 -1.33594,-0.632812 -5.52148,-1.308594 0.0117,0.05664 -0.0215,-0.0059 0.19336,0.773438 0.10742,0.484375 0.23047,0.310547 1.36914,1.916015 v 0.94336 0.0078 l -1.58398,-0.316406 -0.94922,0.791016 -0.15821,3.466796 -1.08593,1.087891 -0.23633,0.146485 -0.73633,0.367187 -5.38672,-1.109375 -1.8789,0.134766 -0.40625,0.02539 2.10546,3.994141 0.50196,1.431641 0.15429,1.541015 v 0.357422 l -0.0742,0.447266 -0.18165,0.140625 -0.5371,0.322265 -1.70899,0.425781 -0.20703,0.04492 -0.74609,-0.169922 -2.64844,-0.689453 -2.25195,-1.017578 -0.0391,-0.01953 -0.11718,0.03906 -0.42383,0.05273 -0.14453,0.21875 0.94336,1.451172 0.13085,0.552734 0.0859,0.695313 0.25977,1.169922 0.0312,0.197265 0.0254,0.433594 v 0.732422 l -0.12109,0.964843 -0.0488,0.265626 -0.6543,1.599609 -1.09961,1.154297 -0.29297,0.292968 -1.99609,1.513672 -2.56641,1.904297 -0.008,0.04883 -0.0234,0.01758 -0.1582,0.949218 0.1582,6.019532 -0.043,0.261718 -0.14453,0.621094 -0.36328,0.798828 -1.15625,1.046875 -0.35156,0.28125 -0.32813,0.328125 -0.34375,0.304688 -0.57812,0.664062 -1.44336,1.552737 -1.08008,1.38867 -0.0215,0.0273 -1.59766,1.23437 0.0254,0.0293 -0.0176,0.0137 0.79102,0.95117 2.44531,-0.51562 0.5918,-0.11328 0.60742,0.15234 0.002,0.002 0.47266,0.47266 0.22851,0.57422 0.084,0.25 0.14453,1.37891 -0.94336,8.35351 0.0117,0.041 -0.002,0.0156 0.0625,0.21094 0.36328,1.33008 0.75781,1.27148 1.66797,2.88867 2.46289,3.69336 0.70312,1.08008 5.375,1.08985 0.29102,0.0625 3.83789,0.88476 0.31641,0.30274 3.25586,3.2539 3.375,2.84375 2.08203,1.83594 1.76367,0.93359 0.95312,0.54102 0.29297,0.58398 0.4043,2.10352 0.35352,1.98047 -1.08985,4.5039 -1.16211,3.92188 -1.08984,4.57617 -0.51758,2.74414 -0.22461,1.07813 -0.13476,0.97265 -0.57618,3.63086 0.0762,0.72852 v 0.68554 l 0.36523,0.97461 0.0664,0.22657 0.80078,1.30664 3.58008,3.70898 0.55859,0.57813 0.0137,0.0156 1.875,2.23438 2.03516,2.39843 2.0332,2.6875 1.50195,2.5 0.0234,0.041 0.58008,0.71484 1.29687,1.6211 0.35547,0.35546 0.7461,0.79493 0.57812,0.52929 1.01172,1.01172 1.55078,1.55078 0.78125,0.83204 1.16211,2.10546 3.32813,5.125 1.25586,1.94922 0.79296,1.90039 0.0684,0.20703 0.35938,1.25586 -0.35156,0.28321 -0.44141,0.32031 -0.52539,0.21484 -1.48633,0.57032 -0.81055,0.73828 -0.95507,0.80078 v 0.29101 l 0.0234,0.0176 v 0.0527 l 1.90039,1.42578 -0.10156,2.15234 -0.0781,1.2168 1.23437,4.5039 -0.58203,2.6875 0.006,0.043 -0.002,0.008 v 0.4746 l 0.1582,0.47657 0.2207,0.14843 0.19922,0.15821 0.0391,-0.002 0.0156,0.0117 0.36133,-0.0215 2.27148,-0.0625 0.29297,0.39062 0.084,0.16797 0.4629,1.23633 0.0117,0.0312 v 0.006 l 0.15821,1.26172 -0.95117,1.26758 -0.3418,0.62695 -0.58789,1.04102 0.002,0.0352 -0.0215,0.0391 0.043,0.3379 0.0488,0.89648 0.19922,0.5 0.1836,0.64062 1.01562,1.59961 0.0547,0.0918 0.0195,0.0234 0.0176,0.0273 1.58398,1.90039 1.30664,0.78516 0.26758,0.16992 1.40039,0.0449 3.03906,0.10938 0.0664,0.0723 0.73047,0.87696 0.79297,1.42578 0.3164,1.42578 -0.54296,1.9043 -0.42774,1.40234 0.10938,0.33008 0.22851,0.79883 1.03516,1.41015 0.66015,0.94922 1.74414,2.25 4.83985,1.5918 1.85742,1.08398 0.79102,1.10938 0.79297,1.90039 0.47265,1.23242 0.25195,0.7832 0.14258,0.96485 0.082,0.97851 -0.16406,1.47657 -0.20508,1.30078 -0.63476,2.41406 -0.89649,3.04492 -2.375,2.69336 v 0.32422 l -0.0156,0.0937 0.0156,0.0156 v 0.041 l 0.71094,0.63281 0.65234,0.61914 7.26368,4.50196 4.43164,1.88867 5.95508,2.39843 3.88085,2.11524 0.0703,0.0391 1.74218,1.90039 0.95899,0.82227 1.19336,1.15039 1.78711,1.25195 0.33789,0.25977 1.58398,1.42578 0.79102,0.95117 0.4043,1.08008 0.0352,0.11719 -0.0879,1.61718 -0.19336,2.41211 0.1582,3.00977 -0.1582,4.43359 -0.47461,3.16797 -1.03711,3.18945 -1.04101,3.0879 -2.125,4.81445 -1.49805,3.32226 -0.63477,2.2168 -1.58398,4.11719 -2.375,8.07812 -0.79297,1.90039 -1.35156,4.26758 -0.75195,2.22656 -0.65235,1.22071 -0.56836,0.99804 -0.36914,0.95899 -0.44336,1.03515 -2.08984,5.55079 -0.25,0.64843 -2.89063,4.98633 -0.25976,0.41211 -2.72656,4.30469 -0.79102,2.06055 -0.52344,1.04492 -0.49219,0.82031 -0.70703,0.88281 -0.8125,0.89453 -0.39062,0.78125 -0.125,0.20313 -2.6875,6.10156 -2.32617,4.95508 -1.59766,3.32227 0.0469,-0.0215 -0.0449,0.0957 5.95703,-2.6875 0.57227,-0.6289 3.92188,-4.20313 0.67773,0.25391 0.56641,0.2207 0.26171,0.1875 1.1875,0.92188 0.44922,1.68554 0.13477,0.61914 0.15234,1.2168 0.0469,0.51758 -1.54102,-0.59766 -0.98437,-0.43164 0.0332,0.0625 -0.10352,-0.041 1.01563,1.74218 2.97852,3.05079 3.19726,0.79882 3.57227,2.27539 1.97656,1.29883 5.06836,-0.79297 0.0254,-0.0137 0.0332,-0.006 2.13867,-1.25195 0.8125,-0.4707 1.05469,-0.19727 1.51367,-0.25977 h 0.002 l 0.0898,0.0469 3.17774,1.69531 1.2207,1.25391 1.33594,1.41992 1.74218,0.47656 2.2168,0.94922 0.21484,1.17578 0.0977,0.60938 -0.2168,1.16211 -3.70703,-0.29297 -4.62305,-0.43555 -8.58398,0.90235 -0.44726,0.043 -0.0801,0.16993 -0.70899,1.41797 -0.2832,1.32226 -0.23438,0.93945 -0.0352,0.81641 -0.0801,0.88086 -0.31836,0.95117 -0.85352,0.73242 -0.23828,0.17969 -0.90234,0.33398 -1.01367,0.3379 -1.36914,0.16992 -1.14649,0.10156 -1.45312,-0.60547 -0.3086,-0.14062 -0.23437,0.52734 -0.47266,0.94531 0.2168,2.82813 -1.09375,1.71679 -0.59961,-0.11914 -1.71875,-0.42968 -1.93945,-1.65235 -0.0176,-0.0156 -0.006,-0.004 -1.16211,0.43555 -0.13281,1.2832 -0.125,0.81836 1.26562,2.53516 1.10938,2.85156 -0.084,1.34766 -0.14453,1.26171 0.89258,0.62891 0.28711,0.24609 1.58398,1.42579 0.36524,0.45703 0.21289,0.36523 -0.0801,0.23633 -0.18164,0.36523 -0.68945,0.57422 -0.28321,0.20313 -0.0254,0.20117 -0.11132,0.44727 -0.0625,0.38085 -0.16407,0.57032 -0.41601,0.16211 -0.93946,0.3125 -0.47656,0.79101 v 0.70117 l -0.0566,2.39063 -0.29101,5.08398 -0.60157,1.85743 -0.3164,0.89648 h 0.24804 l 0.0176,0.006 1.74219,1.96094 4.14062,11.11328 0.12305,0.41015 0.69727,2.50782 V 448.65 l -0.0215,0.41016 -0.72656,0.79883 -0.002,0.006 -0.043,0.043 -1.74219,4.75196 v 1.74218 l 0.47461,1.42578 0.58789,0.78126 0.28906,0.4746 0.0625,-0.006 0.0117,0.0156 2.0586,-0.1582 2.69335,-0.94922 2.2168,0.94922 3.00977,2.37695 1.42578,2.05859 0.64258,1.28711 0.29297,0.66016 -0.10938,0.38281 -0.53711,1.73633 -1.78125,0.18945 -0.25,0.0195 -1.74219,-0.63281 -0.0976,-0.0781 -0.69532,-0.58008 v -0.60938 l -1.41406,-1.06054 -0.48437,-0.37305 -2.47071,-0.36328 -0.58007,0.21875 0.0723,0.0723 1.16211,2.54297 0.0547,0.0332 0.0176,0.0391 0.49414,0.28125 0.5957,0.37305 0.64258,0.39453 0.32617,0.21875 0.006,0.006 0.25977,0.32421 0.14648,0.50977 -0.29102,0.58008 -3.41406,2.32422 -0.004,0.0371 -0.0293,0.0195 -0.1582,1.26562 v 0.85743 l -0.0273,0.50781 -0.60742,1.2539 -0.63086,1.1836 v 1.90039 l 0.23438,1.52734 0.0605,0.59961 0.14453,0.79883 2.10743,-0.36328 0.87109,0.36328 1.16211,2.4707 1.20898,0.61719 1.8125,0.95508 1.42188,0.58594 1.22265,0.52929 0.53516,0.48047 0.14649,0.14649 0.63085,1.57812 0.002,0.006 0.0117,0.0684 0.30664,1.67383 v 0.56445 l -0.0352,0.49414 -0.6543,1.30664 -0.14453,2.90625 0.27539,1.20313 0.24024,1.28711 -0.15821,4.91015 h 0.31836 l 0.65821,-0.41211 1.93554,-1.10547 0.8711,0.29102 0.73047,0.66992 0.0801,0.0801 0.95118,2.85156 1.26562,1.10938 1.42578,1.74218 0.63477,1.42579 1.2539,0.71484 0.99414,0.63086 0.43555,1.08984 2.17969,3.92188 1.08984,2.32422 0.65235,1.8164 0.0469,1.60157 v 0.88671 0.59375 l -0.0469,1.13086 3.34179,2.25 h 0.58204 l 1.08789,-1.52539 0.14648,-0.0723 h 0.11523 l 1.23829,-0.41211 1.62304,-0.45899 1.17188,0.45899 0.54687,0.24804 0.11524,0.13282 1.32226,1.61523 0.875,0.77735 0.47266,0.47265 0.0762,0.0137 0.002,0.002 0.0234,0.004 1.06055,0.19727 1.06445,-1.30469 1.17774,-1.42969 1.42578,-1.10547 1.10937,-0.1582 3.95899,0.79297 1.19726,0.27539 0.81641,0.24219 0.65429,0.79883 0.29102,1.01758 v 1.66992 l 0.0508,1.22656 v 0.4707 l 0.0195,0.0195 0.002,0.0274 1.66992,1.74218 0.89844,0.54688 0.73632,0.51562 0.0352,-0.0469 0.002,0.002 0.0957,-0.13476 2.08398,-2.83008 0.44141,-0.5293 0.35547,-0.35547 1.08984,-0.36328 1.23633,-1.23437 0.008,-0.0156 0.0371,-0.0371 0.28906,-0.65039 0.38281,-0.80664 0.89258,-0.74414 0.48242,-0.0508 1.59571,-0.12305 1.86523,-0.76367 1.56445,-0.58594 2.48438,0.42774 2.16406,0.44726 0.47461,0.47461 2.81445,1.72071 0.19922,0.18359 0.78907,0.78906 0.79101,0.15821 1.42578,0.79101 0.72266,0.0664 0.99219,0.17187 0.94336,-0.50976 0.23242,0.0879 0.27734,0.18359 0.61719,0.49414 0.17969,0.17969 0.0625,0.18555 0.40625,1.35742 1.10937,4.27734 -0.15039,0.67774 -0.1914,0.76562 -0.29883,0.84766 -0.15039,0.40039 0.0273,0.14062 0.0586,0.64453 0.15039,0.48829 0.0781,0.4707 1.74414,1.58203 2.125,1.99414 0.33203,0.33203 0.87305,1.52539 0.0254,0.0918 0.28711,1.28516 -0.74219,3.21484 -0.22461,0.92773 -0.0684,0.16993 -0.39062,0.91406 0.041,0.5 0.0547,1.4668 0.14844,0.96093 0.0723,0.87305 0.25782,0.42969 0.17578,0.35156 0.75,0.32422 3.56839,1.58789 2.8066,0.70117 0.2832,0.0742 0.7989,0.6543 0.2129,0.42382 0.01,0.0156 -0.1347,1.09375 -0.3301,2.42187 0.1582,0.94922 2.4941,0.625 1.7344,1.73438 2.0332,3.05078 1.4102,1.23633 1.5136,1.43164 3.7969,1.06836 1.3418,0.40234 1.9395,0.45703 1.791,0.44727 0.5664,0.3789 0.3515,0.24219 0.3614,0.67188 0.1465,0.29101 0.057,0.26172 0.3809,1.97266 v 2.90429 l -0.027,0.64649 -0.094,1.02539 0.1894,0.0215 1.3106,0.19532 2.7285,-0.99219 0.5234,-0.17383 0.2754,-0.0527 3.8828,-0.66993 2.793,0.7168 2.8691,0.79688 0.211,0.56054 0.2285,0.68555 -0.1465,1.38086 0.025,0.041 v 0.0254 l 0.6348,1.10937 0.4922,0.41016 0.4473,0.44726 3.705,1.38867 1.5313,0.60352 0.1191,0.11914 0.6016,0.72266 0.4101,1.07812 0.1368,0.45703 0.1191,0.48047 0.1328,0.74414 -0.6738,0.35938 -0.3692,0.1582 -0.291,0.28906 -0.8457,0.79102 -1.6601,2.02148 -0.01,0.0117 -0.045,0.0527 -0.1094,1.54101 -0.064,0.65821 -2.5411,3.77734 -1.7441,1.88867 -0.8027,0.2793 -0.9161,0.25 -4.1171,0.63476 -1.7422,-0.79297 -0.9512,-1.10742 h -0.2773 l -1.5079,-0.0625 -2.0332,0.50782 -2.832,1.08984 -0.1367,0.18359 -0.3399,0.33985 v 1.74218 l -0.4746,2.84961 -0.2363,1.29883 -0.1211,0.48633 0.6367,0.45508 0.3535,0.29492 0.5098,0.41601 1.1875,1.08594 2.4707,1.88867 2.4688,1.59766 0.9453,1.08984 0.289,0.94336 -0.4492,1.07032 -0.1347,0.30273 v 0.008 l 0.07,0.1875 0.7285,1.91797 2.6152,2.39844 -0.4355,0.65234 0.1816,0.74219 0.6387,2.80664 0.5059,1.51758 0.707,2.34375 0.5078,0.50781 0.1797,0.22461 0.3672,0.13672 0.834,0.36523 0.789,0.69727 0.3848,0.38477 1.1621,1.3164 1.2226,1.45117 0.065,0.14258 0.2441,0.73242 h 0.4747 l 2.0585,0.31641 1.2266,0.0879 1.0156,0.10156 0.8926,-0.23437 0.5078,-0.11328 1.0254,-0.51367 0.4805,-0.22852 0.023,-0.0234 0.055,-0.0273 1.584,-1.58399 0.9512,-1.42578 v -5.85937 l 0.078,-0.38672 0.1406,-0.42774 0.7988,-0.72656 1.3809,-0.50781 1.877,0.0898 1.1093,0.0586 0.055,-0.002 h 0.01 l 3.414,-0.14648 1.8165,-0.72656 2.7753,-3.02735 1.2754,-1.32422 2.5332,-1.26757 3.4844,-0.47461 3.168,-0.95118 1.4824,-0.8457 0.752,-0.38867 0.9726,0.2168 0.9102,0.22656 1.8437,0.92187 0.9942,0.52344 2.8339,2.54102 1.9981,2.67578 1.834,2.52344 4.0801,2.36718 3.7812,2.24024 0.5078,1.23437 -0.1387,0.97266 -2.5273,1.73828 -2.2188,1.26758 0.129,0.44922 0.1816,0.72851 0.4629,0.46485 0.4941,0.57422 1.4258,1.16796 0.3047,0.26368 0.1289,0.32031 0.6738,1.89258 0.4903,1.36718 0.2324,0.77735 0.2441,0.39258 0.7754,1.42187 0.7656,0.19141 0.4649,0.17383 0.4375,0.87109 -0.3125,0.72656 -0.4043,0.73047 v 0.75977 l -0.01,0.10742 0.5801,0.29101 5.1582,-1.59765 2.9043,0.29101 2.252,0.36328 0.3496,-0.10742 0.6445,-0.10742 1.9004,-1.42578 2.2168,-1.26758 1.2051,-0.53516 0.2304,-0.0918 0.9414,0.62695 0.6094,0.95703 0.4727,0.78907 0.289,0.31835 1.1621,1.41993 0.625,0.0898 0.4668,0.13281 1.3809,-0.65429 0.5957,-0.1504 0.2578,-0.0508 0.3262,0.25977 0.418,0.37695 -0.1465,1.3086 0.2129,0.42578 0.2988,0.79687 1.043,1.04102 0.084,0.0957 1.1719,1.89258 0.8223,1.33984 0.014,0.01 0.033,0.0547 0.9492,0.79297 0.9511,1.10742 0.4747,1.58398 -0.1582,1.42578 v 1.26758 l 0.7226,1.17383 0.5,0.9375 2.1211,1.74805 0.2988,0.25781 0.021,0.004 0.027,0.0234 1.3105,0.27539 0.066,0.0156 0.1309,0.14258 1.6172,1.81835 1.8886,0.14454 1.8145,-2.83204 1.5254,-1.74218 1.2851,-0.14649 1.2422,-0.0781 2.375,-0.47461 1.8535,0.77148 0.7227,0.57227 1.0684,0.87305 1.0273,0.30859 0.5957,0.20703 0.5195,-0.52148 0.5489,-0.46875 2.7793,-0.46289 v 0 l 1.0938,0.63867 0.7187,0.45703 1.4258,0.3164 0.022,-0.0332 0.01,0.002 0.5469,-0.875 0.5312,-0.83594 0.012,-0.0332 0.7813,-2.02539 2.4375,-2.04687 1.5019,-1.23047 1.0078,-0.57227 1.7051,-0.90234 0.6328,-0.63281 1.2676,-1.74219 0.7617,-0.76367 0.711,-0.67578 0.8828,-0.24024 0.8047,-0.20898 0.4863,0.33984 1.8965,1.39063 2.2187,0.95117 0.1836,0.28516 1.1699,1.97265 3.2696,2.6875 6.6816,2.6875 0.6582,0.19336 1.8164,0.56836 1.2676,-0.79297 0.4746,-0.63281 0.1426,-0.71484 0.016,-0.0781 -0.375,-1.40625 -0.2226,-0.91406 0.291,-1.08985 0.6054,-0.27929 0.334,-0.11133 4.9102,1.26758 0.023,-0.006 0.01,0.002 2.1074,-0.58203 0.625,-0.23242 1.3516,-0.44922 3.3261,1.10937 1.1309,0.2461 2.5,0.56055 0.252,-0.084 1.9804,-0.56641 1.4239,-1.58203 0.58,-0.58007 0.3907,-0.36329 1.0859,0.46485 1.2598,1.33203 1.6718,0.79883 1.4512,-0.21875 0.018,-0.006 0.037,-0.004 1.8887,-0.6289 0.709,0.18359 3.4218,0.92187 2.2266,0.59961 1.8691,0.53321 1.961,-0.6543 1.3066,-1.45313 0.3574,-0.21875 0.9903,-0.54882 1.2226,0.15234 0.6113,0.85547 0.067,0.0996 -0.1582,1.74219 0.2363,0.50976 0.6699,1.62109 1.0449,0.69727 1.0586,0.81445 0.9082,1.81446 0.039,0.0879 0.289,1.96093 -0.025,0.66407 -0.1016,1.33398 -0.9512,3.00977 -0.791,2.84961 -1.7285,1.60547 -0.541,0.48828 -1.0567,1.55078 -0.033,0.0469 0.6758,0.91797 0.3067,0.45899 0.2949,0.17773 1.2636,0.8418 1.9766,0.16015 0.7422,0.0879 0.9394,-0.10351 1.8633,-0.14453 0.6543,0.80078 -0.1465,0.65234 -1.4531,1.16211 -1.4062,0.29883 -0.9278,0.18555 -0.01,0.0137 -0.057,0.0117 -0.3652,0.97461 -0.047,0.10937 -0.012,0.0469 -0.012,0.0312 -0.098,0.40429 -0.3535,1.41797 0.1582,1.34961 0.1485,1.4043 0.1386,0.9668 0.1875,1.50586 0.027,-0.004 0.01,0.0723 1.6309,-0.26367 1.0254,-0.12109 1.7422,0.31641 1.1465,1.43359 0.1191,0.16015 0.2266,0.32813 1.0429,1.5625 0.8575,1.57227 0.09,0.17578 -0.3633,1.09375 -0.1094,0.27929 0.01,0.0215 -0.01,0.0254 0.3164,0.94922 0.6348,0.31836 0.9219,-0.26563 0.1601,-0.0312 0.2696,0.0195 0.707,0.11719 0.4649,0.93164 -0.6426,2.85352 0.07,1.57226 0.1074,3.35547 0.1582,2.69141 0.4668,1.0039 0.5781,1.40039 -0.289,1.73243 -1.5489,0.77343 -3.4902,1.7461 -1.8633,0.90625 -4.8672,1.88867 -0.9941,0.26562 -1.1387,0.26172 -3.3261,1.10938 -0.024,0.0215 -0.037,0.0117 -0.3516,0.33203 -1.0136,0.90039 -0.01,0.0684 -0.01,0.006 -0.6523,4.86719 -0.168,0.37305 -0.9062,1.81445 -2.043,2.51367 -0.016,0.0195 v 0.002 l -1.1504,0.70117 -1.6718,0.96875 -0.1172,0.25195 -1.0195,2.03711 0.1835,1.10742 0.2266,1.75977 0.7988,2.32422 0.1465,1.23437 -0.291,1.3086 0.045,0.49609 v 0.32226 l 0.3164,0.63282 h 0.037 l 0.037,0.0742 h 0.7988 1.0176 l 0.086,0.22851 0.082,0.33008 v 0.61133 l -0.023,0.2832 -0.6524,1.16211 v 1.37891 l 0.25,0.5332 0.2676,0.625 0.4239,0.76562 0.3652,0.69141 4.6484,-5.08398 0.711,-1.73243 0.5039,-1.13476 3.4843,-2.2168 -0.019,0.12305 -0.1758,0.82031 -1.5976,1.59766 -0.5625,1.37304 -0.6543,1.47071 0.061,-0.0215 -0.01,0.0117 2.4687,-0.87305 3.3438,-2.14843 1.7363,-1.08594 0.791,-3.96094 3.6094,-1.41211 1.2051,1.15821 0.5703,0.57226 2.2187,2.69141 0.1621,0.3789 0.2364,0.75586 -0.072,1.00977 v 0.008 l -2.7598,1.96094 -5.375,6.68359 -3.1953,2.54102 -1.0644,1.1582 -2.3457,2.45117 2.0586,2.21875 1.1093,2.0586 -1.6445,0.44726 -1.8184,0.45508 -2.6875,0.29102 -0.4609,0.31445 -0.9922,0.55078 -3.1367,4.07617 -2.3106,0.36133 -2.1074,0.77149 -0.047,0.0176 -0.025,0.01 0.9629,1.36133 1.121,1.63867 1.42,1.18359 2.3066,1.99024 1.6719,0.21679 1.584,-0.99804 0.3027,-0.17578 5.5664,2.27734 1.3359,0.56836 5.5918,3.3418 -0.029,0.0176 -1.8515,1.08008 -2.0586,0.31836 -0.8711,0.41016 -1.8711,0.78711 v 3.41406 l -0.1504,1.10547 -0.2617,1.49023 -0.2363,-0.4414 -0.252,-0.58985 -0.4766,-1.42578 -0.06,-0.0215 -0.016,-0.0449 -0.8535,-0.27149 -0.8125,-0.29492 -0.7598,1.52148 -0.4063,0.7168 0.3633,7.4082 -0.7461,2.28711 -1.3007,3.90625 -0.041,0.875 -0.164,2.51953 0.6523,2.17969 0.2227,0.0664 0.4375,0.21875 0.7929,-0.47461 0.1,0.23828 0.6269,1.69336 v 1.88867 l -7.5547,5.52149 -0.4004,0.91992 -0.3418,0.75 -2.4023,-0.0625 -0.3223,-0.0195 -3.6426,-1.58399 -2.8515,-0.47656 -0.049,0.0391 -0.014,-0.002 -1.4531,1.16211 -0.016,0.0273 -0.053,0.041 -1.1094,1.74218 0.051,0.0215 -0.035,0.0566 1.1622,0.43555 1.1621,-0.14649 1.3925,0.20899 1.9707,0.375 -1.1093,1.74218 -1.6817,1.56836 -3.1133,2.78907 0.043,0.0762 0.4746,0.95117 0.793,0.63281 0.051,-0.004 0.018,0.0137 5.0839,-0.4668 1.9747,-0.17578 6.8105,0.95117 2.0449,1.14844 0.4981,0.28516 v 0.002 l 0.1172,0.13867 2.6425,3.12891 0.078,0.0469 0.057,0.0352 1.6855,1.07422 2.377,0.63281 1.9004,0.1582 2.5742,-0.77148 0.5547,-0.15821 0.012,-0.0117 0.027,-0.008 0.8027,-0.75586 1.9141,-1.76367 10.4296,6.16211 0.024,0.002 0.01,0.006 0.8614,0.0742 2.5898,0.23438 7.7598,-1.10742 2.0605,0.1582 18.0352,6.96094 v 0 l 0.3965,0.23632 5.6407,3.41407 5.6992,2.47851 5.1855,2.29688 1.8496,0.45117 1.2032,0.31641 0.1582,-2.53321 c 0,0 0,-0.12658 0,-0.12695 l 0.4941,-2.75586 1.2364,-1.16211 4.5761,-1.01758 4.2129,-0.72656 2.541,-1.96094 4.0684,0.2168 3.7774,0.58203 3.6308,-0.0723 6.4649,-1.45313 0.7109,-906.783207 -189.2012,1.089843 1.0176,1.378907 0.3633,0.945312 0.072,0.654297 -0.1445,1.451172 -1.0176,0.945312 -3.6308,0.94336 -2.9063,0.509765 -4.0683,-4.287109 -0.8711,-2.6875 0.2187,-1.015625 c -0.2404,-2.043899 -6.3185,-4.587159 -10.4687,-4.523438 z"
+         transform="matrix(0.13767347,0,0,0.13767347,194.23271,174.67637)" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region RUS"
+         d="m 339,173.75 0.3,0.35 0.03,0.2 -0.04,0.09 -0.2,-0.21 -0.14,-0.06 -0.03,0.42 0.12,0.37 0.04,0.61 -0.37,0.69 -0.27,0.36 -0.31,0.24 -0.51,-0.08 -0.54,-0.43 -0.15,-0.14 -0.17,-0.2 -0.15,-0.22 -0.22,-0.35 -0.21,-0.34 -0.08,-0.37 0.04,-0.52 0.12,-0.4 0.1,-0.14 0.35,-0.23 1.58,0.12 0.38,0.05 z"
+         id="path15209" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region RUS"
+         d="m 334.48,189.73 -0.03,0.08 -0.43,-0.04 -0.11,-0.13 -0.02,-0.07 0.1,-0.1 0.17,-0.01 0.2,0.15 z"
+         id="path15205" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region RUS"
+         d="m 325.85,201.18 0.14,0.15 0.13,0.28 0.02,0.2 0.1,0.14 -0.07,0.15 -0.33,-0.29 -0.11,0.04 -0.18,-0.11 -0.16,-0.23 0.07,-0.11 0.06,0.03 0.15,-0.25 z"
+         id="path15201" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region RUS"
+         d="m 304.4,256.31 h 0.26 l 0.34,0.14 0.3,-0.01 0.5,-0.23 -0.04,-0.84 -0.08,-0.74 0.17,-0.03 0.24,-0.09 0.18,0.18 0.32,0.14 0.37,0.11 0.56,0.2 0.57,0.09 0.18,-0.01 0.55,-0.11 0.6,-0.07 0.24,0.39 0.33,0.15 0.28,0.23 0.05,0.15 -0.16,1.03 -0.01,0.34 0.04,0.33 0.2,0.39 0.15,0.21 -0.09,0.05 -1.55,0.21 -1.47,0.15 -1.37,0.13 -1.32,0.12 -1.26,0.1 -0.79,0.04 -0.78,0.04 -0.12,-0.05 0.37,-0.46 0.22,-0.46 0.16,-0.58 -0.03,-0.38 v -0.44 l 0.34,-0.22 0.79,-0.08 0.3,-0.25 0.36,-0.57 0.36,-0.68 0.1,-0.28 0.17,0.02 -0.2,0.49 -0.58,1.05 z"
+         id="path15193" />
+      <path
+         id="polyF1S184P20"
+         d="m 304.4,256.31 h 0.26 l 0.34,0.14 0.3,-0.01 0.5,-0.23 -0.04,-0.84 -0.08,-0.74 0.17,-0.03 0.24,-0.09 0.18,0.18 0.32,0.14 0.37,0.11 0.56,0.2 0.57,0.09 0.18,-0.01 0.55,-0.11 0.6,-0.07 0.24,0.39 0.33,0.15 0.28,0.23 0.05,0.15 -0.16,1.03 -0.01,0.34 0.04,0.33 0.2,0.39 0.15,0.21 -0.09,0.05 -1.55,0.21 -1.47,0.15 -1.37,0.13 -1.32,0.12 -1.26,0.1 -0.79,0.04 -0.78,0.04 -0.12,-0.05 0.37,-0.46 0.22,-0.46 0.16,-0.58 -0.03,-0.38 v -0.44 l 0.34,-0.22 0.79,-0.08 0.3,-0.25 0.36,-0.57 0.36,-0.68 0.1,-0.28 0.17,0.02 -0.2,0.49 -0.58,1.05 z"
+         class="region RUS"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S184P24"
+         d="m 325.85,201.18 0.14,0.15 0.13,0.28 0.02,0.2 0.1,0.14 -0.07,0.15 -0.33,-0.29 -0.11,0.04 -0.18,-0.11 -0.16,-0.23 0.07,-0.11 0.06,0.03 0.15,-0.25 z"
+         class="region RUS"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S184P26"
+         d="m 334.48,189.73 -0.03,0.08 -0.43,-0.04 -0.11,-0.13 -0.02,-0.07 0.1,-0.1 0.17,-0.01 0.2,0.15 z"
+         class="region RUS"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S184P28"
+         d="m 339,173.75 0.3,0.35 0.03,0.2 -0.04,0.09 -0.2,-0.21 -0.14,-0.06 -0.03,0.42 0.12,0.37 0.04,0.61 -0.37,0.69 -0.27,0.36 -0.31,0.24 -0.51,-0.08 -0.54,-0.43 -0.15,-0.14 -0.17,-0.2 -0.15,-0.22 -0.22,-0.35 -0.21,-0.34 -0.08,-0.37 0.04,-0.52 0.12,-0.4 0.1,-0.14 0.35,-0.23 1.58,0.12 0.38,0.05 z"
+         class="region RUS"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="san_marino"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S197P1-55"
+         d="m 283.36,311.1 -0.2,0.04 -0.11,-0.19 0.15,-0.23 0.21,-0.04 0.04,0.17 z"
+         class="region SMR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <circle
+         r="0.25"
+         id="pointF2S65P1"
+         cy="310.91965"
+         cx="283.26831"
+         class="region SMR"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="serbia"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S201P1-5"
+         d="m 308.76,298.52 0.22,0.25 0.24,0.33 0.28,0.13 0.33,0.15 0.18,0.12 0.29,0.4 0.22,0.18 0.06,-0.02 0.05,-0.06 0.04,-0.05 0.05,0.03 0.02,0.13 0.05,0.28 v 0.31 l 0.1,0.28 0.01,0.09 -0.03,0.09 0.01,0.08 0.08,0.06 0.28,0.16 0.27,0.26 0.3,0.17 0.27,0.09 0.16,-0.01 0.29,0.2 0.54,0.09 0.18,0.04 0.12,0.08 0.1,0.1 0.02,0.12 -0.07,0.07 -0.09,0.18 -0.02,0.21 -0.07,0.06 -0.08,0.02 -0.06,0.07 0.03,0.08 0.08,0.07 0.12,0.06 0.21,0.04 0.22,0.08 0.01,0.09 -0.03,0.1 -0.25,0.07 -0.19,0.05 -0.09,0.05 0.03,0.16 0.57,0.09 0.27,0.13 0.16,0.19 0.37,0.09 0.57,-0.02 0.43,0.15 0.27,0.34 0.35,-0.15 0.42,-0.62 0.47,-0.23 0.52,0.18 0.3,0.17 0.07,0.16 -0.1,0.09 -0.28,0.01 -0.2,0.14 -0.14,0.27 0.01,0.26 0.16,0.25 0.2,0.16 0.24,0.06 0.14,0.13 0.04,0.17 0.07,0.04 -0.12,0.11 -0.12,0.14 -0.04,0.23 0.03,0.35 -0.39,0.34 -0.16,0.08 -0.05,0.19 -0.04,0.52 0.07,0.38 0.09,0.18 0.05,0.16 0.17,0.17 0.17,0.27 0.14,0.38 0.24,0.27 0.53,0.22 0.26,0.13 0.22,0.22 0.17,0.21 0.44,0.23 0.01,0.22 -0.06,0.23 -0.08,0.11 -0.16,0.31 -0.17,0.18 -0.25,0.53 -0.51,0.12 -0.11,0.05 -0.18,0.17 -0.06,0.25 0.12,0.18 0.02,0.19 -0.04,0.39 0.18,0.39 0.21,0.15 0.04,0.1 v 0.2 l -0.21,0.43 -0.07,0.15 -0.26,0.12 -0.09,-0.03 -0.16,-0.11 -0.14,-0.01 -0.3,0.2 -0.32,0.15 -0.26,-0.03 -0.26,0.03 -0.17,0.09 -0.13,0.05 -0.24,0.21 -0.41,0.18 -0.19,0.01 -0.1,-0.15 -0.11,-0.21 0.03,-0.11 0.25,-0.22 0.01,-0.17 0.28,-0.87 0.04,-0.27 -0.01,-0.09 -0.11,-0.04 -0.21,0.03 -0.98,-0.18 -0.01,-0.38 -0.3,-0.17 -0.32,-0.13 -0.08,-0.2 -0.38,-0.36 -0.27,-0.19 -0.32,-0.07 -0.29,-0.13 -0.17,-0.08 -0.1,-0.18 -0.01,-0.12 -0.1,-0.09 -0.12,0.03 -0.2,0.18 -0.25,0.17 -0.03,0.1 0.12,0.21 0.09,0.13 -0.02,0.15 -0.06,0.18 -0.47,0.45 -0.04,0.15 0.12,0.2 -0.05,0.11 -0.41,0.2 v -0.12 l -0.05,-0.19 -0.28,-0.17 -0.36,-0.11 -0.84,-0.43 -0.3,-0.03 -0.28,-0.03 -0.41,-0.21 -0.2,-0.02 -0.23,-0.15 -0.54,-0.56 -0.44,-0.29 -0.29,-0.14 -0.1,-0.15 -0.03,-0.17 v -0.06 l 0.18,-0.27 0.16,-0.05 0.2,-0.03 0.15,0.1 0.18,0.01 0.08,-0.17 0.03,-0.23 -0.06,-0.29 -0.49,-0.61 -0.42,-0.42 -0.05,-0.1 0.07,-0.1 0.12,-0.06 0.14,0.02 0.36,-0.01 0.34,-0.08 0.1,-0.13 -0.02,-0.15 -0.14,-0.13 -0.44,-0.33 -0.34,-0.3 -0.4,-0.22 -0.28,-0.07 -0.09,-0.12 -0.05,-0.14 v -0.26 l -0.02,-0.33 0.05,-0.22 0.2,-0.41 0.18,-0.45 0.1,-0.41 0.04,-0.38 -0.04,-0.1 -0.13,-0.07 -0.26,-0.04 -0.35,0.11 -0.29,0.17 -0.11,0.02 -0.06,-0.16 0.04,-0.08 h 0.09 l 0.09,0.02 0.07,-0.08 0.03,-0.23 -0.21,-0.76 0.22,-0.1 -0.01,-0.11 0.01,-0.1 0.24,0.11 0.33,-0.04 0.28,-0.06 0.03,-0.08 -0.01,-0.11 -0.07,-0.08 -0.11,-0.06 -0.08,-0.1 -0.2,-0.02 -0.63,-0.21 -0.33,-0.26 -0.02,-0.32 0.06,-0.18 0.1,-0.08 -0.04,-0.05 -0.35,-0.11 -0.14,-0.19 0.07,-0.27 -0.23,-0.51 -0.22,-0.3 0.17,-0.16 v -0.21 -0.11 l 0.08,-0.01 0.27,-0.17 0.1,-0.12 0.04,-0.13 0.07,-0.04 0.21,0.11 0.21,-0.01 0.22,-0.12 0.15,-0.14 0.2,-0.12 0.09,-0.09 0.1,-0.12 0.21,-0.35 0.26,-0.1 0.37,0.04 0.4,-0.03 0.29,-0.11 h 0.75 l 0.17,0.05 z"
+         class="region SRB"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="slovakia"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S204P1-8"
+         d="m 314.07,283.38 -0.01,0.2 -0.09,0.25 -0.12,0.26 -0.09,0.31 -0.08,0.63 -0.07,0.3 -0.39,0.64 0.08,0.77 -0.05,0.07 -1.04,0.43 -0.15,-0.02 -0.17,-0.12 -0.09,-0.1 -0.07,-0.07 -0.12,-0.2 -0.15,-0.14 -0.2,-0.09 -0.18,-0.12 -0.22,0.02 -0.55,0.29 -0.4,0.08 -0.28,-0.02 -0.37,-0.07 -0.71,0.08 -0.46,0.17 -0.03,0.16 -0.32,1.01 -0.6,0.43 -0.52,0.43 -0.15,0.1 -0.3,-0.08 -0.34,-0.17 -0.28,-0.08 -0.19,0.07 -0.18,0.27 -0.07,0.26 -0.61,0.25 -1.11,0.24 -0.36,0.29 -0.1,0.3 0.02,0.23 0.11,0.17 -0.09,0.24 -0.04,0.1 -0.79,0.13 -1.05,0.18 -0.63,0.05 -0.6,0.04 -0.42,-0.15 -0.53,-0.32 -0.57,-0.44 -0.05,-0.01 -0.08,-0.05 h -0.33 l -0.09,0.03 -0.21,-0.14 -0.07,-0.2 -0.35,-0.52 -0.42,-0.88 -0.03,-0.25 0.11,-0.31 0.1,-0.24 0.01,-0.18 v -0.05 l 0.07,-0.38 0.21,-0.52 0.2,-0.31 0.16,-0.11 0.34,0.06 0.59,0.01 0.45,-0.11 0.39,-0.26 0.21,-0.22 0.17,-0.22 0.05,-0.14 0.08,-0.07 0.34,-0.15 0.09,-0.15 0.02,-0.26 v -0.29 l 0.05,-0.22 0.07,-0.17 0.6,-0.44 0.04,-0.14 0.09,-0.14 0.17,-0.17 0.16,-0.22 0.17,-0.15 0.25,-0.02 0.22,-0.05 0.17,-0.09 0.08,-0.02 0.33,0.03 0.09,0.23 0.06,0.24 0.56,-0.08 0.25,-0.57 0.15,-0.08 0.24,-0.22 0.15,-0.18 0.13,0.08 0.21,0.32 0.21,0.26 0.12,0.09 0.02,0.09 0.11,0.03 0.21,0.01 0.14,0.06 0.07,0.25 0.04,0.23 -0.05,0.18 -0.01,0.15 0.15,0.04 0.19,-0.08 0.14,-0.1 0.46,0.13 0.1,-0.45 0.15,-0.24 0.21,-0.13 0.19,-0.16 0.17,-0.12 0.13,-0.01 0.05,-0.05 0.16,-0.01 0.19,0.02 0.24,-0.08 0.37,0.05 0.24,0.17 0.22,0.03 0.24,-0.04 0.15,-0.14 0.19,-0.4 0.17,-0.02 0.27,-0.1 0.38,-0.06 0.9,-0.05 0.25,0.11 0.57,0.1 0.27,0.17 0.14,0.23 0.08,0.17 0.61,0.18 0.88,0.2 z"
+         class="region SVK"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="slovenia"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S205P1-88"
+         d="m 296.34,297.98 -0.3,-0.1 -0.36,-0.02 -0.06,0.07 -0.13,0.08 -0.07,0.12 0.09,0.45 -0.08,0.08 -0.4,-0.01 -0.13,0.06 -0.19,0.33 -0.22,0.15 -0.27,0.11 -0.21,0.13 -0.25,0.12 -0.23,0.08 -0.08,0.14 -0.04,0.15 0.02,0.15 0.25,0.27 0.05,0.31 v 0.38 l -0.04,0.21 -0.08,0.14 -0.56,0.21 -0.57,0.35 -0.01,0.07 0.29,0.26 0.01,0.07 -0.21,0.17 -0.01,0.16 0.03,0.18 0.13,0.18 0.06,0.16 -0.32,0.14 -0.45,-0.01 -0.53,-0.2 -0.19,0.04 -0.17,0.13 -0.18,-0.04 -0.21,-0.13 -0.3,-0.29 -0.14,-0.17 -0.07,-0.2 -0.08,-0.02 -0.11,0.06 -0.08,0.25 -0.24,0.44 -0.19,0.13 -0.29,-0.01 -0.41,0.02 -0.26,0.05 -0.31,-0.13 -0.08,0.03 0.01,0.1 -0.11,0.16 -0.19,0.11 -0.9,-0.19 -0.13,-0.19 0.2,-0.1 0.26,-0.26 0.19,0.02 0.23,-0.06 0.1,-0.11 -0.16,-0.31 -0.38,-0.37 -0.2,-0.13 -0.27,-0.09 -0.05,-0.1 0.12,-0.62 -0.05,-0.08 -0.3,0.04 -0.08,-0.06 -0.02,-0.11 0.01,-0.14 0.2,-0.25 0.22,-0.22 0.05,-0.12 -0.01,-0.09 -0.29,-0.08 -0.18,-0.09 -0.14,-0.03 -0.1,0.06 -0.07,-0.06 -0.08,-0.17 0.06,-0.27 0.25,-0.26 0.28,-0.23 0.23,-0.17 0.14,-0.07 0.06,-0.28 0.14,0.02 0.29,0.01 0.33,0.04 0.3,0.07 0.27,0.08 0.56,0.07 0.5,0.04 0.16,0.05 0.12,-0.01 0.16,0.07 0.09,-0.07 0.06,-0.11 0.26,-0.15 0.25,-0.18 0.16,-0.23 0.09,-0.18 0.17,-0.13 0.18,-0.05 0.16,-0.07 0.71,-0.12 0.73,0.01 0.35,-0.14 0.27,-0.23 0.41,-0.09 h 0.02 l 0.64,0.11 0.04,-0.09 0.03,-0.05 -0.05,-0.45 0.18,-0.22 0.18,-0.11 0.63,-0.02 0.09,0.14 0.05,0.21 0.07,0.29 0.11,0.07 0.07,0.11 v 0.2 l 0.14,0.14 0.31,0.38 z"
+         class="region SVN"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="sweden"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S206P1-5"
+         d="m 292.52,251.2 -0.11,0.25 -0.12,-0.01 -0.11,-0.31 -0.09,-0.82 0.01,-0.41 0.44,-1.52 0.25,-0.14 0.27,-0.92 0.06,-0.41 0.12,-0.37 0.05,-0.33 0.07,-0.14 0.17,0.05 0.08,0.05 -0.16,0.2 0.05,0.24 -0.01,0.1 -0.34,1.1 -0.05,0.7 -0.14,0.18 z"
+         class="region SWE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S206P2"
+         d="m 298.33,243.2 -0.2,0.14 -0.08,0.35 -0.16,0.07 -0.15,0.13 0.07,1.07 0.35,0.36 -0.16,0.08 -0.13,0.14 -0.09,0.19 -0.06,0.39 -0.39,0.27 -0.14,0.17 -0.19,0.39 -0.06,0.53 -0.21,0.25 -0.26,0.08 0.1,-0.45 0.17,-0.36 -0.22,-0.22 -0.16,-0.36 -0.19,-0.27 0.09,-0.33 -0.12,-0.52 -0.04,-0.51 0.14,-0.28 0.18,-0.23 0.25,-0.51 0.3,-0.39 0.44,-0.21 0.23,0.13 0.05,-0.33 0.15,-0.09 0.15,0.05 z"
+         class="region SWE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S206P3"
+         d="m 298.48,242.77 -0.01,0.3 -0.14,-0.01 -0.14,-0.2 0.2,-0.36 0.37,-0.03 0.13,0.06 z"
+         class="region SWE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S206P4"
+         d="m 295.99,237.75 -0.11,0.05 h -0.05 l 0.04,-0.23 0.04,-0.1 0.15,-0.11 0.05,0.01 z"
+         class="region SWE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S206P5"
+         d="m 296.17,235.62 -0.04,0.16 -0.09,-0.19 0.02,-0.04 0.02,-0.19 0.1,-0.12 0.2,0.05 v 0.04 l -0.16,0.18 z"
+         class="region SWE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S206P6"
+         d="m 298.19,193.27 0.25,0.19 0.27,0.23 0.27,0.52 0.24,-0.02 0.11,0.18 0.28,0.29 0.35,0.23 0.01,0.09 -0.17,0.31 0.05,0.36 0.12,0.44 0.16,0.36 0.01,0.11 -0.03,0.14 -0.02,0.21 0.01,0.18 0.03,0.08 0.03,0.05 0.13,-0.02 h 0.23 l 0.14,0.05 0.17,0.42 v 0.08 l -0.15,0.23 -0.02,0.16 0.05,0.23 0.08,0.24 0.13,0.27 0.22,0.26 0.27,0.28 0.19,0.23 0.1,0.16 0.05,0.13 -0.05,0.17 -0.01,0.33 0.06,0.36 0.02,0.24 -0.11,0.35 -0.1,0.14 v 0.18 l 0.05,0.28 0.11,0.34 0.06,0.24 0.08,0.16 0.08,0.1 0.34,0.14 0.25,0.37 0.18,0.3 0.39,0.8 -0.48,0.2 -0.43,-0.14 -0.17,0.14 -0.33,0.06 -0.36,0.15 -0.09,0.19 -0.09,0.08 -0.4,-0.17 -0.41,-0.33 -0.18,0.34 -0.15,0.08 -0.19,-0.24 -0.13,-0.03 -0.05,0.1 -0.02,0.25 -0.05,0.2 v 0.12 l 0.07,0.48 v 0.11 l -0.34,-0.01 0.05,0.12 0.08,0.05 0.04,0.08 -0.1,0.12 -0.32,0.04 -0.02,0.12 0.13,0.16 -0.04,0.16 -0.06,0.07 -0.37,0.16 -0.23,0.01 -0.05,0.11 0.01,0.13 0.06,0.12 0.12,0.05 0.04,0.07 0.03,0.18 -0.08,0.04 -0.29,-0.27 -0.07,0.03 0.08,0.15 0.17,0.15 0.11,0.17 0.11,0.2 0.01,0.16 -0.2,0.57 -0.2,0.36 -0.15,0.33 -0.06,0.33 0.17,0.14 0.18,0.21 0.19,0.42 0.19,0.37 0.33,0.34 -0.02,0.22 -0.03,0.18 -0.36,0.43 -0.39,0.64 -0.29,1.5 -0.14,0.22 -0.43,0.31 -0.13,0.26 -0.31,0.33 -0.57,0.32 -0.23,0.37 -0.07,0.36 -0.14,0.04 -0.16,-0.11 -0.2,-0.08 0.01,0.23 0.03,0.16 -0.33,-0.21 -0.11,0.25 -0.06,0.39 -0.36,0.56 -0.48,-0.04 -0.04,0.1 0.14,0.05 0.03,0.08 -0.08,0.05 -0.13,0.01 -0.19,0.12 -0.13,0.01 -0.03,0.25 -0.06,0.3 -0.25,0.15 -0.13,0.04 -0.05,0.18 0.41,-0.01 -0.01,0.14 0.01,0.15 -0.03,0.15 -0.44,0.27 -0.05,0.18 -0.08,0.12 -0.21,0.01 v -0.1 l 0.02,-0.11 -0.31,0.04 -0.13,-0.24 -0.05,0.07 0.06,0.2 0.1,0.2 0.13,0.29 -0.05,0.2 -0.07,0.1 0.07,0.09 0.17,0.05 0.09,0.11 -0.19,0.12 -0.21,0.38 -0.25,0.04 -0.13,0.25 -0.17,0.01 -0.15,-0.13 -0.23,-0.1 -0.05,0.22 0.01,0.17 0.17,0.42 0.27,0.31 0.24,0.12 -0.15,0.11 -0.09,0.23 -0.07,0.69 -0.05,0.27 -0.03,0.47 0.09,0.39 0.07,0.19 0.13,0.26 -0.3,-0.01 -0.32,-0.12 0.07,0.31 -0.15,0.4 0.07,0.33 0.06,0.21 -0.02,0.37 0.1,0.1 0.08,0.21 -0.07,0.17 0.05,0.13 0.07,0.49 0.14,0.75 -0.01,0.16 0.25,0.64 -0.02,0.23 0.01,0.3 0.28,0.26 0.23,-0.03 0.22,-0.02 0.1,0.06 0.11,0.19 0.1,0.23 0.19,-0.04 0.28,-0.22 0.19,-0.07 0.17,0.36 0.41,0.45 0.24,0.2 0.36,0.07 0.42,0.36 0.01,0.48 0.17,0.14 0.47,0.13 0.18,0.24 0.11,0.21 0.14,0.16 0.2,0.52 v 0.34 l -0.17,0.14 -0.38,0.4 -0.15,0.29 -0.13,0.18 -0.38,0.4 -0.15,0.08 -0.12,0.2 -0.14,0.1 -0.13,-0.03 -0.45,0.38 0.06,0.14 0.37,0.02 0.18,-0.09 0.13,-0.18 0.15,-0.06 0.15,0.02 0.14,-0.15 0.11,-0.07 0.14,0.05 0.17,0.31 -0.26,0.19 -0.21,0.03 -0.04,0.54 -0.09,0.23 -0.08,0.12 -0.43,0.27 -0.27,0.32 -0.33,0.26 -0.16,-0.03 -0.21,0.25 -0.5,0.32 -0.23,0.4 -0.57,0.38 -0.28,0.3 -0.84,0.09 h -0.81 l -0.24,0.15 0.26,0.02 0.19,0.11 0.21,-0.07 0.52,0.02 0.27,0.05 0.37,0.41 -0.23,0.17 -0.42,0.16 0.22,0.61 0.17,0.41 -0.15,0.27 0.1,1.15 -0.25,0.05 -0.06,0.48 0.1,0.24 0.04,0.57 0.09,0.34 0.15,0.31 -0.02,0.34 -0.33,0.82 0.04,0.37 0.09,0.21 0.08,0.35 -0.12,0.68 -0.08,0.58 -0.11,0.48 -0.3,0.6 -0.14,0.44 -0.3,1.35 -0.18,0.28 -0.24,0.22 -0.29,-0.17 -0.26,-0.08 -0.31,0.03 -0.48,0.19 -0.74,-0.05 -0.71,0.09 -0.17,0.14 0.13,0.48 -0.26,0.07 -0.26,-0.12 -0.22,0.18 -0.18,0.19 -0.36,0.44 -0.11,0.27 v 0.5 l 0.22,0.43 0.2,0.51 -0.42,0.65 -0.25,0.04 -0.76,-0.14 -1.3,0.44 -1.2,-0.26 0.14,-0.35 -0.01,-0.24 0.05,-0.38 0.03,-0.39 -0.02,-0.26 -0.1,-0.28 -0.3,-0.35 -0.69,-1.2 -0.21,-0.51 -0.14,-0.22 0.1,-0.01 0.54,0.26 0.12,-0.04 0.13,-0.1 -0.17,-0.39 -0.14,-0.18 -0.1,-0.27 0.3,-0.08 0.23,0.01 0.15,-0.31 -0.11,-0.48 -0.25,-0.14 -0.2,-0.06 -0.4,-0.76 -0.41,-0.38 -0.74,-1.52 -0.28,-1.04 -0.24,0.1 -0.12,-0.45 -0.09,-0.43 -0.03,-0.32 -0.37,-0.18 -0.02,-0.22 -0.08,-0.99 -0.4,-0.13 -0.26,-0.55 -0.06,-1.06 -0.26,-0.19 -0.2,0.06 0.01,-0.26 0.04,-0.25 -0.13,-0.97 -0.05,-0.89 -0.1,-0.26 -0.05,-0.32 0.04,-0.27 0.07,-0.15 0.25,-0.05 0.23,0.24 0.21,0.6 0.18,0.08 0.25,-0.16 0.16,-0.45 0.09,-0.66 0.1,-0.63 -0.15,-0.67 -0.15,-0.59 -0.02,-0.17 0.37,-0.51 0.1,-0.4 0.12,-0.39 0.13,-0.13 0.2,-0.04 0.23,-0.08 0.29,-0.26 0.25,-0.35 0.2,-0.32 0.04,-0.63 v -0.32 l 0.08,-0.23 0.07,-0.46 -0.1,-0.45 -0.28,-0.67 -0.33,-0.95 -0.06,-0.52 0.13,-0.1 0.27,-0.1 0.5,-0.04 0.05,-0.06 0.04,-0.23 0.1,-0.31 0.11,-0.23 0.07,-0.33 0.03,-0.29 -0.3,-0.43 -0.38,-0.45 -0.26,-0.14 -0.45,-0.37 -0.32,-0.31 0.14,-1.21 0.11,-0.9 0.01,-0.22 v -0.34 l -0.46,-1.43 0.01,-0.32 0.03,-0.29 -0.06,-0.49 -0.03,-0.44 0.07,-0.13 0.16,-0.25 -0.17,-0.38 -0.02,-0.03 -0.32,-0.95 0.43,-0.95 -0.09,-0.48 0.26,-0.36 0.46,-0.82 0.26,-0.46 0.06,-0.08 0.21,-0.21 0.4,-0.25 0.45,-0.13 0.2,-0.01 0.78,0.13 0.62,0.1 0.08,-0.13 0.11,-0.26 0.14,-0.37 -0.01,-0.41 -0.09,-0.59 -0.11,-0.35 -0.43,-0.22 -0.48,-0.29 0.51,-1.03 0.35,-0.71 0.41,-1.07 0.12,-0.45 0.1,-0.17 0.03,-1.61 0.06,-0.46 0.06,-0.23 -0.01,-0.24 -0.08,-0.4 -0.19,-0.91 0.72,-0.15 0.23,-0.08 0.21,-0.13 0.41,-0.31 0.19,-0.26 -0.19,-0.84 0.23,-0.3 0.53,-1.05 0.58,-1 0.27,-0.39 0.02,-0.18 -0.01,-0.28 -0.18,-0.44 -0.17,-0.26 -0.33,-0.5 0.08,-0.38 0.2,-0.08 0.26,-0.17 0.18,-0.33 0.02,-0.04 0.23,-1.25 0.63,-0.68 0.23,-0.36 0.46,0.21 0.67,0.32 0.21,-0.59 0.07,-0.22 0.05,-0.31 -0.11,-0.53 -0.1,-0.68 -0.01,-0.28 0.23,-0.15 0.12,-0.05 0.72,0.21 0.17,-0.02 h 0.33 l 0.38,0.08 0.8,0.24 0.33,0.1 h 0.18 l 0.13,-0.17 0.25,-0.44 -0.52,-0.23 0.27,-0.34 0.11,-0.32 0.07,-0.38 -0.02,-0.44 -0.06,-0.22 -0.12,-0.15 -0.35,-0.35 0.63,-0.14 0.22,-0.05 0.5,0.19 0.03,0.05 0.03,0.14 0.04,0.13 0.52,0.29 0.16,0.17 0.33,0.24 0.1,0.14 0.3,0.14 0.22,0.17 0.25,0.12 0.3,0.2 0.38,0.14 0.3,0.01 0.79,0.21 z"
+         class="region SWE"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="gSYR"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S210P1-7"
+         d="m 373.83,337.56 -0.54,-0.88 -0.15,-0.41 -0.13,-0.49 v -0.79 l -0.18,-0.3 -0.07,-0.23 -0.13,-0.29 -0.67,-0.48 -0.07,-1.33 0.11,-0.36 0.27,-0.07 0.66,0.13 0.09,-0.04 0.04,-0.52 0.12,-0.22 0.31,-0.26 -0.11,-0.78 0.12,-0.2 0.17,-0.15 c 0.83662,-0.30209 0.42399,-0.52332 -0.09,-1.13 l -0.02,-0.23 -0.08,-0.92 0.02,-0.38 0.07,-0.15 z"
+         class="region SYR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         sodipodi:nodetypes="cccccccccccccccccccccccccc" />
+    </g>
+    <g
+       id="gTUN"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S220P2"
+         d="m 279.56,354.11 -0.6,0.33 0.11,-0.29 0.4,-0.35 0.1,0.08 z"
+         class="region TUN"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S220P3"
+         d="m 273.76,342.72 0.17,0.36 0.26,-0.21 -0.07,-0.15 -0.01,-0.19 0.43,-0.02 0.38,0.04 0.41,0.21 -0.03,0.8 0.56,0.79 -0.16,0.39 0.46,0.23 0.4,-0.28 0.21,-0.41 0.75,-0.24 0.7,-0.6 0.4,-0.06 0.09,0.49 0.19,0.43 -0.27,0.15 -0.34,0.46 -0.64,1.17 -0.61,0.34 -0.45,0.45 -0.14,0.31 -0.05,0.37 0.12,0.67 0.33,0.67 0.38,0.4 0.37,0.13 0.86,0.63 -0.01,0.38 0.12,0.45 0.05,0.55 0.31,0.44 -0.64,0.96 -0.35,0.69 -0.69,0.95 -0.62,0.61 -1.32,0.91 -0.33,0.31 -0.21,0.31 -0.1,0.33 0.03,0.38 -10.16,0.13 0.09,-0.47 0.17,-0.2 0.78,-0.57 0.38,-0.7 0.45,-0.25 0.38,-0.19 0.31,-0.23 0.29,-0.37 0.22,-0.39 0.04,-0.44 0.1,-0.69 0.15,-0.48 0.34,-0.54 -0.13,-0.45 -0.16,-0.48 0.07,-0.83 -0.03,-0.33 -0.13,-0.31 -0.13,-0.38 v -0.32 l 0.15,-0.83 0.12,-0.64 0.18,-0.82 -0.05,-0.24 -0.12,-0.17 -0.35,-0.2 -0.01,-0.11 0.1,-0.12 0.54,-0.39 0.3,-0.59 0.24,-0.11 0.37,-0.21 -0.01,-0.23 -0.07,-0.25 0.95,-0.26 0.91,-0.72 0.32,-0.17 2.1,-0.65 0.27,0.05 0.3,0.1 -0.09,0.25 z"
+         class="region TUN"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+    </g>
+    <g
+       id="turkey"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region TUR"
+         d="m 335.75,313.27 0.46,0.27 0.23,0.07 0.14,-0.09 0.25,-0.2 0.27,-0.07 0.22,-0.03 0.07,-0.13 0.16,-0.07 0.48,-0.03 0.02,0.55 0.33,0.53 0.67,0.68 0.6,0.28 2.27,0.48 0.4,-0.01 v 0.43 l -0.04,0.4 -0.09,0.28 -0.57,0.31 -1.77,-0.03 -0.43,0.07 -0.28,0.16 -0.48,0.46 -0.64,0.05 -0.82,0.39 -0.12,0.67 -0.46,0.85 -0.88,0.8 -0.65,0.46 -0.86,1.34 -0.37,0.74 -0.19,0.17 -0.22,0.15 0.02,-0.32 0.07,-0.31 -0.06,-0.2 -0.05,-0.31 0.29,-0.43 0.28,-0.33 0.87,-0.67 0.18,-0.44 -0.75,0.18 -0.74,0.26 -0.49,0.05 -0.41,0.12 -0.2,-0.31 -0.14,-0.17 0.1,-0.09 0.13,-0.07 0.18,-0.41 0.17,-0.31 0.25,-0.4 0.05,-0.22 -0.04,-0.18 -0.1,-0.11 -0.04,-0.15 -0.05,-0.21 -0.06,-0.45 0.62,-0.64 0.22,-0.1 0.03,-0.24 -0.15,-0.5 -0.17,-0.39 h -0.13 l -0.2,-0.08 -0.14,-0.12 -0.2,-0.11 -0.33,-0.03 -0.04,-0.13 0.01,-0.13 0.09,-0.16 0.5,-0.23 0.04,-0.11 0.03,-0.25 0.06,-0.26 0.1,-0.11 0.22,-0.04 0.41,-0.15 0.27,-0.14 0.26,-0.23 0.11,-0.18 0.61,-0.23 0.16,-0.11 0.18,0.02 z"
+         id="path15380" />
+      <path
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0"
+         class="region TUR"
+         d="m 332.57,323.1 -0.78,0.32 -0.28,-0.09 0.2,-0.33 0.45,-0.28 0.15,-0.05 0.25,0.23 z"
+         id="path15376" />
+      <path
+         id="polyF1S221P1-4"
+         d="m 332.57,323.1 -0.78,0.32 -0.28,-0.09 0.2,-0.33 0.45,-0.28 0.15,-0.05 0.25,0.23 z"
+         class="region TUR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+      <path
+         id="polyF1S221P2"
+         d="m 361.67,305.96 0.12,0.29 0.41,0.33 0.37,0.19 0.98,0.12 1.06,-0.79 0.2,-0.03 0.27,0.02 0.77,0.99 0.44,0.29 0.5,0.12 0.35,-0.08 0.17,-0.38 0.15,-0.19 0.41,-0.21 0.82,0.12 0.37,0.32 1.27,-0.15 1.13,-0.27 0.58,0.15 1.62,-0.27 0.55,-0.29 0.39,20.66 -0.61,0.06 -0.42,0.12 -0.07,0.15 -0.02,0.38 0.08,0.92 0.02,0.23 0.61,0.72 0.02,0.14 -0.25,0.14 -0.29,0.13 -0.17,0.15 -0.12,0.2 0.11,0.78 -0.31,0.26 -0.12,0.22 -0.04,0.52 -0.09,0.04 -0.66,-0.13 -0.27,0.07 0.13,-0.45 -0.44,-0.62 -0.45,-0.57 0.13,-0.52 0.38,-0.71 0.37,-0.8 -0.1,-0.37 -0.11,-0.28 -0.21,-0.14 -0.37,-0.15 -0.43,0.47 -0.27,0.44 -0.21,0.15 -0.21,0.27 -0.04,0.36 -0.24,0.36 -0.47,0.28 -0.84,0.01 -0.92,-0.12 -0.55,-0.16 -0.4,0.05 -0.32,0.27 -0.85,1.17 -0.67,1.51 -0.19,0.28 -0.8,0.82 -0.57,0.37 -0.3,0.06 -1.17,0.62 -0.6,0.23 -0.42,0.42 -1.01,0.01 -0.65,-0.19 -0.42,-0.28 -0.74,-0.64 -0.48,-0.27 -0.96,-0.08 -1.72,-0.39 -0.43,0.03 -1.07,0.18 -1.12,0.25 -0.15,0.37 0.18,1.25 -0.12,0.39 0.06,0.66 -0.1,0.22 -0.19,0.18 -0.38,-0.11 -0.25,-0.02 -0.48,0.41 -1,0.66 -0.35,0.15 -1.35,-0.12 -0.51,-0.18 -0.36,-0.25 -0.22,-0.53 -0.24,-0.27 -0.07,-0.21 -0.13,-0.23 -0.27,-0.04 -0.23,0.26 -0.29,0.07 -0.38,-0.02 -0.95,-0.25 -0.67,0.13 -0.28,0.66 -0.28,0.26 -0.33,0.14 -0.05,-0.16 0.19,-0.43 -1.01,0.32 -0.5,0.41 -0.43,0.06 -0.34,-0.05 0.02,-0.17 0.31,-0.13 0.26,-0.2 1.09,-0.37 0.24,-0.17 0.21,-0.47 0.45,-0.47 0.04,-0.17 -0.4,0.1 -1.68,0.52 -1.18,0.22 -0.11,0.2 -0.17,0.07 -0.14,-0.46 0.15,-0.26 0.25,-0.04 0.58,-0.33 -0.13,-0.37 -0.49,-0.16 -0.11,-0.14 -0.33,0.04 -0.29,-0.12 -0.14,-0.46 -0.3,-0.46 -0.33,-0.18 0.01,-0.15 0.5,-0.3 -0.02,-0.74 -0.17,-0.42 -0.27,0.02 -0.84,-0.16 -0.23,0.09 -0.33,-0.33 -0.5,-0.17 -0.21,0.15 -0.12,0.16 -0.22,-0.01 -0.39,-0.16 -0.37,-0.06 -0.18,-0.12 0.12,-0.47 0.26,-0.05 -0.01,-0.35 -0.31,-0.51 -0.03,-0.29 0.22,-0.13 h 0.27 l 0.32,0.27 0.15,0.31 v 0.32 l 0.22,0.27 0.13,0.05 0.02,-0.34 0.11,-0.09 0.17,0.11 0.35,-0.01 0.82,-0.39 0.13,-0.2 -0.62,0.16 -0.26,-0.1 -0.31,-0.29 -0.21,-0.28 -0.06,-0.15 -0.13,-0.21 0.08,-0.14 0.39,-0.28 0.28,-0.6 -0.18,-0.11 -0.2,-0.03 -0.18,0.09 -0.22,-0.13 -0.06,-0.24 0.11,-0.23 -0.04,-0.27 -0.6,-0.56 -0.16,-0.11 0.06,-0.25 0.3,-0.44 0.26,-0.54 -0.07,-0.14 h -0.27 l -1.18,0.47 -0.44,0.28 -0.84,0.26 -0.1,-0.23 -0.02,-0.23 0.11,-0.45 -0.19,-0.99 0.01,-0.57 0.44,-0.26 0.43,-0.92 0.75,-1.15 0.96,-0.2 0.33,-0.35 0.57,-0.15 0.14,0.17 0.1,0.16 0.55,0.14 0.88,-0.25 0.19,-0.15 0.18,-0.2 -0.5,-0.36 0.1,-0.16 0.37,-0.1 0.42,0.01 0.04,0.1 -0.08,0.17 -0.07,0.28 0.13,0.02 1.1,-0.43 1.22,-0.18 0.36,-0.16 0.93,-0.24 0.13,-0.2 -0.32,-0.13 -0.29,0.01 -0.21,-0.05 -0.21,-0.09 0.49,-0.6 0.32,-0.17 1.5,-0.69 1.13,-0.45 -0.01,-0.1 -0.17,0.04 -1.54,0.18 -0.4,-0.08 -0.6,-0.28 -0.13,-0.09 -0.17,-0.17 -0.02,-0.45 0.02,-0.38 0.14,-0.24 0.58,-0.19 2.12,-0.2 1.4,-0.61 1.7,0.06 1.48,-0.54 0.26,-0.32 0.19,-0.86 1.8,-1.86 0.56,-0.87 0.69,-0.6 1.24,-0.81 0.97,-0.88 0.31,-0.16 2.72,-0.65 1.83,-0.59 0.69,-0.78 0.53,-0.01 0.01,0.19 z"
+         class="region TUR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel"
+         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+      <path
+         id="polyF1S221P3"
+         d="m 335.75,313.27 0.46,0.27 0.23,0.07 0.14,-0.09 0.25,-0.2 0.27,-0.07 0.22,-0.03 0.07,-0.13 0.16,-0.07 0.48,-0.03 0.02,0.55 0.33,0.53 0.67,0.68 0.6,0.28 2.27,0.48 0.4,-0.01 v 0.43 l -0.04,0.4 -0.09,0.28 -0.57,0.31 -1.77,-0.03 -0.43,0.07 -0.28,0.16 -0.48,0.46 -0.64,0.05 -0.82,0.39 -0.12,0.67 -0.46,0.85 -0.88,0.8 -0.65,0.46 -0.86,1.34 -0.37,0.74 -0.19,0.17 -0.22,0.15 0.02,-0.32 0.07,-0.31 -0.06,-0.2 -0.05,-0.31 0.29,-0.43 0.28,-0.33 0.87,-0.67 0.18,-0.44 -0.75,0.18 -0.74,0.26 -0.49,0.05 -0.41,0.12 -0.2,-0.31 -0.14,-0.17 0.1,-0.09 0.13,-0.07 0.18,-0.41 0.17,-0.31 0.25,-0.4 0.05,-0.22 -0.04,-0.18 -0.1,-0.11 -0.04,-0.15 -0.05,-0.21 -0.06,-0.45 0.62,-0.64 0.22,-0.1 0.03,-0.24 -0.15,-0.5 -0.17,-0.39 h -0.13 l -0.2,-0.08 -0.14,-0.12 -0.2,-0.11 -0.33,-0.03 -0.04,-0.13 0.01,-0.13 0.09,-0.16 0.5,-0.23 0.04,-0.11 0.03,-0.25 0.06,-0.26 0.1,-0.11 0.22,-0.04 0.41,-0.15 0.27,-0.14 0.26,-0.23 0.11,-0.18 0.61,-0.23 0.16,-0.11 0.18,0.02 z"
+         class="region TUR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none;stroke-width:0.25;stroke-linejoin:bevel" />
+    </g>
+    <g
+       id="ukraine"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S225P1-86"
+         d="m 346.29,289.88 0.49,0.09 -0.46,0.08 -1.01,0.08 -0.48,-0.08 -0.17,-0.19 -0.14,-0.29 0.32,0.25 0.21,0.1 z"
+         class="region UKR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S225P2"
+         d="m 342.02,260.45 0.44,-0.14 0.31,-0.16 0.27,0.06 0.38,0.2 0.39,0.35 0.53,0.71 1.08,0.64 0.07,0.17 -0.02,0.14 -0.35,0.24 -0.3,0.17 0.04,0.16 0.14,0.14 0.23,0.2 0.12,0.3 0.09,0.3 0.15,0.24 0.16,0.06 0.06,0.12 -0.09,0.21 -0.01,0.11 0.08,0.04 0.71,-0.22 0.4,0.04 0.31,0.05 0.13,-0.04 0.27,-0.19 0.31,-0.18 0.2,-0.08 0.12,0.08 0.15,0.25 0.21,0.23 0.14,0.04 0.19,-0.09 0.12,-0.03 0.1,0.09 -0.02,0.18 0.08,0.16 0.15,0.17 0.27,0.44 0.14,0.11 0.13,0.16 0.07,0.21 -0.02,0.21 v 0.16 l 0.16,0.3 0.34,0.28 0.19,0.04 0.24,0.27 0.26,0.02 0.25,-0.39 0.21,-0.24 0.35,-0.04 0.32,-0.06 0.26,0.11 0.24,0.19 0.23,0.08 0.14,-0.14 0.39,-0.06 0.24,0.14 0.21,0.05 0.15,-0.24 0.1,-0.28 0.55,-0.45 0.37,-0.21 0.09,-0.09 0.18,-0.24 0.2,-0.19 0.23,-0.06 0.33,0.23 0.3,0.13 0.19,0.32 0.45,0.37 0.92,0.37 0.34,0.1 0.17,-0.11 0.07,-0.09 0.02,-0.09 -0.08,-0.33 0.04,-0.15 0.13,-0.06 0.68,0.18 0.29,-0.08 0.27,-0.1 0.47,0.16 0.49,0.11 0.3,-0.1 0.2,-0.21 0.14,-0.13 0.14,0.06 0.18,0.19 0.23,0.11 0.2,-0.03 0.26,-0.09 0.58,0.15 0.56,0.16 0.27,-0.09 0.18,-0.2 0.18,-0.11 0.17,0.02 0.1,0.14 -0.02,0.24 0.12,0.29 0.3,0.2 0.12,0.27 0.04,0.27 -0.01,0.27 -0.13,0.43 -0.12,0.39 -0.31,0.28 -0.15,0.22 0.14,0.19 0.21,0.14 0.37,0.03 0.39,-0.03 0.09,0.11 -0.02,0.09 -0.2,0.16 -0.33,0.07 -0.06,0.16 -0.06,0.25 0.04,0.38 0.05,0.35 0.37,-0.06 0.24,0.04 0.17,0.23 0.18,0.26 0.13,0.25 -0.07,0.18 0.05,0.13 0.08,0.04 0.15,-0.03 0.14,0.01 0.06,0.13 -0.09,0.4 0.03,0.68 0.02,0.36 0.14,0.34 -0.04,0.24 -0.21,0.11 -0.74,0.36 -0.67,0.26 -0.3,0.08 -0.46,0.15 -0.19,0.18 -0.09,0.67 -0.14,0.31 -0.3,0.35 -0.38,0.22 -0.15,0.32 0.05,0.39 0.11,0.32 0.02,0.17 -0.04,0.18 0.01,0.11 0.05,0.1 h 0.11 0.14 l 0.03,0.08 -0.01,0.12 -0.09,0.16 v 0.19 l 0.08,0.17 0.1,0.19 -0.09,0.09 -1.04,0.34 -0.79,0.43 -0.35,0.94 -0.35,0.14 -0.44,0.38 -0.26,0.36 -0.23,0.66 -0.39,-0.1 -0.38,0.15 -0.33,0.28 -0.34,0.5 -0.23,0.15 -0.54,0.1 -0.52,0.41 -0.92,1.56 -0.17,0.96 -0.11,0.22 -0.16,0.27 -0.2,0.18 -0.12,0.04 0.43,-0.79 0.12,-0.29 -0.02,-0.17 -0.08,-0.25 -0.29,-0.25 -0.25,0.96 -0.25,0.22 -0.28,0.36 0.15,0.54 0.16,0.38 0.3,0.44 0.61,0.68 1.09,0.89 0.48,0.3 0.31,0.07 0.32,-0.08 0.47,-0.57 0.23,-0.15 0.59,-0.07 0.12,-0.31 0.24,-0.24 0.36,-0.15 0.45,-0.05 0.51,0.01 -0.05,0.47 -0.09,0.4 0.05,0.38 0.03,0.44 -0.45,0.36 -0.54,0.18 -0.53,0.33 -0.25,-0.08 -0.18,-0.09 -0.3,-0.05 -0.35,0.04 -0.27,0.2 -0.18,0.67 -0.51,0.6 -0.08,0.5 -0.65,0.12 -0.5,0.26 -0.65,0.66 -0.34,1.04 -0.5,0.74 -0.47,0.34 -0.5,0.11 -0.36,-0.05 -0.8,-0.34 -0.02,-0.2 0.06,-0.13 0.04,-0.33 -0.04,-1.12 -0.14,-0.32 -0.29,-0.48 -0.63,-0.25 -0.39,0.21 -0.26,-0.03 -1.04,-0.43 -0.47,0.09 -0.46,0.31 -0.22,-0.05 -0.2,-0.2 0.75,-1.18 0.77,-1.03 0.4,-0.21 0.48,-0.52 0.46,-0.7 -0.2,-0.37 -0.21,-0.24 -0.27,0.17 -0.19,0.17 -0.6,-0.14 -0.25,-0.17 -0.73,0.5 -0.46,0.1 -0.92,0.54 -0.52,-0.08 -1.07,-0.31 -0.38,-0.02 -0.28,0.11 -0.21,-0.15 0.16,-0.15 0.23,-0.08 0.21,-0.15 0.04,-0.12 -0.07,-0.2 h -0.51 l -0.45,0.09 -0.33,-0.09 -0.27,-0.14 0.5,-0.16 0.54,0.01 0.79,-0.19 0.75,-0.06 0.13,-0.25 0.31,-0.47 0.04,-0.13 -0.61,0.45 -0.74,0.06 -0.31,-0.13 -0.3,-0.23 -0.19,-0.32 -0.03,-0.35 -0.24,-0.56 -0.37,-0.45 -0.16,-0.26 -0.31,-0.18 0.39,0.5 0.2,0.36 0.24,0.31 0.23,0.95 v 0.36 l -0.26,0.17 -0.39,0.07 -0.41,0.01 -0.05,-0.55 -0.15,0.24 -0.16,0.59 -0.23,0.15 -0.58,0.12 -0.97,0.64 0.03,0.38 -0.03,0.54 -0.08,0.33 -0.01,0.19 -0.26,0.87 -0.04,0.09 -0.59,1.27 -0.09,0.11 -0.5,0.4 -0.28,0.3 -0.23,0.16 -0.46,0.01 -0.14,0.2 -0.04,0.21 0.09,0.38 0.28,0.22 0.41,0.86 0.02,0.41 -0.23,-0.21 -0.33,-0.19 -0.58,-0.09 -0.56,0.23 -0.53,0.55 -0.4,0.25 -0.24,-0.04 -0.14,0.04 -0.02,0.13 0.03,0.08 0.09,0.06 v 0.05 l -0.08,0.05 -1.06,-0.01 -0.49,-0.15 -0.44,-0.4 0.13,-0.19 0.13,-0.11 0.51,-0.17 0.08,-0.07 -0.02,-0.11 0.01,-0.16 -0.07,-0.2 -0.1,-0.21 0.15,-0.38 0.27,-0.36 0.13,-0.32 -0.06,-0.4 0.31,-0.29 0.23,-0.41 -0.01,-0.38 0.06,-0.25 -0.32,-0.47 -0.13,-0.33 -0.07,-0.29 0.06,-0.18 0.24,-0.26 0.27,-0.21 0.13,-0.02 0.06,0.07 0.16,0.58 h 0.06 l 0.08,-0.1 0.07,-0.39 0.13,0.08 0.18,-0.01 0.1,-0.12 0.09,-0.01 0.12,0.06 0.23,0.07 0.2,-0.01 0.13,-0.13 0.1,-0.18 0.15,0.01 0.37,0.33 0.12,-0.08 0.59,-0.25 0.07,-0.13 0.05,-0.12 -0.78,-0.36 -0.06,-0.41 -0.1,-0.46 -0.14,-0.25 -0.18,-0.19 -0.55,-0.11 -0.44,-0.16 -0.11,-0.09 -0.05,-0.15 -0.07,-0.23 -0.2,-0.17 -0.06,-0.16 0.03,-0.3 -0.05,-0.29 -0.05,-0.1 -0.12,-0.07 -0.17,0.04 -0.26,-0.11 -0.21,-0.18 -0.48,-0.21 -0.14,-0.02 -0.12,-0.14 -0.08,-0.18 0.03,-0.25 0.02,-0.39 -0.01,-0.36 -0.05,-0.2 -0.17,-0.49 -0.31,-0.32 -0.11,-0.03 -0.14,0.15 -0.17,0.14 -0.18,-0.04 -0.22,-0.16 -0.42,-0.51 -0.55,0.02 -0.23,0.03 -0.13,0.33 -0.09,-0.07 -0.1,-0.16 -0.12,-0.05 -0.13,0.12 -0.06,-0.07 0.01,-0.25 -0.2,-0.08 -0.4,0.1 -0.24,-0.03 -0.07,-0.18 -0.15,-0.08 h -0.24 l -0.26,-0.1 -0.27,-0.18 -0.35,-0.08 -0.45,0.03 -0.04,-0.02 -0.05,-0.02 -0.24,0.22 -0.13,0.17 -0.23,-0.03 -0.26,0.36 -0.67,0.18 -0.33,0.05 -0.18,-0.03 -0.54,0.58 -0.04,0.18 -0.13,0.08 -0.38,0.18 -0.39,0.21 v 0.45 l -0.08,0.25 -0.16,0.39 -0.76,0.29 -0.65,0.31 -0.68,0.25 -0.84,0.6 -0.23,0.42 -0.27,0.16 -0.26,0.09 -0.22,-0.17 -0.68,-0.43 -0.27,-0.21 -0.31,-0.02 -0.32,0.1 -0.28,0.19 -0.32,0.09 -0.41,-0.12 -0.03,0.03 -0.14,0.05 -0.95,-0.05 -0.09,-0.02 -0.05,-0.01 -0.13,0.01 -0.68,0.15 -0.72,-0.33 -0.2,0.02 -0.12,0.21 -0.08,0.22 -0.41,0.28 -0.1,0.1 -0.08,-0.06 -0.06,-0.16 0.01,-0.16 -0.09,-0.14 -0.19,-0.13 -0.06,-0.07 -0.2,0.05 -0.06,0.03 h -0.02 l -0.32,-0.09 -0.25,-0.31 -0.33,-0.13 -0.24,-0.02 -0.12,-0.13 -0.1,-0.18 -0.09,-0.13 -0.01,-0.02 -0.09,-0.21 -0.07,-0.01 h -0.02 l -0.29,0.08 -0.08,-0.77 0.39,-0.64 0.07,-0.3 0.08,-0.63 0.09,-0.31 0.12,-0.26 0.09,-0.25 0.01,-0.2 0.12,-0.04 0.4,0.11 0.35,0.03 0.08,-0.1 0.02,-0.12 -0.03,-0.08 -0.31,-0.22 -0.19,-0.13 -0.03,-0.1 0.02,-0.24 -0.01,-0.27 -0.08,-0.27 -0.28,-0.58 -0.08,-0.26 0.12,-0.34 0.44,-0.86 0.14,-0.31 0.19,-0.39 0.55,-0.94 0.35,-0.56 0.25,-0.31 0.34,-0.54 0.15,-0.27 0.75,-0.3 0.05,-0.24 0.1,-0.27 0.09,-0.12 -0.06,-0.41 -0.24,-0.48 -0.14,-0.15 -0.11,-0.11 0.03,-0.12 0.08,-0.05 0.1,-0.03 0.11,-0.15 -0.05,-0.12 -0.38,-0.26 -0.19,-0.22 -0.33,-0.59 -0.57,-0.57 -0.17,-0.19 -0.06,-0.2 0.03,-0.21 -0.11,-0.24 -0.21,-0.3 0.01,-0.04 -0.08,-0.4 0.09,-0.11 0.17,-0.09 0.24,-0.02 0.23,0.02 0.28,0.14 0.08,-0.05 0.36,-0.42 0.35,-0.61 0.06,-0.32 0.09,-0.16 0.37,-0.15 0.32,-0.09 0.22,-0.04 0.51,-0.15 0.3,-0.12 0.24,-0.15 0.57,-0.15 0.91,-0.12 0.59,-0.12 0.4,-0.04 1.04,0.06 0.37,-0.03 0.2,0.11 0.34,-0.02 0.62,0.02 0.53,-0.04 0.34,-0.11 0.2,-0.01 0.52,0.56 0.09,0.06 0.15,-0.02 0.28,-0.12 0.43,-0.08 0.29,0.07 0.05,0.4 0.08,0.04 0.12,-0.05 0.08,-0.25 0.06,-0.26 0.07,-0.09 0.47,0.05 0.19,-0.07 0.14,-0.22 0.1,-0.06 0.34,0.05 0.4,-0.01 0.3,-0.07 0.22,0.04 0.24,0.37 0.14,0.05 0.12,-0.01 0.09,-0.4 0.12,-0.18 0.2,-0.16 0.13,-0.08 0.06,-0.15 0.11,-0.16 0.11,-0.04 0.11,0.02 0.15,0.14 0.26,0.35 0.3,0.34 0.17,0.1 0.32,-0.21 0.2,-0.19 0.43,-0.14 0.55,-0.24 0.4,-0.23 0.28,-0.06 0.2,0.08 0.32,0.17 0.16,0.32 0.39,0.15 0.28,-0.03 0.03,-0.28 0.1,-0.21 -0.12,-0.22 -0.11,-0.29 -0.19,-0.25 -0.17,-0.28 0.03,-0.47 0.05,-0.41 0.02,-0.23 0.14,-0.44 0.17,-0.34 0.25,-0.54 0.23,-0.22 0.27,-0.01 0.15,0.02 0.28,-0.36 0.63,-0.2 0.53,-0.13 h 0.05 l 0.3,0.05 0.3,0.03 0.19,-0.05 0.21,-0.1 0.22,-0.22 0.13,-0.2 v -0.8 l 0.04,-0.12 0.11,-0.1 0.19,-0.07 0.42,0.02 0.47,-0.02 0.25,-0.1 0.55,-0.6 0.36,-0.18 z"
+         class="region UKR"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="vatican"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
+       style="fill:#c0c1c5;fill-opacity:1;stroke:none">
+      <path
+         id="polyF1S229P1-3"
+         d="m 283.42,320.62 h -0.03 l -0.01,-0.01 0.01,-0.03 h 0.03 z"
+         class="region VAT"
+         inkscape:connector-curvature="0"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+      <circle
+         r="0.25"
+         id="pointF2S66P1"
+         cy="320.60852"
+         cx="283.46643"
+         class="region VAT"
+         style="fill:#c0c1c5;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Lakes"
+     inkscape:label="Lakes"
+     transform="translate(-603.68384,627.99738)"
+     sodipodi:insensitive="true">
+    <g
+       id="gF1S1-2"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S1P1-3"
+         d="m 294.76,236.44 -0.22,0.3 -0.75,0.09 -0.24,-0.09 -0.26,0.01 -0.15,0.12 -0.35,-0.37 -0.28,-0.05 -0.4,-0.31 -0.41,0.1 -0.33,-0.08 -1.13,0.12 -0.25,-0.13 0.5,-0.11 0.52,-0.16 0.2,-0.46 0.2,0.23 0.27,0.06 0.19,-0.23 0.35,0.15 0.19,-0.11 0.79,0.28 v -0.42 l 0.37,0.18 0.37,-0.05 -0.07,-0.25 0.2,-0.14 0.07,0.1 0.08,0.21 -0.01,0.66 0.15,0.15 0.34,0.06 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S2-77"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S2P1-6"
+         d="m 320.33,222.57 0.03,-0.08 -0.01,-0.05 -0.05,-0.09 0.05,-0.13 0.13,-0.01 0.23,0.11 0.12,0.03 0.01,-0.08 -0.03,-0.06 -0.04,-0.13 0.07,-0.08 0.1,-0.03 0.02,-0.08 -0.02,-0.09 -0.05,-0.05 -0.03,-0.05 0.03,-0.09 -0.02,-0.14 -0.01,-0.06 0.03,-0.08 0.01,-0.07 -0.02,-0.06 -0.07,-0.08 -0.02,-0.1 0.1,-0.04 0.43,0.02 0.03,-0.02 -0.03,-0.11 0.05,-0.07 0.06,-0.07 0.11,-0.06 v -0.09 l -0.08,-0.07 -0.04,-0.12 0.17,-0.68 0.14,-0.24 0.09,0.02 0.03,0.04 0.04,0.05 0.3,0.05 0.1,0.1 0.1,0.19 0.09,0.09 0.14,-0.03 v -0.06 l 0.13,-0.1 h 0.04 l 0.1,0.1 0.06,0.03 0.03,-0.07 -0.01,-0.05 0.07,-0.02 0.37,0.27 0.18,0.21 0.19,0.24 0.08,0.05 0.03,-0.03 -0.03,-0.06 -0.02,-0.09 0.03,-0.02 0.2,0.17 0.19,0.11 0.29,0.09 0.09,0.09 1.21,0.33 0.46,0.17 0.14,0.15 0.09,0.14 0.05,0.14 0.05,0.07 0.11,0.02 0.04,0.07 0.4,0.29 0.19,0.24 0.12,0.31 0.14,0.18 0.16,0.04 0.11,0.08 0.06,0.12 0.01,0.28 -0.01,0.44 -0.03,0.09 h -0.08 l -0.18,-0.11 -0.2,-0.02 -0.09,0.05 0.03,0.1 0.1,0.15 0.18,0.18 0.08,0.15 -0.01,0.11 -0.11,0.12 0.03,0.11 0.12,0.18 0.06,0.19 -0.01,0.18 -0.13,0.2 -0.26,0.23 -0.24,0.04 -0.2,-0.14 -0.36,-0.05 -0.51,0.05 -0.3,0.15 -0.12,0.37 v 0.07 l 0.03,0.05 h 0.02 l 0.02,0.04 -0.04,0.32 0.04,0.17 0.11,0.15 0.05,0.14 v 0.13 l -0.06,0.12 -0.1,0.09 -0.13,0.02 -0.15,-0.06 -0.17,0.03 -0.21,0.12 -0.16,0.03 -0.11,-0.04 -0.06,-0.02 0.02,-0.07 0.13,-0.25 -0.05,-0.11 -0.12,-0.09 -0.06,-0.12 -0.03,-0.24 -0.03,-0.05 -0.27,-0.15 -0.24,-0.28 -0.5,-0.74 -0.06,-0.06 h -0.04 l -0.01,0.07 -0.06,0.01 -0.07,-0.2 -0.08,-0.14 -0.13,-0.14 -0.18,-0.11 -0.34,-0.08 -0.06,-0.11 -0.11,-0.21 -0.04,-0.13 0.03,-0.04 -0.02,-0.13 -0.07,-0.2 -0.11,-0.13 -0.12,-0.05 -0.05,-0.05 -0.06,-0.13 -0.09,-0.1 -0.37,-0.28 -0.48,-0.27 -0.73,-0.29 -0.1,-0.11 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S18-5"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S18P1-6"
+         d="m 285.22,238.33 0.06,-0.07 0.04,-0.01 0.02,0.03 0.01,0.06 -0.02,0.07 -0.02,0.18 -0.03,0.05 -0.02,0.03 -0.02,0.03 -0.07,0.01 -0.04,0.09 0.01,0.19 v 0.22 l -0.03,0.16 -0.04,0.11 -0.07,0.1 -0.08,0.11 -0.07,0.14 -0.07,0.13 -0.07,0.11 -0.15,0.1 -0.26,0.1 -0.28,0.11 -0.19,0.11 -0.19,0.13 -0.14,0.27 -0.14,0.23 -0.11,0.02 h -0.06 l -0.06,-0.05 -0.03,-0.09 0.03,-0.08 -0.01,-0.07 v -0.12 l -0.09,-0.05 -0.18,0.03 -0.22,0.16 -0.09,0.13 -0.11,0.2 -0.17,0.09 -0.17,0.17 -0.12,0.15 -0.07,0.12 -0.06,0.07 -0.06,0.03 -0.05,0.02 h -0.05 l -0.03,-0.03 0.01,-0.08 0.04,-0.11 v -0.07 l -0.04,0.02 -0.12,0.16 -0.33,0.07 -0.1,0.05 -0.05,-0.1 0.03,-0.19 0.39,-0.39 0.28,-0.5 0.01,-0.11 -0.13,-0.04 -0.09,-0.05 -0.06,-0.16 -0.01,-0.16 -0.01,-0.17 -0.07,-0.09 h -0.06 l -0.06,-0.08 0.02,-0.06 0.06,-0.02 0.04,-0.11 -0.01,-0.17 -0.03,-0.21 0.01,-0.07 0.03,0.02 0.04,0.05 0.04,0.09 0.03,0.16 0.02,0.1 0.02,0.06 0.06,0.07 0.04,-0.04 0.06,-0.09 0.04,-0.2 0.06,-0.22 0.06,-0.26 0.08,-0.24 0.08,-0.14 0.1,-0.05 0.08,-0.03 0.13,0.04 0.19,0.11 0.24,0.15 0.06,0.17 0.07,0.15 0.09,0.12 0.1,0.07 0.08,0.03 0.1,-0.04 0.02,-0.12 -0.07,-0.29 -0.13,-0.5 -0.15,-0.47 -0.06,-0.27 v -0.09 l 0.01,-0.05 0.02,-0.05 0.02,-0.12 0.03,-0.11 0.03,-0.05 0.04,0.03 0.05,0.1 0.07,0.07 h 0.07 l 0.01,-0.03 v -0.04 l -0.01,-0.06 0.01,-0.04 0.02,-0.03 0.04,-0.03 0.09,-0.02 0.15,-0.02 0.2,-0.04 0.21,-0.06 0.2,-0.05 h 0.12 l 0.1,0.05 0.05,0.08 0.02,0.09 0.02,0.05 h 0.04 l 0.08,-0.04 0.07,-0.02 0.09,0.03 0.1,0.03 0.07,-0.02 0.06,-0.02 0.09,0.02 0.08,0.04 0.04,0.03 0.02,0.04 0.01,0.07 0.01,0.1 -0.01,0.13 -0.04,0.18 -0.07,0.22 -0.11,0.22 -0.03,0.11 0.04,0.11 h 0.07 l 0.08,-0.01 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S25-5"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S25P1-3"
+         d="m 334.05,217.28 0.05,0.08 0.04,0.11 0.02,0.14 0.01,0.09 v 0.08 0.02 l 0.01,0.05 0.02,0.06 0.04,0.07 0.05,0.06 0.05,0.08 0.03,0.1 -0.01,0.13 -0.03,0.13 -0.06,0.14 -0.08,0.12 -0.11,0.1 -0.09,0.14 -0.07,0.2 -0.07,0.2 -0.08,0.17 -0.04,0.11 0.04,0.07 0.07,0.05 0.04,0.06 v 0.06 l -0.02,0.07 -0.04,0.05 -0.05,0.04 h -0.07 l -0.08,-0.04 -0.15,-0.04 h -0.2 l -0.21,-0.02 -0.17,-0.1 -0.11,-0.13 -0.09,-0.07 -0.06,-0.03 -0.07,-0.01 -0.08,0.04 -0.08,0.08 -0.1,0.11 -0.14,0.09 -0.11,0.03 -0.06,-0.05 -0.09,-0.09 -0.18,-0.03 -0.18,0.03 -0.06,0.14 -0.02,0.11 -0.05,0.02 -0.06,-0.04 -0.05,-0.06 -0.06,-0.08 -0.06,-0.09 -0.04,-0.12 -0.03,-0.12 -0.01,-0.12 v -0.11 l 0.09,-0.09 0.17,-0.09 0.22,-0.05 h 0.2 l 0.13,0.03 0.07,0.04 -0.04,0.04 -0.13,0.06 -0.13,0.07 -0.03,0.07 0.04,0.06 0.07,0.06 0.09,0.05 0.1,0.04 h 0.12 l 0.14,-0.04 0.18,-0.09 0.21,-0.03 0.26,0.11 0.09,-0.09 v -0.21 l -0.02,-0.16 -0.09,-0.18 -0.12,-0.19 -0.16,-0.2 -0.16,-0.17 -0.16,-0.13 -0.12,-0.09 -0.18,-0.09 -0.27,-0.12 -0.41,-0.13 -0.51,-0.12 -0.49,-0.11 -0.39,-0.14 -0.29,-0.15 -0.26,-0.15 -0.19,-0.15 -0.15,-0.12 -0.09,-0.09 -0.04,-0.06 h 0.05 l 0.14,0.06 0.17,0.07 0.12,0.01 0.07,-0.04 0.04,-0.08 v -0.11 l -0.02,-0.13 -0.06,-0.14 -0.07,-0.14 -0.09,-0.12 -0.11,-0.12 -0.2,-0.13 -0.29,-0.17 -0.26,-0.15 -0.13,-0.1 -0.03,-0.07 -0.02,-0.12 -0.04,-0.12 -0.06,-0.1 -0.13,-0.12 -0.19,-0.16 -0.21,-0.13 -0.14,-0.04 -0.09,0.01 -0.06,-0.01 -0.06,-0.07 -0.08,-0.11 -0.06,-0.13 -0.03,-0.08 0.02,-0.05 0.03,-0.04 0.05,-0.02 h 0.05 l 0.09,0.06 0.11,0.12 0.19,0.18 0.27,0.22 0.25,0.19 0.13,0.12 0.03,0.08 0.02,0.09 0.09,0.11 0.22,0.13 0.27,0.1 0.2,0.04 0.09,-0.02 0.01,-0.07 -0.06,-0.12 -0.11,-0.19 -0.02,-0.15 -0.03,-0.15 -0.19,-0.23 -0.08,-0.15 0.04,-0.06 0.11,0.01 -0.02,-0.12 -0.14,-0.16 -0.23,-0.18 -0.16,-0.15 -0.08,-0.1 -0.05,-0.07 0.02,-0.03 0.06,0.01 0.11,0.06 0.15,0.1 0.19,0.17 0.23,0.22 0.19,0.19 0.1,0.07 0.05,0.06 0.08,0.15 0.09,0.17 0.11,0.13 0.12,0.09 0.17,0.15 0.18,0.14 0.13,0.08 0.08,-0.03 0.04,-0.11 0.02,-0.05 -0.02,-0.07 -0.11,-0.12 -0.18,-0.16 -0.15,-0.15 -0.05,-0.07 0.13,0.01 0.23,0.06 0.25,0.06 0.14,0.01 0.07,-0.07 0.1,-0.15 0.08,-0.18 0.02,-0.14 -0.02,-0.11 -0.04,-0.12 -0.08,-0.14 -0.1,-0.14 -0.17,-0.19 -0.25,-0.23 -0.26,-0.18 -0.2,-0.04 -0.15,0.03 -0.13,-0.01 -0.14,-0.05 -0.2,-0.1 -0.16,-0.07 h -0.05 l -0.1,0.2 -0.02,0.1 -0.18,-0.09 -0.08,0.03 -0.11,-0.07 -0.15,-0.13 -0.13,-0.12 -0.15,-0.16 -0.21,-0.25 -0.21,-0.2 -0.03,-0.14 0.07,-0.08 0.22,0.14 0.24,0.05 h 0.19 l 0.15,-0.02 h 0.13 l 0.12,0.05 0.14,0.07 0.21,0.09 0.3,0.07 0.32,0.08 0.25,0.11 0.14,0.07 0.04,-0.03 -0.01,-0.06 0.01,-0.03 0.05,0.02 0.08,0.06 0.12,0.07 0.15,0.05 0.15,0.04 0.11,0.04 0.11,0.09 0.13,0.13 0.13,0.2 0.11,0.26 0.08,0.33 0.06,0.36 0.06,0.32 -0.01,0.3 0.1,0.16 0.2,0.14 0.22,0.16 0.14,0.19 0.15,0.19 0.2,0.17 0.21,0.18 0.18,0.2 0.16,0.19 0.18,0.15 0.17,0.14 0.16,0.14 0.17,0.13 0.19,0.1 0.18,0.07 0.11,0.07 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S25P2"
+         d="m 330.82,215.72 -0.07,-0.29 -0.08,-0.15 -0.14,-0.17 -0.12,0.03 0.05,0.45 0.09,0.38 0.06,0.21 0.12,0.06 0.09,-0.19 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S37-92"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S37P1-4"
+         d="m 262.99,269.29 -0.01,0.37 -0.24,0.26 -0.93,0.79 -0.51,-0.23 -0.79,-0.31 -0.07,-0.1 0.08,-0.19 0.09,-0.12 0.02,-0.1 0.03,-0.33 -0.01,-0.21 0.04,-0.28 h 0.21 l 0.31,-0.19 0.04,-0.28 -0.22,-0.29 -0.12,-0.25 -0.05,-0.24 -0.06,-0.19 0.26,-0.18 0.36,-0.27 0.32,-0.16 0.05,0.12 v 0.67 l 0.01,0.13 0.09,0.09 0.27,0.07 h 0.31 l 0.02,0.16 -0.13,0.17 -0.03,0.11 -0.04,0.35 0.01,0.12 0.09,0.15 0.52,0.13 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S37P2"
+         d="m 262.77,269.74 0.11,-0.17 -0.01,-0.16 -0.08,-0.14 -0.17,-0.1 -0.23,-0.04 -0.35,0.12 -0.5,0.29 -0.64,0.49 0.03,0.1 0.17,0.13 0.52,0.21 h 0.22 l 0.15,-0.1 0.23,-0.23 0.36,-0.23 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S38-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S38P1-8"
+         d="m 358,290.72 -0.44,-0.07 -0.66,-0.05 -0.11,-0.06 -0.09,-0.09 -0.05,-0.12 0.02,-0.36 -0.18,-0.27 -0.14,-0.14 -0.11,-0.1 -0.44,-0.13 -0.2,-0.12 h -0.24 l -0.13,-0.18 -0.2,-0.01 -0.04,-0.07 -0.13,-0.05 -0.38,0.4 -0.02,-0.08 0.21,-0.64 -0.02,-0.09 -0.05,-0.03 h -0.13 l -0.07,0.26 -0.07,0.06 -0.14,-0.04 -0.11,0.17 -0.06,0.03 -0.05,-0.05 -0.05,-0.23 -0.06,-0.12 -0.09,-0.08 -0.31,-0.02 -0.13,0.07 h -0.12 l -0.01,0.07 0.07,0.17 0.03,0.1 -0.05,0.07 -0.1,-0.05 -0.09,-0.21 -0.06,-0.06 -0.19,-0.1 -0.25,0.01 -0.03,0.12 -0.04,0.07 -0.11,0.04 -0.15,-0.05 -0.27,-0.33 -0.05,0.02 -0.13,0.09 -0.25,-0.16 -0.06,-0.07 v -0.07 l 0.05,-0.09 0.15,-0.08 0.22,-0.05 h 0.25 l 0.4,0.14 0.17,0.03 0.09,-0.05 -0.07,-0.17 0.01,-0.05 0.06,-0.01 0.05,-0.02 0.04,-0.07 -0.08,-0.21 -0.03,-0.08 0.05,-0.01 0.26,0.17 0.14,0.07 0.09,0.01 h 0.05 l 0.04,-0.07 0.69,-0.09 0.07,0.09 0.01,0.11 -0.17,0.07 -0.05,0.08 -0.01,0.4 0.07,0.09 0.13,0.04 0.13,-0.07 0.15,-0.22 -0.03,-0.66 0.06,-0.12 0.16,-0.01 0.16,0.11 0.03,0.09 -0.08,0.14 0.04,0.17 0.1,0.05 h 0.17 l 0.17,0.27 0.24,0.5 0.28,0.15 0.6,0.57 0.69,0.59 0.52,0.36 0.48,0.17 0.07,0.08 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S39-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S39P1-1"
+         d="m 345.11,229.77 -0.17,0.04 -0.52,0.17 -0.02,0.12 0.3,0.21 0.04,0.08 -0.05,0.03 -0.13,-0.03 -0.15,0.02 -0.09,-0.03 -0.09,-0.06 -0.08,-0.13 -0.18,-0.42 -0.14,-0.14 -0.18,0.01 -0.56,-0.04 -0.08,0.08 -1.33,-0.72 -0.35,-0.27 -0.3,-0.11 -0.43,-0.02 -0.03,-0.05 v -0.1 l -0.27,-0.53 0.52,0.26 0.19,0.07 0.12,-0.02 0.05,0.17 0.03,0.09 0.18,0.11 0.21,0.03 0.17,0.24 0.12,-0.01 0.09,-0.1 -0.02,-0.07 -0.2,-0.2 0.01,-0.05 0.22,0.01 0.11,-0.05 0.64,0.09 0.19,-0.03 -0.1,-0.22 0.01,-0.15 -0.04,-0.06 -0.31,-0.07 -0.05,-0.08 -0.14,-0.09 -0.03,-0.06 0.03,-0.06 0.13,-0.06 -0.28,-0.49 -0.17,0.09 -0.18,-0.13 -0.12,-0.04 -0.13,-0.01 -0.15,0.05 -0.14,0.11 -0.1,0.14 -0.07,0.31 -0.09,-0.03 -0.05,-0.07 -0.05,-0.25 v -0.09 l 0.16,-0.29 0.07,-0.22 -0.02,-0.19 -0.12,-0.15 -0.14,-0.13 -0.03,-0.08 0.44,-0.17 0.17,-0.17 0.1,-0.05 0.06,0.06 0.05,0.06 0.07,0.06 0.24,0.03 0.1,-0.04 0.02,-0.07 -0.03,-0.08 -0.04,-0.07 -0.22,-0.19 0.03,-0.05 h 0.1 l 0.32,0.08 0.24,-0.16 0.02,0.1 -0.05,0.33 -0.14,0.21 -0.16,0.05 -0.64,0.07 -0.08,0.08 0.02,0.09 0.2,0.09 0.37,0.1 0.23,0.11 1.08,0.63 0.61,0.32 0.49,0.26 h 0.62 l 0.07,0.08 v 0.18 l 0.17,0.21 0.07,0.12 -0.25,0.24 -0.02,0.2 0.05,0.21 0.23,0.5 v 0.07 l -0.08,-0.03 -0.34,-0.24 h -0.14 l -0.01,0.1 0.31,0.22 0.05,0.08 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S44-81"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S44P1-4"
+         d="m 318.4,218.68 -0.01,0.17 -0.04,0.06 0.1,0.14 0.19,0.16 0.16,0.05 0.02,-0.11 0.1,-0.02 0.22,0.2 0.1,0.19 0.03,0.07 -0.07,0.1 0.02,0.12 -0.05,0.08 -0.06,0.06 -0.07,0.14 -0.14,0.15 -0.07,0.19 -0.1,0.07 -0.17,0.47 -0.01,0.16 -0.3,0.16 -0.01,0.11 -0.4,-0.13 -0.52,-0.09 -0.18,0.19 -0.01,0.12 0.34,-0.05 0.09,0.08 -0.14,0.08 -0.06,0.12 0.04,0.16 0.08,0.17 -0.09,0.06 -0.13,0.05 0.01,0.16 -0.17,0.25 -0.09,0.16 -0.11,0.13 0.06,0.07 0.25,-0.06 0.34,-0.18 0.02,-0.09 0.14,0.04 0.3,0.19 0.17,0.2 -0.12,0.25 -0.33,0.29 -0.47,0.45 -0.13,0.1 -0.67,0.17 -0.08,0.07 -0.08,-0.04 -0.1,-0.14 -0.07,-0.19 0.14,-0.19 0.27,-0.02 0.23,0.07 0.04,-0.06 -0.08,-0.1 -0.28,-0.15 -0.49,0.03 -0.38,0.19 -0.09,0.11 -0.25,-0.02 -0.29,-0.08 0.04,-0.06 -0.02,-0.12 -0.19,-0.1 -0.14,0.02 -0.07,0.04 -0.08,-0.25 0.01,-0.27 -0.1,-0.14 0.04,-0.09 -0.1,-0.33 -0.16,-0.43 0.07,-0.21 0.07,0.28 0.07,0.15 0.12,0.3 0.23,-0.02 0.02,-0.08 -0.02,-0.05 -0.07,-0.23 0.02,-0.09 0.04,0.08 0.07,0.09 0.16,-0.06 0.13,-0.15 -0.01,-0.14 0.15,-0.14 -0.01,-0.14 -0.2,-0.17 -0.22,-0.11 -0.06,-0.07 0.02,-0.1 0.51,0.23 0.14,0.12 0.17,0.15 0.04,0.14 0.09,0.1 0.18,0.21 0.17,0.15 0.09,-0.08 0.02,-0.13 0.04,-0.02 0.09,0.01 0.01,-0.38 -0.09,-0.44 -0.01,-0.14 0.08,-0.07 0.08,0.01 0.06,-0.03 0.14,-0.11 0.11,-0.39 h 0.31 l 0.29,-0.09 0.04,-0.1 -0.02,-0.08 -0.26,-0.07 -0.12,-0.11 -0.35,-0.26 -0.4,-0.19 -0.08,-0.06 -0.26,-0.07 -0.27,0.07 -0.19,0.02 -0.12,-0.01 -0.26,-0.05 -0.09,-0.1 -0.1,-0.4 -0.12,-0.27 -0.05,-0.1 -0.08,-0.1 -0.04,-0.1 -0.17,-0.22 -0.09,0.03 -0.14,0.11 -0.18,0.02 -0.1,0.05 -0.16,-0.11 -0.11,-0.15 -0.11,-0.06 -0.09,0.09 -0.14,0.06 -0.17,-0.11 -0.18,-0.18 -0.07,-0.1 0.08,0.01 0.28,0.19 0.1,-0.02 -0.01,-0.12 0.02,-0.1 0.04,-0.07 0.53,0.27 0.09,-0.04 0.03,-0.08 -0.02,-0.07 -0.22,-0.3 -0.11,-0.5 0.03,-0.13 0.01,-0.12 -0.11,-0.25 -0.04,-0.27 -0.01,-0.18 -0.08,-0.05 -0.05,0.06 -0.05,0.09 -0.03,0.11 0.03,0.13 -0.15,-0.03 -0.22,-0.13 -0.1,-0.17 -0.2,-0.25 -0.42,-0.3 0.02,-0.08 v -0.1 l -0.09,-0.22 -0.07,-0.27 -0.08,-0.27 0.02,-0.1 0.07,-0.01 -0.05,-0.11 -0.17,-0.23 -0.09,-0.22 -0.15,-0.24 -0.17,-0.1 -0.06,0.05 -0.01,0.08 -0.16,-0.08 -0.17,-0.16 -0.03,-0.08 0.49,0.07 0.18,0.09 0.18,0.26 0.04,0.13 -0.04,0.06 0.13,0.17 0.12,0.07 0.1,0.02 0.09,0.13 0.01,0.17 0.06,0.3 -0.07,0.35 0.3,0.31 0.22,0.16 0.28,0.04 0.08,-0.08 0.19,0.12 0.13,0.09 0.11,0.02 -0.06,-0.23 -0.16,-0.27 0.02,-0.2 0.09,0.01 0.11,0.08 0.06,0.17 0.09,0.04 0.22,-0.15 0.25,0.09 0.33,-0.19 0.14,-0.08 0.01,0.07 -0.06,0.12 -0.07,0.11 -0.12,0.13 -0.03,0.16 0.16,0.33 -0.05,0.16 0.04,0.1 0.11,0.13 0.12,0.17 0.09,0.1 0.08,0.06 0.03,0.12 0.99,0.41 0.4,0.24 0.3,0.25 -0.18,0.08 -0.36,-0.09 -0.35,-0.17 -0.11,-0.11 0.15,-0.02 -0.05,-0.11 -0.2,-0.11 -0.14,-0.06 -0.14,-0.02 -0.04,0.06 -0.13,0.09 -0.05,0.29 0.03,0.29 -0.03,0.07 h -0.15 l -0.04,-0.16 -0.01,-0.3 -0.37,-0.65 -0.21,-0.15 -0.26,0.13 -0.12,0.22 0.01,0.13 0.13,0.09 -0.04,0.22 0.26,0.23 0.27,0.39 0.29,0.03 0.04,0.14 -0.05,0.21 -0.01,0.2 0.06,0.17 0.23,0.02 0.15,-0.08 0.28,-0.09 -0.02,-0.09 0.08,-0.07 0.09,0.06 0.15,0.12 0.23,0.02 0.13,-0.04 0.02,-0.28 0.02,-0.08 0.07,-0.08 0.03,-0.11 -0.12,-0.17 -0.03,-0.08 h 0.06 l 0.2,0.12 0.26,0.33 0.12,0.13 -0.01,0.11 0.01,0.13 -0.1,0.07 0.14,0.17 0.31,-0.12 0.31,-0.21 0.11,-0.07 0.3,-0.02 v -0.1 l -0.03,-0.16 -0.1,-0.08 -0.09,-0.14 -0.05,-0.17 -0.09,-0.15 -0.09,-0.2 0.02,-0.17 -0.06,-0.22 -0.18,-0.32 -0.03,-0.23 0.11,-0.03 0.08,0.12 0.08,0.18 h 0.13 l 0.26,0.2 0.31,0.15 0.04,-0.05 -0.13,-0.13 -0.1,-0.16 -0.03,-0.13 0.01,-0.16 -0.02,-0.18 0.12,-0.09 0.2,0.1 0.19,0.24 0.21,0.22 0.12,0.1 -0.13,0.26 -0.03,0.14 0.02,0.13 -0.02,0.11 -0.17,0.03 -0.09,0.06 -0.03,0.08 -0.01,0.12 0.17,0.18 0.2,0.07 0.14,-0.04 0.19,0.02 0.22,0.04 0.08,0.13 -0.12,0.12 -0.48,-0.04 -0.03,0.07 -0.18,0.01 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S44P2"
+         d="m 313.79,215.82 0.03,0.19 0.19,0.32 0.34,0.21 0.16,0.1 0.07,-0.06 -0.04,-0.15 -0.1,-0.28 -0.16,-0.37 -0.08,-0.18 -0.15,0.03 h -0.01 l -0.17,0.07 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S44P3"
+         d="m 315.44,223.59 0.04,-0.19 -0.09,-0.19 -0.1,-0.12 -0.18,-0.02 -0.12,-0.03 -0.23,-0.09 -0.11,0.1 -0.05,0.12 0.13,0.12 0.3,0.19 0.31,0.17 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S44P4"
+         d="m 315.89,222.47 -0.01,-0.11 -0.08,-0.1 -0.05,0.02 -0.13,0.07 -0.16,-0.05 -0.15,-0.02 -0.03,0.08 0.03,0.21 -0.07,0.04 -0.17,0.03 h -0.09 l -0.06,0.04 0.13,0.11 0.25,0.05 0.15,0.12 0.08,-0.02 0.1,-0.04 0.21,-0.23 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S44P5"
+         d="m 317.06,222.19 -0.16,-0.14 -0.02,-0.21 0.02,-0.21 0.06,-0.12 -0.14,-0.34 -0.12,-0.09 -0.18,0.1 -0.15,-0.05 -0.08,0.12 0.06,0.21 0.07,0.18 0.1,0.18 -0.09,0.23 0.02,0.07 0.06,0.11 0.01,0.12 v 0.15 l 0.09,0.21 0.13,-0.1 0.23,-0.1 0.13,-0.17 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      <path
+         id="polyF1S44P6"
+         d="m 318.52,219.42 -0.17,-0.31 -0.26,-0.26 -0.12,-0.09 -0.19,0.07 -0.09,0.05 -0.17,0.06 -0.19,0.02 -0.14,0.13 -0.25,0.18 -0.22,0.05 0.03,0.22 0.11,0.17 0.28,0.09 0.37,0.34 0.19,0.3 0.36,0.04 0.21,-0.21 0.03,-0.32 -0.06,-0.35 -0.01,-0.13 0.13,-0.05 0.12,0.1 0.06,-0.03 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S56-2"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S56P1-4"
+         d="m 302.24,259.12 -0.15,-0.22 0.37,-0.56 0.14,-0.3 0.02,-0.17 0.06,-0.14 0.13,0.02 0.16,0.12 0.33,-0.1 0.54,-0.06 -0.76,0.58 -0.43,0.37 -0.39,0.44 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S57-7"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S57P1-3"
+         d="m 302.09,258.9 0.15,0.22 -0.05,0.11 -0.2,0.21 -0.18,0.15 -0.26,0.26 -0.36,0.2 -0.29,-0.17 0.06,-0.14 0.6,-0.28 0.28,-0.26 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S67-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S67P1-7"
+         d="m 312.03,216.72 0.07,-0.04 0.24,0.01 -0.01,0.05 -0.13,0.04 0.03,0.14 -0.12,0.06 -0.16,0.03 0.14,0.22 0.21,0.23 -0.03,0.17 0.15,0.15 -0.02,0.06 -0.21,-0.05 -0.07,0.1 -0.02,0.21 0.06,0.17 0.09,0.12 0.07,-0.01 0.11,0.04 -0.01,0.13 -0.31,-0.04 -0.11,-0.05 -0.09,-0.27 -0.12,-0.17 -0.05,0.07 0.05,0.14 0.01,0.35 -0.03,0.33 -0.15,0.13 -0.13,0.15 0.06,0.17 -0.01,0.06 -0.12,-0.11 -0.03,-0.17 v -0.18 l 0.12,-0.07 h 0.09 l -0.03,-0.14 0.06,-0.19 -0.12,-0.21 -0.34,-0.06 -0.22,0.13 -0.04,0.15 0.05,0.18 0.08,0.2 0.11,0.12 0.1,0.17 -0.04,0.14 -0.25,-0.03 -0.06,0.15 0.06,0.23 -0.11,-0.05 -0.14,-0.23 -0.15,-0.08 -0.06,0.09 0.1,0.19 0.09,0.15 -0.04,0.12 -0.01,0.21 0.09,0.3 -0.07,-0.01 -0.11,-0.22 -0.05,-0.01 -0.05,0.28 0.08,0.35 0.18,0.21 -0.02,0.1 -0.14,0.08 -0.01,0.12 -0.15,0.05 -0.12,0.09 0.02,0.16 0.06,0.05 0.12,0.06 -0.02,0.08 -0.11,0.16 -0.01,0.24 0.09,0.07 0.11,-0.16 0.07,-0.07 0.04,0.16 -0.02,0.33 0.09,0.34 0.09,0.16 -0.17,0.03 -0.08,0.07 0.05,0.23 0.02,0.22 0.19,0.09 -0.05,0.13 -0.12,0.12 0.06,0.14 0.04,0.27 0.11,0.11 0.43,0.05 h 0.51 l 0.1,0.08 0.06,0.1 0.14,0.04 0.06,-0.08 -0.07,-0.16 0.06,-0.32 0.17,-0.35 0.03,0.06 -0.04,0.22 0.07,0.14 0.05,0.17 -0.05,0.04 -0.07,-0.09 -0.1,-0.02 -0.04,0.08 0.11,0.16 0.1,0.19 v 0.13 l 0.18,0.19 -0.03,0.11 -0.06,0.11 0.01,0.09 -0.01,0.19 -0.08,0.21 -0.16,0.04 0.06,-0.22 -0.04,-0.46 -0.25,-0.28 -0.17,-0.06 -0.1,0.05 -0.07,0.09 -0.24,-0.18 -0.33,-0.21 -0.09,0.07 0.08,0.12 0.06,0.13 -0.12,0.22 -0.06,0.26 0.11,0.15 0.11,0.09 0.01,0.15 -0.1,0.01 -0.1,-0.15 -0.12,-0.1 -0.04,0.08 -0.09,0.09 -0.13,-0.06 0.05,-0.2 0.09,-0.22 0.01,-0.35 -0.13,-0.22 -0.04,0.04 v 0.11 l -0.06,0.01 -0.06,-0.15 -0.12,-0.12 -0.14,-0.07 -0.09,-0.07 -0.05,-0.05 -0.01,-0.11 -0.24,-0.37 -0.08,-0.26 0.09,-0.08 0.05,-0.12 0.14,-0.09 0.13,-0.04 v -0.21 l -0.08,-0.19 -0.13,-0.11 -0.35,-0.23 -0.08,-0.15 0.06,-0.02 0.17,0.06 0.16,-0.12 0.07,-0.25 -0.14,-0.11 -0.18,0.01 -0.02,-0.11 0.21,-0.14 0.18,-0.08 -0.03,-0.09 0.03,-0.2 0.16,-0.11 0.05,-0.27 -0.24,-0.15 -0.2,-0.01 -0.09,-0.13 0.17,-0.04 0.26,-0.02 0.07,-0.14 -0.03,-0.15 0.02,-0.12 0.03,-0.08 0.12,-0.11 0.08,-0.21 0.01,-0.19 -0.03,-0.26 -0.11,-0.24 h -0.08 l -0.04,0.06 -0.05,-0.06 -0.07,-0.2 -0.16,-0.17 -0.16,-0.01 -0.15,-0.19 -0.07,-0.17 0.29,-0.18 -0.03,-0.25 0.05,-0.1 0.14,-0.01 -0.05,-0.16 -0.15,-0.1 -0.04,-0.05 0.05,-0.16 -0.04,-0.23 0.1,-0.2 -0.22,-0.31 -0.11,-0.11 -0.23,-0.1 -0.28,-0.07 -0.12,0.22 0.03,0.31 -0.04,0.05 -0.15,-0.05 -0.18,-0.12 0.01,-0.11 0.1,-0.13 -0.04,-0.22 -0.05,-0.13 0.12,-0.11 0.1,-0.33 0.07,-0.04 0.03,0.15 0.18,0.18 0.28,0.16 0.05,-0.07 v -0.12 l 0.16,0.05 0.09,0.12 0.17,0.16 0.25,0.18 0.01,0.06 -0.15,-0.02 0.02,0.09 0.18,0.16 0.39,0.28 0.4,0.33 0.07,0.19 -0.15,0.02 -0.27,-0.19 -0.26,-0.17 -0.07,0.05 -0.04,0.12 v 0.22 l 0.03,0.19 -0.05,0.03 0.13,0.17 0.06,0.15 -0.26,-0.02 -0.16,0.2 0.11,0.35 0.31,0.29 0.17,-0.11 0.02,-0.21 0.08,-0.01 0.05,0.13 -0.03,0.18 0.07,0.14 0.2,0.12 -0.03,-0.35 -0.12,-0.41 0.06,-0.11 0.22,-0.23 0.01,-0.12 0.2,-0.04 -0.05,-0.33 -0.27,-0.36 -0.11,-0.15 -0.03,-0.13 0.25,0.22 0.18,0.19 0.18,0.17 0.35,0.26 0.23,0.08 0.04,-0.08 -0.01,-0.17 -0.06,-0.17 -0.2,-0.17 -0.18,-0.18 -0.08,-0.13 -0.22,-0.21 -0.09,-0.12 0.04,-0.01 0.26,0.21 0.12,0.02 -0.01,-0.14 -0.14,-0.28 v -0.14 l 0.06,-0.02 -0.01,-0.09 0.28,-0.2 0.14,-0.15 0.09,0.03 -0.09,0.13 -0.03,0.28 0.07,0.11 -0.04,0.02 h -0.08 l 0.02,0.1 0.12,0.15 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S73-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S73P1-0"
+         d="m 315.76,204.62 0.05,-0.07 0.19,0.12 0.41,0.13 0.25,-0.22 0.17,-0.13 -0.01,-0.18 0.05,-0.13 0.7,-0.2 0.5,0.06 0.12,0.09 0.1,0.2 0.11,0.13 0.43,0.22 0.31,0.22 0.08,0.14 -0.12,-0.05 -0.38,-0.15 -0.18,0.01 -0.31,-0.19 -0.13,-0.15 -0.04,-0.12 -0.1,-0.11 -0.23,-0.03 -0.25,0.07 -0.08,0.09 0.02,0.12 -0.1,0.03 -0.23,-0.01 -0.05,0.07 -0.13,0.08 -0.08,0.17 0.04,0.28 -0.08,0.22 -0.15,0.06 -0.22,0.1 0.01,-0.09 0.05,-0.15 0.19,-0.14 -0.06,-0.11 -0.4,-0.09 -0.32,-0.15 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S77-9"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S77P1-0"
+         d="m 318.88,237.89 0.13,-0.19 0.11,0.18 0.3,-0.03 0.36,-0.13 0.31,0.13 0.41,0.33 0.21,0.29 0.12,0.27 -0.09,0.29 -0.28,0.03 -0.23,-0.08 -0.12,-0.1 v -0.08 l -0.26,-0.2 -0.34,-0.05 -0.12,0.05 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S95-1"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S95P1-5"
+         d="m 306.41,187.03 0.12,-0.08 0.13,-0.16 0.03,-0.15 0.1,-0.14 0.01,0.11 -0.04,0.16 -0.14,0.34 0.03,0.19 0.1,0.14 v 0.14 l -0.1,0.21 0.04,0.17 -0.02,0.16 -0.22,0.15 -0.18,0.31 0.04,0.12 0.36,0.18 0.15,0.1 0.07,0.08 -0.01,0.08 -0.06,0.04 -0.39,-0.02 -0.16,0.02 -0.13,0.12 0.09,0.14 0.11,0.03 0.06,0.12 -0.14,0.25 -0.06,-0.02 -0.05,-0.14 -0.11,-0.03 -0.08,0.18 -0.04,0.14 -0.17,-0.04 -0.19,-0.01 -0.05,0.02 -0.1,0.06 -0.09,0.19 -0.07,-0.08 0.12,-0.2 0.08,-0.16 -0.07,-0.17 -0.2,-0.15 -0.11,-0.01 -0.18,-0.03 -0.04,-0.07 0.1,-0.14 0.33,-0.35 0.03,-0.13 0.02,-0.15 0.21,-0.37 0.25,-0.29 0.09,0.05 0.18,-0.04 -0.05,-0.12 -0.07,-0.05 -0.1,-0.09 -0.07,-0.11 0.02,-0.16 0.1,-0.08 0.06,0.12 0.08,0.14 0.14,-0.09 0.08,-0.19 -0.01,-0.1 0.01,-0.08 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S96-2"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S96P1-6"
+         d="m 309.82,209.79 0.04,-0.12 v -0.12 l -0.07,-0.13 -0.02,-0.16 0.05,-0.13 0.49,-0.09 0.24,0.08 0.11,0.37 0.14,0.18 0.26,0.13 0.19,-0.09 0.17,-0.24 0.27,-0.14 0.41,-0.03 0.04,0.23 0.07,0.11 -0.1,0.01 -0.16,0.06 -0.09,0.13 0.1,0.16 0.2,0.01 0.2,0.08 0.27,0.07 0.22,0.03 0.08,0.06 0.02,0.05 -0.03,0.06 -0.19,0.05 h -0.13 l -0.18,-0.04 -0.66,-0.23 -0.24,-0.18 -0.11,0.05 -0.02,0.1 -0.1,0.12 -0.17,0.14 -0.03,0.18 0.06,0.19 -0.05,0.06 -0.16,-0.14 -0.31,-0.14 -0.3,-0.11 -0.1,-0.17 -0.35,-0.32 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S97-3"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S97P1-8"
+         d="m 319.01,237.7 -0.13,0.19 -0.1,-0.14 -0.22,-0.37 -0.36,-0.4 -0.27,-0.19 -0.42,-0.86 -0.64,-0.62 -0.07,-0.37 0.23,-0.39 0.4,-0.3 0.52,-0.18 0.41,0.04 0.24,0.27 0.57,1.53 0.12,0.4 -0.01,0.19 -0.1,0.11 -0.24,0.66 v 0.24 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S103-2"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S103P1-0"
+         d="m 354.44,280.69 -0.03,0.23 -0.17,0.06 -0.45,0.27 -0.23,0.19 -0.53,-0.1 -0.72,-0.03 -0.47,0.32 -0.58,0.54 v 0.16 l 0.08,0.19 v 0.11 l -0.21,0.11 -0.36,0.91 -0.25,1.19 v 0.21 l 0.01,0.18 -0.33,0.31 -0.07,-0.02 0.04,-0.27 -0.05,-0.75 0.05,-0.1 0.05,0.03 0.09,-0.13 0.09,-0.32 -0.02,-0.21 0.11,-0.29 0.2,-0.42 0.01,-0.25 -0.03,-0.13 -0.18,-0.4 -0.16,-0.4 0.12,-0.12 0.24,-0.09 0.27,-0.01 0.19,-0.04 0.03,-0.2 0.06,-0.1 0.18,0.06 0.2,-0.03 0.15,-0.11 0.12,-0.16 0.74,-0.18 0.77,-0.32 0.14,-0.49 -0.23,-0.68 0.04,-0.1 0.07,-0.02 0.62,0.76 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S104-7"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S104P1-1"
+         d="m 346,275.87 0.02,0.12 -0.27,0.03 -0.05,-0.06 -0.12,-0.17 -0.21,-0.03 -0.35,0.08 -0.31,-0.04 -0.19,-0.06 -0.36,-0.18 -0.76,-0.28 -0.39,-0.1 -0.44,-0.16 -0.92,-0.26 -0.1,-0.18 0.18,-0.13 0.5,-0.01 0.23,0.03 0.55,0.09 0.38,0.1 0.55,0.05 0.12,-0.14 -0.15,-0.27 -0.09,-0.33 0.11,-0.15 0.22,0.3 0.42,0.26 0.62,0.44 0.37,0.28 0.38,0.29 0.03,0.11 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S114-1"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S114P1-4"
+         d="m 360.03,321.85 0.28,0.11 0.26,-0.02 0.37,0.3 -0.04,0.67 -0.23,0.34 -0.42,-0.03 -0.39,-0.12 -0.38,-0.16 -0.39,-0.38 0.09,-0.54 0.15,-0.49 -0.05,-0.43 -0.1,-0.31 0.16,-0.02 0.33,0.21 0.18,0.25 0.02,0.26 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S117-8"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S117P1-7"
+         d="m 315.63,225.18 -0.28,-0.09 -0.23,-0.1 -0.03,-0.09 0.05,-0.07 0.23,0.14 0.3,-0.02 0.22,-0.19 -0.03,-0.21 0.02,-0.11 0.13,0.01 0.1,0.1 0.16,0.25 -0.19,0.21 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S118-3"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S118P1-7"
+         d="m 317.27,215.33 0.15,0.14 0.08,-0.03 -0.03,-0.26 -0.22,-0.37 -0.16,-0.21 0.02,-0.12 0.25,0.28 0.47,0.39 0.27,0.32 0.06,0.29 -0.1,0.2 -0.13,0.11 -0.17,-0.24 -0.22,-0.1 -0.25,-0.22 -0.15,-0.21 0.03,-0.06 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S119-15"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S119P1-5"
+         d="m 316.99,216.21 -0.12,-0.3 0.11,-0.19 0.19,0.24 0.13,0.09 0.14,-0.1 0.16,0.09 -0.06,0.33 -0.26,-0.01 -0.24,0.1 -0.11,-0.13 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S125-7"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S125P1-3"
+         d="m 327.39,209.04 0.3,0.01 0.19,-0.11 0.24,-0.09 0.16,0.16 -0.04,0.09 -0.31,0.26 v 0.12 l -0.15,0.04 -0.12,-0.04 -0.2,-0.08 -0.27,-0.08 -0.03,0.16 0.36,0.58 0.33,0.45 0.12,0.27 0.13,0.38 0.08,0.39 -0.04,0.17 -0.04,-0.09 -0.05,-0.16 -0.07,-0.15 -0.03,-0.14 0.02,-0.08 -0.11,-0.22 -0.18,-0.27 -0.1,-0.23 -0.13,-0.21 -0.14,-0.2 -0.33,-0.25 -0.4,-0.16 -0.12,-0.09 -0.01,-0.08 -0.35,-0.49 -0.32,-0.25 -0.09,0.05 -0.01,0.19 -0.03,0.22 -0.11,-0.28 -0.04,-0.49 -0.01,-0.37 0.17,-0.04 0.31,0.05 0.21,0.07 -0.02,0.12 0.55,0.03 0.07,0.14 0.43,0.37 0.02,0.09 -0.01,0.13 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S126-8"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S126P1-9"
+         d="m 324.42,210.37 0.21,-0.29 0.12,0.02 0.11,0.17 0.12,0.08 0.25,-0.23 0.2,0.04 0.32,0.49 0.27,0.25 -0.05,0.16 -0.22,0.14 -0.39,0.12 -0.28,0.03 -0.17,-0.01 -0.49,-0.18 -0.12,-0.12 -0.04,-0.11 -0.05,-0.18 -0.12,-0.17 0.19,-0.07 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S127-7"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S127P1-7"
+         d="m 319.59,214.66 -0.12,-0.27 0.01,-0.14 0.12,-0.07 -0.01,-0.19 0.05,-0.2 0.19,0.06 0.14,0.31 -0.08,0.47 -0.08,0.11 -0.01,0.19 0.06,0.1 v 0.09 l -0.06,-0.03 -0.28,0.06 -0.05,-0.02 0.07,-0.18 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S128-0"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S128P1-8"
+         d="m 317.74,213.13 0.05,0.1 -0.07,0.04 0.04,0.18 0.2,0.37 0.53,0.67 0.6,0.54 0.01,0.1 -0.18,0.07 -0.06,0.42 h -0.12 l 0.05,-0.31 0.01,-0.39 -0.25,-0.23 -0.17,-0.03 -0.08,-0.05 -0.55,-0.47 -0.17,-0.24 -0.47,0.06 -0.16,-0.06 -0.28,0.06 -0.3,-0.28 -0.21,-0.27 -0.35,-0.32 -0.26,-0.26 0.01,-0.17 -0.06,-0.25 0.02,-0.05 0.27,0.22 0.32,0.17 0.16,0.06 0.4,0.2 0.48,0.17 0.16,0.06 0.1,-0.01 0.14,-0.15 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S129-2"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S129P1-8"
+         d="m 315.81,199.94 0.15,0.18 0.14,0.23 0.14,0.2 0.17,0.13 -0.06,0.08 -0.27,0.04 -0.45,-0.12 -0.68,-0.23 -0.03,-0.39 -0.04,-0.24 0.05,-0.23 0.15,-0.2 0.23,-0.1 0.17,0.07 0.29,0.44 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S130-3"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S130P1-8"
+         d="m 319.19,201.72 0.37,0.15 0.08,0.1 0.11,0.15 0.03,0.12 -0.07,0.02 -0.11,-0.11 -0.37,-0.13 -0.44,-0.04 -0.37,-0.09 -0.25,-0.03 -0.14,-0.11 -0.04,-0.1 -0.11,-0.03 -0.1,-0.01 -0.25,-0.05 -0.4,-0.2 -0.22,-0.23 0.25,-0.37 0.48,-0.31 0.14,0.02 0.19,0.15 0.12,0.21 0.15,0.05 0.33,0.21 0.11,0.13 0.07,0.16 0.11,0.22 0.15,0.13 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S134-1"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S134P1-5"
+         d="m 321.47,218.56 -0.05,-0.16 -0.09,-0.17 -0.06,-0.15 0.16,-0.05 0.12,0.06 0.31,0.37 v 0.21 l -0.16,0.08 -0.15,-0.05 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S135-1"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S135P1"
+         d="m 328.46,235.09 -0.17,0.17 -0.03,0.33 -0.6,0.03 h -0.73 l -0.08,-0.1 0.17,-0.28 0.1,-0.2 0.13,-0.1 0.17,-0.19 0.09,-0.36 0.04,-0.26 0.25,0.16 0.15,0.02 0.23,0.07 0.04,0.07 0.25,-0.16 0.07,0.08 0.01,0.08 0.06,0.2 0.26,0.45 -0.15,0.02 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S144-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S144P1-2"
+         d="m 375.36,235.59 -0.17,-0.25 -0.21,-0.47 -0.26,-0.48 -0.33,-0.62 0.17,-0.41 0.37,-0.35 -0.01,-0.33 -0.12,-0.32 -0.09,-0.32 -0.35,-0.58 0.1,-0.41 0.17,-0.61 -0.29,-0.55 -0.3,-0.16 -0.34,-0.29 -0.07,-0.18 0.14,-0.05 0.38,0.29 0.21,0.12 0.18,-0.03 0.08,-0.14 -0.16,-0.12 -0.18,-0.3 -0.17,-0.27 0.02,-0.16 0.05,0.08 0.15,0.24 0.33,0.14 0.31,-0.12 0.45,-0.25 0.37,-0.41 0.06,-0.32 0.35,-0.08 0.34,-0.18 0.14,-0.26 0.43,-0.22 0.25,-0.34 0.55,-0.49 0.2,-0.27 h 0.23 l 0.05,-0.02 0.13,-0.08 0.07,-0.14 -0.21,-0.31 -0.38,-0.29 -0.21,-0.39 -0.02,-0.2 0.01,-0.12 0.08,0.16 0.22,0.4 0.3,0.19 0.2,-0.21 0.07,-0.48 0.27,-0.09 0.13,-0.07 -0.02,0.19 -0.21,0.06 -0.08,0.11 0.04,0.16 0.1,0.22 -0.13,0.25 -0.11,0.12 0.08,0.26 -0.07,0.4 -0.54,0.09 v 0.15 l 0.11,0.06 0.14,0.13 0.04,0.22 -0.2,-0.06 -0.18,-0.01 -0.5,0.12 -0.17,0.25 -0.01,0.12 -1.48,1.61 -0.04,0.32 -0.12,0.37 -0.22,0.46 -0.09,0.17 0.09,0.18 0.04,0.1 -0.02,0.21 -0.16,0.11 -0.23,0.09 -0.12,0.22 -0.21,0.29 0.02,0.37 0.24,0.27 0.18,-0.01 0.17,-0.05 0.02,0.12 -0.09,0.33 0.13,0.26 0.05,0.11 v 0.14 l -0.02,0.21 0.11,0.12 0.02,0.1 -0.01,0.16 0.1,0.16 -0.13,0.16 -0.31,0.26 -0.13,0.31 0.08,0.29 0.33,0.32 0.41,0.14 0.27,-0.04 0.14,0.02 0.1,0.12 0.21,0.17 0.46,-0.12 0.42,-0.57 0.15,-0.37 0.22,-0.48 0.24,-0.41 0.12,0.12 -0.09,0.23 -0.2,0.32 0.01,0.49 -0.14,0.45 -0.1,0.29 0.14,0.23 0.26,0.18 0.17,0.04 0.12,0.04 0.14,0.14 0.08,0.15 -0.06,0.02 -0.13,-0.05 -0.09,0.01 -0.39,-0.2 -0.18,0.02 v 0.17 l 0.15,0.36 0.24,0.46 0.23,0.26 0.43,-0.09 0.7,-0.42 0.75,-0.4 0.12,0.09 -0.04,0.2 -0.82,0.46 -0.32,0.39 v 0.29 l 0.1,0.32 -0.27,0.25 -0.69,0.36 -0.19,-0.12 0.4,-0.17 0.48,-0.29 0.08,-0.22 -0.07,-0.12 -0.31,-0.02 -0.34,0.02 -0.01,-0.11 -0.3,-0.24 -0.47,-0.34 -0.23,-0.46 -0.12,-0.34 -0.14,-0.13 -0.33,-0.21 -0.57,-0.2 -0.35,-0.12 -0.29,0.02 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S145-9"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S145P1-5"
+         d="m 264.51,298.82 -0.03,0.14 -0.08,0.08 -0.59,-0.12 -0.65,0.04 -0.44,0.1 -0.64,0.71 H 262 l 0.11,-0.46 0.66,-0.71 0.82,-0.29 0.74,0.34 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S146-1"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S146P1-2"
+         d="m 230.09,253.96 0.07,0.05 0.37,0.12 0.06,0.26 -0.09,0.25 -0.26,0.33 -0.04,0.1 -0.2,-0.03 -0.34,-0.16 -0.01,-0.22 0.19,-0.27 0.16,-0.33 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S147-0"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S147P1-6"
+         d="m 287.51,239.63 0.03,0.13 -0.01,0.27 -0.05,0.31 -0.01,0.21 0.19,0.24 -0.03,0.14 -0.28,0.25 -0.33,0.34 -0.14,0.46 -0.07,0.47 -0.08,0.31 -0.1,0.25 -0.36,0.75 -0.21,0.6 -0.21,0.07 -0.13,-0.6 0.17,-1.09 0.38,-1.24 0.25,-0.75 0.27,-0.58 0.22,-0.26 0.21,-0.3 0.27,-0.31 0.09,0.02 -0.01,0.06 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S162-2"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S162P1-6"
+         d="m 284.23,218.62 -0.07,-0.17 -0.07,-0.11 0.08,-0.03 0.34,0.08 0.39,0.18 0.11,-0.01 0.14,-0.02 0.23,0.27 0.15,0.3 -0.23,-0.09 -0.14,-0.01 -0.1,0.06 -0.05,0.13 v 0.18 l 0.06,0.28 0.08,0.35 0.03,0.31 -0.01,0.24 -0.04,0.04 -0.03,0.01 -0.1,-0.22 -0.11,-0.23 -0.02,-0.13 0.06,-0.02 0.05,0.01 0.05,-0.01 0.03,-0.12 -0.08,-0.22 -0.11,-0.28 -0.34,-0.28 -0.21,-0.12 -0.13,-0.06 -0.18,-0.24 -0.02,-0.08 0.07,0.02 0.13,0.1 0.04,-0.03 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S170-1"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S170P1-2"
+         d="m 313.65,222.12 -0.09,0.01 h -0.14 l -0.19,-0.08 h -0.16 l -0.1,0.07 0.09,0.11 0.17,0.05 0.12,0.08 0.05,0.15 0.02,0.06 0.02,0.05 -0.04,0.03 -0.09,-0.02 -0.05,0.02 -0.01,0.07 -0.06,-0.08 -0.09,-0.15 -0.29,-0.27 -0.33,-0.3 -0.22,-0.11 -0.16,-0.05 -0.15,-0.09 -0.16,-0.06 -0.04,-0.05 0.02,-0.17 0.06,-0.18 0.09,-0.22 0.08,0.05 -0.01,0.08 -0.04,0.2 0.01,0.17 0.1,0.01 0.09,-0.07 0.04,-0.09 0.06,-0.06 0.02,-0.08 -0.05,-0.05 v -0.05 l 0.1,-0.02 0.08,0.09 0.1,0.12 0.1,0.07 0.03,-0.03 -0.01,-0.04 0.01,-0.04 h 0.05 l 0.08,0.06 0.08,0.03 0.04,-0.06 0.01,-0.08 -0.02,-0.07 -0.11,-0.02 -0.17,-0.05 -0.16,-0.15 -0.18,-0.22 -0.02,-0.07 0.14,0.09 0.16,0.06 0.13,0.05 0.17,0.1 0.18,0.18 0.05,0.14 0.01,0.08 0.11,0.25 0.06,0.2 0.09,0.09 0.14,0.06 0.11,0.01 0.05,0.06 0.03,0.08 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S171-0"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S171P1-2"
+         d="m 290.93,236.89 0.01,0.01 -0.12,0.1 -0.1,0.07 -0.43,0.2 -0.49,0.25 -0.06,0.09 -0.03,0.07 -0.15,0.08 -0.28,0.01 -0.2,-0.07 -0.01,-0.11 -0.09,-0.16 -0.12,-0.09 -0.06,-0.04 -0.1,-0.02 -0.34,-0.02 0.02,-0.06 0.35,-0.11 0.27,-0.09 0.29,0.06 h 0.23 l 0.08,-0.05 0.33,0.06 0.48,-0.04 0.2,-0.07 0.15,-0.03 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S172-7"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S172P1-9"
+         d="m 311.04,215.68 -0.05,0.13 0.09,0.24 0.16,0.22 0.03,0.09 -0.03,0.06 -0.23,-0.1 -0.2,-0.11 v -0.05 l -0.01,-0.07 -0.05,-0.11 -0.05,-0.13 -0.09,-0.12 -0.21,-0.17 -0.22,-0.18 -0.12,-0.13 -0.02,-0.08 0.06,0.01 0.13,0.13 0.17,0.16 0.17,0.07 0.12,-0.05 0.12,-0.16 v -0.18 l -0.21,-0.16 -0.16,-0.09 -0.09,-0.11 -0.02,-0.11 0.06,-0.07 0.17,0.08 0.22,0.05 0.16,-0.04 0.05,0.02 -0.06,0.07 -0.06,0.06 0.11,0.05 0.11,0.08 0.05,0.13 -0.01,0.17 -0.08,0.15 -0.01,0.13 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S173-7"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S173P1-5"
+         d="m 312.67,222.53 0.01,0.03 -0.04,0.05 -0.16,0.02 -0.33,-0.14 -0.31,-0.24 -0.14,-0.02 -0.12,0.09 -0.08,0.08 0.02,0.11 0.05,0.1 0.05,0.03 0.03,-0.05 0.04,-0.06 0.07,0.06 0.06,0.1 0.01,0.14 0.01,0.17 v 0.09 l -0.07,0.04 -0.14,-0.04 -0.15,-0.13 -0.14,-0.11 -0.16,-0.11 -0.05,-0.12 0.06,-0.1 0.03,-0.12 -0.01,-0.13 -0.05,-0.1 -0.06,-0.08 v -0.05 l 0.23,0.06 0.21,-0.02 0.07,-0.16 0.05,-0.22 0.03,-0.01 0.04,0.08 0.09,0.17 0.07,0.15 0.02,0.08 0.05,0.07 0.08,-0.01 0.06,-0.02 0.11,-0.03 0.04,-0.1 0.07,-0.01 0.11,0.05 0.11,0.13 0.09,0.17 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S175-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S175P1-8"
+         d="m 338.04,222.02 -0.04,-0.09 0.02,-0.26 0.14,-0.34 0.25,-0.25 0.39,-0.21 0.39,-0.01 0.3,0.2 0.2,0.32 0.09,0.26 -0.03,0.1 -0.29,0.15 -0.23,0.1 -0.54,0.17 -0.18,0.01 -0.31,-0.05 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S179-9"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S179P1-5"
+         d="m 290.58,198.45 -0.69,-0.43 -0.39,-0.09 -0.11,-0.02 -0.19,-0.1 -0.25,-0.02 -0.18,-0.07 -0.06,-0.06 -0.14,-0.21 -0.07,-0.26 0.33,0.16 0.26,0.15 1.32,0.58 0.17,0.11 0.39,0.29 0.09,0.19 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S180-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S180P1-9"
+         d="m 299.73,296.4 -0.34,0.23 -0.65,0.07 -0.03,-0.09 v -0.09 l 0.12,-0.03 0.24,-0.09 0.3,-0.13 0.58,-0.31 0.49,-0.33 0.17,-0.17 0.22,-0.24 0.25,-0.26 0.12,-0.1 0.18,0.06 0.12,0.12 -0.04,0.23 -0.81,0.55 -0.65,0.43 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S195-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S195P1-8"
+         d="m 318.51,210.27 -0.02,-0.22 -0.06,-0.2 h 0.08 l 0.1,0.05 0.04,0.06 0.06,0.08 0.3,0.07 0.31,0.01 0.11,0.11 v 0.05 l -0.03,0.03 -0.08,-0.03 -0.09,-0.01 -0.03,0.06 0.06,0.11 0.1,0.07 0.07,0.1 0.01,0.05 -0.02,0.09 0.06,0.11 0.08,0.1 -0.01,0.08 -0.16,-0.08 -0.18,-0.08 -0.12,-0.04 -0.11,-0.09 -0.03,-0.14 -0.05,-0.13 -0.1,-0.08 -0.29,0.01 -0.07,-0.08 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S203-7"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S203P1-3"
+         d="m 338.71,215.67 -0.04,-0.21 0.01,-0.17 0.11,-0.21 0.17,-0.14 0.09,0.07 0.06,0.31 0.06,0.27 0.11,0.13 0.11,0.13 0.03,0.13 -0.06,0.13 -0.13,0.12 -0.13,0.04 -0.11,-0.05 -0.14,-0.23 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S204-7"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S204P1-0"
+         d="m 311.31,200.19 0.16,-0.02 0.14,-0.05 0.12,0.02 -0.04,0.08 -0.03,0.07 v 0.14 l -0.09,0.13 -0.19,0.33 -0.09,0.29 -0.08,0.23 -0.17,0.11 -0.28,0.14 -0.55,0.14 -0.06,-0.05 -0.02,-0.08 -0.03,-0.11 -0.05,-0.07 -0.03,-0.05 -0.17,-0.08 -0.15,-0.08 0.09,-0.04 h 0.18 l 0.13,0.06 0.08,0.07 0.06,0.12 0.05,0.1 0.07,-0.01 0.23,-0.19 0.18,-0.16 0.12,-0.09 0.02,-0.15 0.01,-0.1 0.22,-0.18 0.22,-0.16 -0.01,-0.04 -0.03,-0.09 -0.15,-0.14 -0.14,-0.11 0.04,-0.05 0.1,-0.01 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S205-5"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S205P1-8"
+         d="m 318.12,190.57 0.02,-0.06 0.1,-0.05 0.14,0.09 0.14,0.21 0.27,0.26 0.33,0.32 0.15,0.21 -0.01,0.2 -0.19,0.11 -0.16,0.05 -0.05,-0.12 -0.05,-0.12 -0.1,-0.24 -0.08,-0.2 -0.07,-0.08 -0.12,-0.09 -0.07,-0.08 -0.02,-0.1 -0.13,-0.17 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S206-1"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S206P1-2"
+         d="m 317.24,197.57 v 0.08 l 0.02,0.02 0.06,0.06 0.08,0.01 0.04,0.01 0.04,0.03 v 0.04 l -0.04,0.07 -0.28,-0.05 -0.21,-0.02 -0.24,0.07 -0.05,-0.08 -0.01,-0.04 0.19,-0.16 0.02,-0.1 -0.07,-0.1 -0.27,-0.26 -0.22,-0.25 -0.18,-0.15 -0.31,0.05 -0.29,0.05 -0.04,-0.04 -0.04,-0.06 0.01,-0.08 0.04,-0.08 0.01,-0.05 0.15,-0.04 0.07,-0.1 -0.03,-0.09 -0.13,-0.03 -0.06,-0.04 0.07,-0.16 0.25,0.06 0.22,0.15 0.24,-0.09 0.24,-0.03 0.07,0.07 v 0.18 l -0.01,0.09 0.05,0.06 0.12,0.04 0.15,0.07 0.06,0.06 0.04,0.07 -0.01,0.11 -0.05,0.15 -0.03,0.12 0.1,0.14 0.18,0.15 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S214-5"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S214P1-4"
+         d="m 319.18,199.55 0.07,0.06 0.1,0.05 h 0.17 l 0.09,0.07 0.04,0.14 0.03,0.12 0.03,0.09 -0.16,0.24 -0.22,0.22 -0.11,0.01 -0.04,-0.08 -0.04,-0.08 -0.1,-0.09 0.09,-0.16 0.09,-0.12 -0.02,-0.08 -0.05,-0.08 -0.1,-0.05 -0.12,-0.05 -0.04,-0.12 0.03,-0.17 -0.02,-0.12 0.03,-0.06 0.11,-0.03 0.02,0.09 v 0.12 l 0.03,0.06 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S219-1"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S219P1-2"
+         d="m 315.43,237.97 0.06,0.27 -0.01,0.29 0.01,0.33 h -0.09 l -0.19,-0.31 -0.28,-0.36 -0.01,-0.19 0.02,-0.19 0.11,-0.09 0.15,-0.01 0.13,0.06 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S221-9"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S221P1-1"
+         d="m 281.6,216.88 0.06,-0.16 0.17,-0.13 0.22,-0.07 h 0.2 l 0.14,0.06 0.06,0.07 -0.05,0.04 h -0.25 l -0.1,0.09 -0.05,0.1 0.03,0.19 0.06,0.25 0.22,0.31 0.31,0.16 -0.04,0.11 -0.2,-0.11 -0.14,-0.08 -0.15,-0.12 -0.23,-0.21 -0.17,-0.26 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S290-3"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S290P1-1"
+         d="m 343.1,221.92 h 0.1 0.11 l 0.33,0.13 0.13,-0.03 0.23,0.12 0.33,0.02 0.15,-0.08 -0.02,0.15 0.01,0.16 0.16,0.1 0.11,0.06 -0.04,0.25 -0.52,-0.12 -0.48,-0.2 -0.68,-0.34 -0.48,-0.28 -0.06,-0.13 0.08,-0.04 0.15,0.08 0.18,0.1 0.11,0.03 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S291-2"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S291P1-1"
+         d="m 274,293.86 -0.04,0.06 -0.11,0.04 -0.42,-0.03 -0.33,-0.02 -0.65,-0.41 -0.21,-0.35 -0.22,-0.49 0.06,-0.05 0.32,0.24 0.45,0.28 0.46,0.25 0.41,0.29 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S292-0"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S292P1-7"
+         d="m 308.32,223.29 -0.1,0.09 -0.11,0.15 -0.06,0.13 0.15,0.15 -0.06,0.13 -0.27,0.09 -0.15,0.14 -0.12,0.21 -0.01,0.17 0.01,0.09 -0.01,0.13 -0.02,0.16 0.08,0.07 0.2,0.02 0.11,0.08 -0.08,0.04 -0.18,0.07 -0.16,0.13 -0.11,0.09 -0.01,0.08 0.09,0.09 0.13,0.08 0.2,-0.02 0.13,-0.09 0.13,0.02 0.16,0.09 0.05,0.07 -0.03,0.02 -0.06,0.03 0.04,0.08 0.18,0.21 0.14,0.16 -0.06,-0.01 -0.18,-0.15 -0.19,-0.06 -0.61,-0.17 -0.38,-0.08 -0.24,-0.1 -0.09,-0.31 0.09,0.09 0.13,0.13 0.18,0.05 0.06,-0.08 0.03,-0.16 0.07,-0.13 v -0.15 l -0.09,-0.26 v -0.26 l 0.22,-0.33 0.14,-0.25 0.09,-0.13 0.08,-0.18 -0.07,-0.08 -0.07,-0.06 0.02,-0.05 0.11,-0.01 0.12,0.02 0.07,-0.04 0.04,-0.11 0.01,-0.1 -0.02,-0.05 0.06,-0.05 0.16,-0.11 0.18,-0.12 0.04,0.08 -0.03,0.17 -0.02,0.06 -0.05,0.02 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S293-3"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S293P1-8"
+         d="m 306.11,224.84 0.02,0.13 0.07,0.1 0.11,0.08 0.19,0.04 0.15,0.04 0.02,0.06 0.03,0.08 0.03,0.07 v 0.05 l -0.11,-0.05 -0.25,-0.05 -0.23,-0.13 -0.14,-0.17 -0.14,-0.03 -0.08,-0.02 0.02,-0.07 0.1,-0.09 0.18,-0.19 0.25,-0.23 0.14,-0.13 -0.09,-0.07 -0.11,-0.11 -0.06,-0.15 -0.09,-0.14 -0.09,-0.07 0.07,-0.04 0.06,-0.04 -0.02,-0.06 -0.08,-0.09 0.02,-0.12 0.09,-0.1 -0.02,-0.07 v -0.16 l -0.01,-0.15 0.01,-0.08 0.04,-0.06 -0.07,-0.12 0.09,-0.08 h 0.2 l 0.04,-0.05 -0.02,-0.07 v -0.08 l 0.15,-0.19 0.15,-0.17 -0.03,-0.06 -0.03,-0.06 -0.04,-0.17 -0.06,-0.17 -0.08,-0.05 -0.23,0.01 -0.3,0.02 -0.14,-0.04 v -0.04 l -0.03,-0.05 -0.09,-0.12 -0.05,-0.15 v -0.08 l 0.05,-0.07 0.05,-0.01 v 0.07 0.11 l 0.07,0.12 h 0.11 l 0.14,-0.01 0.11,0.05 0.06,-0.02 0.04,-0.06 -0.02,-0.16 v -0.16 l 0.07,-0.07 0.07,-0.01 -0.02,0.12 -0.02,0.15 0.02,0.08 0.05,-0.01 0.13,0.01 0.19,-0.03 0.12,-0.05 -0.06,0.08 -0.03,0.1 0.02,0.15 0.05,0.15 0.14,0.04 0.08,-0.02 0.05,-0.18 0.02,-0.18 0.03,-0.02 0.05,0.02 0.04,0.05 v 0.14 0.15 l 0.05,0.05 0.12,-0.02 0.26,-0.04 0.13,-0.11 -0.12,-0.15 -0.16,-0.06 -0.19,-0.06 -0.11,-0.1 0.03,-0.06 0.18,0.04 0.24,0.12 0.15,0.05 0.02,-0.1 -0.07,-0.16 -0.07,-0.15 -0.01,-0.08 0.03,-0.03 0.03,-0.02 -0.03,-0.1 -0.03,-0.11 0.03,-0.06 0.07,-0.03 0.06,0.16 0.05,0.16 0.09,-0.04 0.03,0.08 0.01,0.23 -0.01,0.18 -0.07,0.27 0.07,0.26 0.14,0.15 0.08,0.12 -0.07,-0.03 -0.21,-0.13 -0.14,-0.11 -0.15,-0.01 -0.14,0.06 0.01,0.04 h -0.09 l -0.19,0.01 -0.26,-0.02 -0.2,-0.01 0.09,0.14 v 0.17 l -0.09,0.13 -0.08,0.12 -0.08,0.08 -0.01,0.06 -0.18,0.26 -0.16,0.26 0.07,0.13 0.05,0.12 -0.02,0.13 -0.02,0.15 0.01,0.1 0.18,-0.01 0.04,0.04 -0.12,0.11 0.04,0.02 0.04,0.06 0.02,0.18 0.01,0.19 -0.08,0.14 -0.23,0.21 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S294-3"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S294P1-2"
+         d="m 305.51,224.96 -0.11,0.07 -0.18,0.1 -0.12,0.05 -0.12,0.1 -0.27,0.26 -0.27,0.34 -0.06,0.22 -0.09,0.1 -0.08,-0.03 0.1,-0.13 0.04,-0.17 0.09,-0.17 0.24,-0.23 0.26,-0.31 0.14,-0.18 0.17,-0.11 0.26,-0.12 0.08,0.02 -0.08,0.11 v 0.04 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S296-6"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S296P1-4"
+         d="m 374.69,346.11 -0.02,0.16 -0.12,0.18 -0.12,-0.09 -0.12,-0.22 -0.04,-0.23 0.05,-0.19 0.12,-0.08 0.11,0.06 0.09,0.18 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S308-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S308P1-3"
+         d="m 291.12,205.96 -0.03,-0.05 -0.07,-0.07 -0.09,-0.04 -0.12,0.12 -0.14,0.06 -0.1,-0.07 -0.02,-0.14 0.01,-0.12 0.05,-0.09 -0.05,-0.14 -0.18,-0.13 h -0.08 l -0.03,0.04 -0.06,-0.03 -0.08,-0.17 -0.12,-0.06 -0.1,0.08 -0.08,0.03 -0.04,-0.16 0.08,-0.1 0.14,-0.07 0.15,0.01 0.11,0.1 0.15,0.06 0.11,-0.08 -0.03,-0.15 -0.24,-0.22 v -0.12 l 0.1,-0.04 0.2,0.04 0.13,0.14 0.28,0.2 0.11,0.24 -0.08,0.02 -0.01,0.24 0.03,0.18 0.01,0.11 0.05,0.1 0.08,0.13 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S309-8"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S309P1-2"
+         d="m 291.16,205.81 0.08,0.11 0.25,0.35 0.29,-0.03 0.18,0.1 0.03,0.1 0.11,0.13 0.19,0.17 -0.25,0.08 -0.26,-0.11 -0.15,0.08 -0.04,0.09 0.04,0.11 -0.06,0.03 -0.08,-0.06 -0.03,-0.09 -0.06,-0.3 -0.11,-0.26 -0.17,-0.35 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S310-6"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S310P1-2"
+         d="m 287.63,216.07 -0.26,-0.22 -0.13,0.13 -0.06,0.11 -0.03,-0.18 -0.05,-0.23 -0.49,-0.36 -0.09,-0.13 0.28,0.15 0.05,-0.07 v -0.09 l -0.11,-0.17 -0.13,-0.15 -0.03,-0.37 -0.18,-0.21 -0.27,-0.4 -0.2,-0.17 -1.5,-0.4 -0.3,-0.25 -0.22,-0.33 -0.28,-0.19 -0.54,-0.32 0.18,-0.12 0.64,0.45 0.22,0.34 0.35,0.27 h 0.28 l 0.37,0.14 0.4,0.15 h 0.18 l 0.11,0.03 h 0.05 l 0.07,-0.02 0.13,-0.02 0.21,0.08 0.13,0.27 0.16,0.45 0.23,0.4 -0.04,0.12 0.02,0.15 0.17,0.23 0.27,0.44 0.36,0.16 0.2,0.34 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S311-9"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S311P1-6"
+         d="m 282.21,211.78 0.21,-0.23 0.28,0.26 0.22,0.18 -0.06,0.06 -0.48,-0.07 -0.27,0.12 -0.08,-0.06 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S313-8"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S313P1-5"
+         d="m 307.61,317.11 0.23,-0.15 0.13,0.28 0.24,0.31 0.13,0.22 -0.03,0.14 -0.26,-0.01 -0.66,-0.26 -0.47,-0.51 0.27,-0.03 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S339-4"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S339P1-4"
+         d="m 272.06,293.14 -0.8,0.06 0.22,-0.14 0.11,-0.08 -0.01,-0.13 0.07,-0.1 0.3,0.17 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S340-8"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S340P1-9"
+         d="m 333.46,213.4 -0.13,-0.07 -0.13,-0.03 -0.06,-0.09 -0.02,-0.15 -0.1,-0.33 -0.11,-0.3 0.02,-0.15 0.11,-0.08 0.28,0.09 0.15,0.24 0.09,0.34 0.1,0.13 0.01,0.26 -0.11,0.2 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S341-5"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S341P1-4"
+         d="m 340.75,218.74 -0.03,0.02 -0.16,-0.34 -0.24,-0.26 -0.04,-0.21 0.17,-0.02 0.4,0.09 0.26,0.09 0.15,0.26 0.25,0.52 0.03,0.26 -0.02,0.26 -0.14,0.05 -0.03,-0.06 -0.03,-0.13 -0.02,-0.18 -0.12,-0.2 -0.2,-0.18 -0.14,-0.05 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S342-0"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S342P1-4"
+         d="m 319.11,207.14 -0.43,-0.02 -0.01,-0.17 0.23,0.02 0.24,-0.05 0.11,-0.02 0.18,-0.07 0.06,-0.1 -0.06,-0.13 -0.09,-0.13 0.12,-0.02 0.21,0.13 0.25,0.02 0.11,0.14 0.01,0.26 -0.27,0.03 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S343-2"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S343P1-8"
+         d="m 315.83,193.35 -0.09,0.1 -0.12,0.17 -0.24,-0.02 -0.51,-0.22 0.03,-0.17 0.21,-0.06 0.26,-0.06 0.3,0.16 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S344-9"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S344P1-0"
+         d="m 319.83,190.28 0.01,0.13 0.04,0.14 0.01,0.22 -0.32,-0.36 0.06,-0.14 0.03,-0.25 -0.01,-0.15 -0.07,-0.08 -0.1,-0.03 -0.06,-0.17 0.05,-0.41 -0.04,-0.19 0.11,0.07 0.15,0.3 0.01,0.24 0.08,0.14 0.08,0.18 0.01,0.17 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S369"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S369P1"
+         d="m 279.42,224.99 -0.1,0.05 -0.03,-0.37 0.08,-0.21 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="gF1S370"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S370P1"
+         d="m 279.51,223.7 0.09,-0.41 -0.01,-0.47 0.07,-0.11 0.09,0.07 -0.02,0.46 -0.04,0.49 -0.06,0.29 -0.02,0.26 0.04,0.3 0.07,0.44 -0.1,0.01 -0.1,-0.55 -0.28,-0.26 0.03,-0.17 0.06,-0.07 z"
+         class="region"
+         inkscape:connector-curvature="0"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Boders"
+     inkscape:label="Borders"
+     transform="translate(-603.68384,627.99738)"
+     style="display:inline">
+    <g
+       id="gF1S3-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S3P1-1"
+         d="m 371.21,354.78 0.3,-0.5 -0.07,-0.31 0.49,-0.93 -0.02,-0.07 -0.22,-0.13"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S4-4"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S4P1-2"
+         d="m 374.82,347.9 -0.26,0.06 -0.35,-0.1 -0.1,-0.17 -0.11,-0.03 -0.22,0.06 -0.43,0.05 -0.39,0.49 -0.07,0.61 0.02,0.26 -0.04,0.58 0.14,0.3 0.13,0.41 0.12,0.32 0.01,0.22 -0.07,0.15 0.05,0.06 h 0.09 l 0.23,-0.18 0.3,-0.01 0.31,0.09 0.05,0.1 -0.17,0.14 -0.38,0.42 -0.24,0.42 -0.01,0.31 -0.07,0.68 0.06,0.12 0.12,0.04 0.71,-0.32 0.59,-0.48 0.43,-0.44 0.16,-0.04"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S5-4"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S5P1-4"
+         d="m 372.44,345.48 0.41,-0.19 0.33,-0.06 0.38,-0.11 0.25,-0.3 v -0.63 l 0.14,-0.15 0.12,0.1"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S17-5"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S17P1-3"
+         d="m 315.3,271.26 0.01,-0.04 -0.08,-0.4 0.09,-0.11 0.17,-0.09 0.24,-0.02 0.23,0.02 0.28,0.14 0.08,-0.05 0.36,-0.42 0.35,-0.61 0.06,-0.32 0.09,-0.16 0.37,-0.15 0.32,-0.09 0.22,-0.04 0.51,-0.15 0.3,-0.12 0.24,-0.15 0.57,-0.15 0.91,-0.12 0.59,-0.12 0.4,-0.04 1.04,0.06 0.37,-0.03 0.2,0.11 0.34,-0.02 0.62,0.02 0.53,-0.04 0.34,-0.11 0.2,-0.01 0.52,0.56 0.09,0.06 0.15,-0.02 0.28,-0.12 0.43,-0.08 0.29,0.07 0.05,0.4 0.08,0.04 0.11,-0.05 0.09,-0.25 0.06,-0.26 0.07,-0.09 0.47,0.05 0.19,-0.07 0.14,-0.22 0.1,-0.06 0.34,0.05 0.4,-0.01 0.3,-0.07 0.22,0.04 0.24,0.37 0.14,0.05 0.12,-0.01 0.09,-0.4 0.12,-0.18 0.2,-0.16 0.13,-0.08 0.06,-0.15 0.11,-0.16 0.11,-0.04 0.11,0.02 0.15,0.14 0.26,0.35 0.3,0.34 0.17,0.1 0.32,-0.21 0.2,-0.19 0.43,-0.14 0.55,-0.24 0.4,-0.23 0.28,-0.06 0.2,0.08 0.32,0.17 0.16,0.32 0.39,0.15 0.28,-0.03 0.03,-0.28 0.1,-0.21 -0.12,-0.22 -0.11,-0.29 -0.19,-0.25 -0.17,-0.28 0.03,-0.47 0.05,-0.41 0.02,-0.23 0.14,-0.44 0.17,-0.34 0.25,-0.54 0.23,-0.22 0.27,-0.01 0.15,0.02 0.28,-0.36 0.63,-0.2 0.53,-0.13"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S22-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S22P1-9"
+         d="m 312.87,259.89 0.22,0.05 0.49,-0.05 0.36,-0.18 0.19,-0.05 h 0.18 l 0.25,-0.11 0.24,-0.07 0.15,0.12 0.25,0.08 0.4,-0.27 0.35,-0.3 0.41,-0.05 0.03,-0.12 -0.01,-0.59 0.09,-0.15 0.49,-0.04 0.16,-0.14 0.13,-0.31 0.24,-0.23 0.24,-0.05 0.2,-0.25 0.15,0.11 0.11,0.22 -0.04,0.2 0.05,0.07 0.19,0.05 0.29,-0.06 0.17,-0.12 0.02,-0.11 -0.04,-0.2 -0.09,-0.17 -0.16,-0.13 -0.25,-0.03 -0.16,0.03 -0.05,-0.09 0.01,-0.22 0.06,-0.42 0.1,-0.39 0.08,-0.16 -0.01,-0.13 -0.07,-0.21 -0.09,-0.38 0.04,-0.57 0.12,-0.45 0.25,-0.19 0.32,-0.14 0.18,-0.24 0.06,-0.25 -0.01,-0.19 0.02,-0.17 0.09,-0.1 0.83,-0.14 0.04,-0.37 0.05,-0.11 0.13,-0.14 0.08,-0.15 -0.06,-0.08 -0.22,-0.02 -0.51,0.06 -0.12,-0.09 v -0.15 l 0.05,-0.38 0.01,-0.49 -0.02,-0.37 -0.04,-0.21"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S25-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S25P1"
+         d="m 286.98,287.69 -0.16,-0.23 -0.28,-0.27 -0.45,-0.38 -0.33,0.03 -0.13,-0.1 -0.06,-0.14 -0.15,-0.25 -0.16,-0.17 -0.2,-0.06 -0.28,-0.22 -0.38,-0.47 -0.35,-0.33 -0.32,0.02 -0.21,-0.17 -0.22,-0.23 -0.16,-0.22 -0.25,-0.54 -0.18,-0.3 -0.14,-0.19 -0.15,-0.16 -0.06,-0.12 0.18,-0.3 0.06,-0.14 0.08,-0.11 0.04,-0.12 -0.01,-0.09 -0.17,-0.28 -0.23,-0.2 -0.34,-0.21 -0.22,-0.25 -0.08,-0.25 -0.03,-0.13 -0.15,-0.18 -0.12,-0.26 v -0.16 l 0.03,-0.04 h 0.11 l 0.12,0.1 0.18,0.21 0.15,0.3 0.08,-0.12 0.16,-0.33 0.27,-0.37 0.29,-0.22 0.27,-0.03 0.21,-0.06 0.18,-0.11 0.32,0.03 0.22,0.07 0.08,-0.05 0.08,-0.19 0.06,-0.17 0.5,-0.11 0.16,-0.33 h 0.09 l 0.11,-0.05 0.1,-0.13 0.1,-0.05 0.09,0.06 0.11,0.03 0.1,-0.08 0.15,-0.37 0.09,-0.06 0.44,-0.08 0.59,-0.24 0.29,-0.2 0.29,-0.12 0.31,-0.2 0.5,-0.21 0.02,-0.07 -0.25,-0.17 -0.08,-0.12 -0.06,-0.11 0.08,-0.14 0.1,-0.05 0.15,0.05 0.43,0.06 0.12,0.07 0.05,0.18 0.12,0.17 0.08,0.01 -0.01,0.29 0.14,0.1 0.2,0.08 0.13,-0.03 0.09,-0.12 0.03,-0.08"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S26-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S26P1"
+         d="m 319.3,241.01 -0.06,0.02 -0.36,0.03 -0.43,-0.1 -0.2,-0.11 -0.16,0.04 -0.18,0.14 -0.64,0.43 -0.19,-0.02 -0.47,-0.18 -0.27,-0.24 -0.59,-0.47 -0.07,-0.13 -0.09,-0.09 -0.52,-0.04 -0.22,-0.17 h -0.16 l -0.24,-0.06 -0.67,-0.33 -0.15,-0.02 -0.02,0.09 0.03,0.1 -0.02,0.07 -0.07,0.01 -0.17,-0.14 -0.19,-0.11 -0.43,0.37 -0.16,0.11 -0.16,0.05 -0.7,0.51 -0.2,0.25 -0.1,-0.01"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S27-7"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S27P1"
+         d="m 319.3,241.01 0.29,-0.05 0.12,0.05 0.16,0.34 0.41,0.21 0.37,0.16 0.1,0.09 0.08,0.21 0.05,0.25 -0.01,0.14 -0.09,0.18 -0.02,0.4 0.08,0.35 -0.02,0.66 h 0.04 l 0.35,-0.2 0.12,0.04 0.12,0.11 0.13,0.38 0.16,0.15 0.2,0.23 0.1,0.21 0.3,0.19 0.06,0.15 0.3,0.54 0.15,0.32 0.09,0.25 0.01,0.34 -0.01,0.24"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S28-4"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S28P1"
+         d="m 304.59,250.89 0.62,-0.66 0.79,-0.73 0.19,-0.09 0.76,-0.48 0.1,-0.04 0.74,-0.06 0.59,-0.01 0.48,-0.09 0.25,-0.14 0.26,0.04 0.24,0.23 0.19,-0.07 0.17,-0.2 1.11,-0.04 0.24,-0.05 0.28,-0.02 0.54,0.07 0.32,0.09 0.62,-0.21 0.28,-0.06 0.13,-0.09 0.35,-0.48 0.18,-0.11 0.16,-0.1 0.17,0.03 0.18,0.31 0.45,0.52 0.38,0.04 1.02,0.02 0.23,0.07 0.67,0.4 0.38,0.19 0.26,0.15 0.41,0.33 0.26,0.24 0.36,0.15 0.4,0.07 0.14,-0.01"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S29-0"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S29P1-1"
+         d="m 293.79,190.84 -0.22,0.05 -0.63,0.14 0.35,0.35 0.12,0.15 0.06,0.22 0.02,0.44 -0.07,0.38 -0.11,0.32 -0.27,0.34 0.52,0.23 -0.25,0.44 -0.13,0.17 H 293 l -0.33,-0.1 -0.8,-0.24 -0.38,-0.08 h -0.33 l -0.17,0.02 -0.72,-0.21 -0.12,0.05 -0.23,0.15 0.01,0.28 0.1,0.68 0.11,0.53 -0.05,0.31 -0.07,0.22 -0.21,0.59 -0.67,-0.32 -0.46,-0.21 -0.23,0.36 -0.63,0.68 -0.23,1.25 -0.02,0.04 -0.18,0.33 -0.26,0.17 -0.2,0.08 -0.08,0.38 0.33,0.5 0.17,0.26 0.18,0.44 0.01,0.28 -0.02,0.18 -0.27,0.39 -0.58,1 -0.53,1.05 -0.23,0.3 0.19,0.84 -0.19,0.26 -0.41,0.31 -0.21,0.13 -0.23,0.08 -0.72,0.15 0.19,0.91 0.08,0.4 0.01,0.24 -0.06,0.23 -0.06,0.46 -0.03,1.61 -0.1,0.17 -0.12,0.45 -0.41,1.07 -0.35,0.71 -0.51,1.03 0.48,0.29 0.43,0.22 0.11,0.35 0.09,0.59 0.01,0.41 -0.14,0.37 -0.11,0.26 -0.08,0.13 -0.62,-0.1 -0.78,-0.13 -0.2,0.01 -0.45,0.13 -0.4,0.25 -0.21,0.21 -0.06,0.08 -0.26,0.46 -0.46,0.82 -0.26,0.36 0.09,0.48 -0.43,0.95 0.32,0.95 0.02,0.03 0.17,0.38 -0.16,0.25 -0.07,0.13 0.03,0.44 0.06,0.49 -0.03,0.29 -0.01,0.32 0.46,1.43 v 0.34 l -0.01,0.22 -0.11,0.9 -0.14,1.21 0.32,0.31 0.45,0.37 0.26,0.14 0.38,0.45 0.3,0.43 -0.03,0.29 -0.07,0.33 -0.11,0.23 -0.1,0.31 -0.04,0.23 -0.05,0.06 -0.5,0.04 -0.27,0.1 -0.13,0.1 0.06,0.52 0.33,0.95 0.28,0.67 0.1,0.45 -0.07,0.46 -0.08,0.23 v 0.32 l -0.05,0.63 -0.19,0.32 -0.25,0.35 -0.29,0.26 -0.23,0.08 -0.2,0.04 -0.13,0.13 -0.12,0.39 -0.1,0.4 -0.37,0.51 0.02,0.17 0.15,0.59 0.15,0.67 -0.1,0.63 -0.09,0.66 -0.16,0.45 -0.25,0.16 -0.18,-0.08 -0.21,-0.6 -0.12,-0.25 -0.11,-0.06 -0.15,-0.01 -0.23,0.08 -0.07,0.31 -0.14,0.3 -0.36,0.07"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S30-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S30P1"
+         d="m 293.79,190.84 0.06,-0.16 0.36,-0.06 0.32,0.09 0.06,-0.07 0.01,-0.12 -0.21,-0.46 v -0.13 l 0.1,-0.16 0.19,-0.15 0.32,-0.07 0.22,-0.02 0.05,0.01 0.43,0.47 0.39,0.47 0.19,0.19 0.5,0.56 0.21,0.33 0.1,0.25 0.16,-0.03 0.55,0.02 0.46,0.02 0.16,0.12 0.3,-0.08 0.2,-0.17 0.38,-0.24 0.07,-0.22 0.09,-0.24 0.25,-0.01 0.3,0.12 0.35,0.16 0.3,0.05 0.4,0.09 0.22,0.18 0.25,0.01 0.19,-0.26 v -0.59 l 0.07,-0.27 0.13,-0.22 0.19,-0.13 0.15,-0.06 0.08,-0.17 0.09,-0.35 -0.07,-0.39 -0.22,-0.68 -0.03,-0.23 0.04,-0.4 -0.09,-1.03 0.01,-0.3 0.05,-0.19 0.1,-0.13 0.17,-0.35 0.18,-0.67 0.08,-0.07 0.23,-0.08 0.32,-0.05 0.3,0.04 0.03,-0.02 0.11,-0.08 0.17,-0.23 0.27,-0.46 0.22,-0.15 0.22,-0.04 0.37,0.33 0.49,0.35 0.29,0.16 0.74,0.24 0.62,0.13 0.59,0.78 -0.03,0.39 -0.04,0.14 -0.15,0.41 -0.13,0.56 0.05,0.26 0.18,0.23 0.18,0.14"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S34-4"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S34P1-5"
+         d="m 263.54,284.27 0.03,-0.28 0.11,-0.41 0.1,-0.22 0.13,-0.17 0.13,-0.11 0.04,-0.23 -0.01,-0.21 -0.14,-0.04 -0.35,-0.17 -0.2,-0.18 -0.15,-0.22 -0.19,-0.29 -0.07,-0.29 0.02,-0.29 0.03,-0.13"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S35-6"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S35P1-9"
+         d="m 252.53,275.45 0.01,0.23 0.09,0.3 0.06,0.17 -0.09,0.2 0.04,0.18 0.18,0.33 0.24,0.32 0.22,0.21 0.07,-0.01 0.19,-0.04 0.32,-0.16 0.26,-0.03 0.13,0.16 0.07,0.09 0.13,0.34 0.01,0.35 0.05,0.29 0.11,0.13 0.49,0.09 0.35,0.13 0.08,0.11 0.07,0.64 0.06,0.1 0.09,-0.07 0.1,-0.09 0.13,-0.01 0.2,0.06 0.28,0.04 0.28,0.09 0.37,0.4 -0.03,0.11 -0.09,0.21 -0.04,0.16 0.06,0.07 0.09,0.18 -0.04,0.2 -0.11,0.13 -0.06,0.11 v 0.07 l 0.03,0.07 0.08,0.06 0.58,0.12 0.55,-0.03 0.36,-0.17 0.07,-0.21 0.12,-0.23 0.22,-0.19 0.14,-0.05 0.12,0.09 -0.28,0.82 0.15,0.23 -0.01,0.33 0.04,0.28 0.19,0.01 0.24,0.07 0.16,0.12 0.18,0.18 0.27,0.18 0.19,0.06 0.06,0.14 0.15,0.16 0.23,0.33 0.22,0.22 0.1,0.01 0.22,-0.07 0.31,-0.03 0.25,0.02"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S36-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S36P1"
+         d="m 263.02,281.03 -0.02,-0.01 -0.06,-0.15 -0.1,-0.01 -0.24,-0.08 -0.36,0.39 -0.17,0.32 -0.11,0.24 -0.15,0.2 -0.04,0.2 0.02,0.09 -0.06,0.11 -0.01,0.12 0.18,0.25 0.04,0.13 0.21,0.44 -0.08,0.15 -0.07,0.16 -0.08,0.11 -0.08,0.07"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S37-9"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S37P1"
+         d="m 396.62,290.41 -0.08,-0.03 h -0.52 l -0.21,-0.04 -0.16,0.08 -0.36,0.1 -0.32,0.04 -0.19,-0.08 -0.26,-0.06 -0.44,-0.02 -0.34,-0.06 -0.07,-0.12 -0.07,-0.61 -0.11,-0.57 -0.1,-0.06 h -0.18 l -0.31,0.07 -0.62,0.37 -0.61,-0.3 -0.19,-0.04 -0.29,0.06 -0.44,0.04 h -0.26 l -0.04,0.07 v 0.69 l -0.4,-0.28 -0.18,-0.04 -0.23,0.05 -0.2,0.11 -0.44,0.46 -0.29,0.42 -0.22,0.31 -0.25,0.23 -0.08,0.2 -0.4,0.18 h -0.24 l -0.1,-0.07 -0.04,-0.19 0.05,-0.26 -0.03,-0.12 -0.08,-0.06 -0.58,-0.02 -0.26,-0.06 -0.71,0.09 -0.93,-0.02 -0.37,-0.14 -0.1,-0.17 -0.37,-0.03 -0.45,0.03 -0.28,0.19 -0.27,0.16 -0.56,-0.09 -0.42,0.18 -0.43,0.32 -0.09,0.08 -0.1,0.1 -1.45,0.53 -0.45,-0.08 -0.41,-0.11 -0.89,0.2 -0.5,0.01 -0.52,-0.08 -0.56,-0.03 -0.35,0.27 -0.58,0.1 -0.63,0.14 -0.17,0.16 -0.07,0.39 -0.03,0.35"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S38-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S38P1"
+         d="m 314.28,322.97 -0.04,-0.1 -0.1,-0.13 -0.24,-0.04 -0.45,0.13 -0.13,-0.1 -0.26,-0.59 -0.16,-0.08 -0.19,-0.19 -0.36,-0.64 -0.05,-0.3 -0.01,-0.26 -0.22,-0.59 0.07,-0.17 0.14,-0.11 -0.03,-0.25 -0.09,-0.37 0.09,-0.75 0.04,-0.06"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S39-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S39P1"
+         d="m 312.29,318.37 0.02,-0.21 -0.07,-0.45 -0.27,-0.72 -0.16,-0.23 -0.3,-0.2 -0.23,-0.13 -0.39,-0.09 -0.24,-0.39 -0.34,-0.42 -0.15,-0.09"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S46-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S46P1"
+         d="m 270.71,257.48 0.19,0.13 0.2,0.57 0.14,0.18 0.21,0.07 0.51,0.02 0.13,0.03 0.77,0.26 0.19,0.18 0.24,0.01 0.44,-0.15 0.32,-0.07 0.13,0.1 0.17,0.04 0.04,0.01"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S50-2"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S50P1"
+         d="m 308.76,298.52 0.11,-0.13 0.72,-0.27 0.37,0.12 0.15,-0.08 0.13,-0.15 0.07,-0.12 v -0.11 l 0.06,-0.15 0.24,-0.1 0.68,-0.01 0.24,-0.23 0.08,-0.11 0.03,-0.24 0.04,-0.2 0.23,-0.13 -0.03,-0.17 -0.06,-0.17 0.08,-0.43 0.06,-0.18 0.13,-0.08 0.14,-0.16 0.24,-0.31 -0.1,-0.22 0.03,-0.18 0.23,-0.46 0.17,-0.44 -0.04,-0.2 0.01,-0.18 0.17,-0.23 0.16,-0.28 0.16,-0.83 0.07,-0.15 0.15,-0.18 0.11,-0.17 -0.06,-0.52 0.1,-0.17 0.21,-0.2 0.19,-0.31 0.14,-0.35 0.12,-0.17 0.19,-0.07 0.19,-0.16 0.22,-0.08 0.24,0.02 0.14,-0.06 0.19,-0.19 0.46,-0.67 0.06,-0.13"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S52-7"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S52P1-5"
+         d="m 302.37,282.89 0.33,0.03 0.09,0.23 0.06,0.24 0.56,-0.08 0.25,-0.57 0.15,-0.08 0.24,-0.22 0.15,-0.18 0.13,0.08 0.21,0.32 0.21,0.26 0.12,0.09 0.02,0.09 0.11,0.03 0.21,0.01 0.14,0.06 0.07,0.25 0.04,0.23 -0.05,0.18 -0.01,0.15 0.15,0.04 0.19,-0.08 0.14,-0.1 0.46,0.13 0.1,-0.45 0.15,-0.24 0.21,-0.13 0.19,-0.16 0.17,-0.12 0.13,-0.01 0.05,-0.05 0.16,-0.01 0.19,0.02 0.24,-0.08 0.37,0.05 0.24,0.17 0.22,0.03 0.24,-0.04 0.15,-0.14 0.19,-0.4 0.17,-0.02 0.27,-0.1 0.38,-0.06 0.9,-0.05 0.25,0.11 0.57,0.1 0.27,0.17 0.14,0.23 0.08,0.17 0.61,0.18 0.88,0.2 0.21,0.01"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S53-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S53P1"
+         d="m 228.6,251.78 -0.49,0.19 -0.1,0.1 -0.23,0.42 -0.05,0.13 -0.19,0.21 -0.2,0.23 -0.18,0.07 -0.24,0.02 -0.14,0.05 -0.15,-0.08 -0.2,-0.04 -0.13,0.06 -0.01,0.07 0.04,0.1 0.14,0.16 0.17,0.16 -0.05,0.1 -0.13,0.08 -0.74,0.1 -0.24,0.11 -0.1,0.09 0.02,0.2 0.39,0.69 0.07,0.08 v 0.34 l 0.43,0.25 0.14,0.25 0.16,0.09 0.36,0.07 0.13,0.11 0.1,-0.03 0.07,-0.09 0.37,-0.2 0.13,-0.09 -0.02,-0.18 -0.03,-0.14 0.25,-0.21 0.28,-0.19 0.11,0.04 0.16,0.2 0.1,0.24 -0.02,0.17 v 0.13 l 0.09,0.29 0.07,0.11 0.25,0.11 0.04,0.11 -0.14,0.36 0.01,0.13 0.27,0.07 0.3,0.04 0.1,0.04 0.12,-0.05 0.18,-0.05 0.23,0.09"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S54-5"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S54P1"
+         d="m 302.37,282.89 -0.02,-0.14 -0.11,-0.34 -0.73,-0.61 -0.11,-0.28 0.01,-0.11 -0.06,-0.18 -0.15,-0.1 -0.53,-0.07 -0.13,0.09 -0.12,-0.07 -0.21,-0.14 -0.34,-0.1 -0.04,-0.07 -0.13,-0.1 -0.06,-0.01 -0.04,0.08 -0.08,0.11 -0.32,0.16 -0.14,-0.04 -0.13,-0.1 -0.16,-0.23 -0.22,-0.19 -0.18,-0.06 -0.1,-0.1 -0.03,-0.08 0.35,-0.21 0.06,-0.18 -0.08,-0.32 -0.06,-0.04 -0.13,0.12 -0.29,0.13 -0.28,0.07 -0.15,0.02 -0.85,-0.52 -0.54,-0.13 -0.31,-0.03 -0.03,0.06 0.17,0.32 0.28,0.39 V 280 l -0.28,0.19 -0.16,0.09 -0.18,0.16 -0.14,0.21 -0.14,0.1 -0.12,-0.01 -0.14,-0.09 -0.38,-0.57 -0.46,-0.43 -0.05,-0.1 -0.14,-0.02 -0.19,-0.09 -0.07,-0.14 0.08,-0.15 0.12,-0.15 0.21,-0.1 0.07,-0.08 0.03,-0.12 0.07,-0.16 -0.03,-0.06 -0.17,-0.16 -0.25,-0.14 -0.64,0.17 -0.18,0.1 -0.11,-0.1 -0.09,-0.17 -0.16,-0.02 -0.24,-0.13 -0.28,-0.13 -0.26,-0.03 -0.56,-0.17 h -0.21 l -0.13,-0.07 -0.14,-0.15 -0.12,-0.17 -0.08,-0.36 -0.41,-0.14 -0.4,-0.08 -0.02,0.06 0.03,0.36 -0.01,0.2 -0.25,0.13 -0.26,0.03"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S56-6"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S56P1-0"
+         d="m 311.42,328.78 0.07,-0.01 0.14,0.03 0.28,0.14 h 0.28 l 0.14,-0.13 0.08,-0.12 0.03,-0.18 v -0.21 l 0.04,-0.07 0.21,-0.01 0.06,-0.06 -0.02,-0.18 -0.16,-0.21 -0.15,-0.27 -0.02,-0.13 0.1,-0.07 0.15,-0.14 0.07,-0.16 0.16,-0.1 0.26,-0.05 0.28,-0.11 0.16,-0.19 0.01,-0.16 0.06,-0.46 0.05,-0.23 0.1,-0.21 0.04,-0.28 0.1,-0.26 0.26,-0.15 0.23,-0.16 0.14,-0.35 0.07,-0.29 -0.02,-0.17 -0.18,-0.25 -0.15,-0.25 -0.01,-0.36"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S58-0"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S58P1-6"
+         d="m 313.3,286.74 -0.08,-0.77 0.39,-0.64 0.07,-0.3 0.08,-0.63 0.09,-0.31 0.12,-0.26 0.09,-0.25 0.01,-0.2"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S65-2"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S65P1-7"
+         d="m 286.98,287.69 0.09,0.03 0.26,0.14 0.21,0.16 0.21,0.43 0.45,0.09 0.57,-0.02 0.19,-0.2 0.18,-0.06 0.21,0.05 0.44,0.05 0.03,-0.36 0.23,-0.37 0.1,-0.14 h 0.32 l 0.06,-0.28 0.04,-0.75 0.06,-0.09 0.23,0.01 0.24,0.12 0.07,0.1 0.12,-0.01 0.16,-0.09 0.18,-0.06 0.3,0.06 0.64,0.3 0.32,0.1 0.21,-0.04 0.18,-0.01 0.77,0.47 0.52,0.04 0.46,-0.04 0.14,-0.17 0.19,-0.15 h 0.21 l 0.18,0.06 0.37,0.2 0.17,0.04 0.22,0.02 0.16,0.04 0.18,0.38 0.08,0.1"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S67-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S67P1-0"
+         d="m 294.82,296.35 0.48,-0.56 0.25,-0.16 h 0.3 l 0.1,-0.05 0.01,-0.08 0.04,-0.17 0.02,-0.17 0.01,-0.15 -0.04,-0.08 -0.14,-0.01 -0.1,-0.37 0.06,-0.14 0.07,-0.11 -0.13,-0.44 0.02,-0.16 0.23,-0.04 0.18,-0.11 0.15,-0.12 0.03,-0.15 0.11,-0.29 -0.15,-0.34 -0.68,-0.17 -0.04,-0.08 0.15,-0.11 0.15,-0.16 0.09,-0.12 0.12,-0.02 0.19,0.04 0.34,0.22 0.13,0.03 0.11,-0.08 0.13,-0.03 0.35,-0.02 0.3,-0.09 -0.09,-0.26 -0.02,-0.19 -0.06,-0.16 0.01,-0.17 0.11,-0.14 0.01,-0.31 0.17,-0.22"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S68-2"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S68P1-1"
+         d="m 264.89,301.26 0.11,0.11 0.24,0.12 0.67,-0.12 0.42,-0.14 0.29,-0.14 0.18,0.03 0.64,0.27 0.22,-0.12 0.48,-0.31 0.08,-0.17 0.38,-0.51 0.01,-0.12 -0.14,-0.34 0.05,-0.07 0.46,-0.32 0.23,-0.29 0.24,-0.19 h 0.18 l 0.04,0.07 0.02,0.14 -0.03,0.57 0.06,0.18 0.34,0.42 0.25,0.24 0.59,0.18 0.02,0.07 -0.17,0.31 0.35,0.38 0.06,0.27 0.16,0.16 0.24,-0.07 0.08,-0.14 -0.09,-0.26 -0.06,-0.26 0.02,-0.15 0.06,-0.18 0.17,-0.24 0.45,-0.55 0.16,-0.32 0.04,-0.5 0.01,-0.4 0.14,-0.09 0.32,0.07 h 0.09 l 0.04,0.24 0.13,0.4 0.15,0.2 0.17,0.06 h 0.2 l 0.5,-0.24 0.32,-0.1 0.18,0.03 0.1,0.17 0.23,0.43 0.13,0.05 0.16,-0.05 0.06,-0.08 -0.05,-0.16 -0.07,-0.36 -0.09,-0.28 -0.12,-0.13 -0.02,-0.17 0.08,-0.3 0.08,-0.25 0.17,-0.07 0.19,-0.03 0.25,0.27 0.3,0.08 0.23,-0.01 0.04,-0.16 -0.02,-0.17 -0.13,-0.22 0.03,-0.34 0.15,-0.62"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S69-5"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S69P1-3"
+         d="m 276.34,297.04 0.01,-0.16 -0.13,-0.31 -0.22,-0.1 -0.56,0.58 -0.15,0.05 -0.45,-0.16 -0.38,-0.25 -0.05,-0.19 -0.06,-0.15 -0.32,-0.14 -0.41,-0.11 h -0.13"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S71-6"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S71P1-4"
+         d="m 312.87,259.89 -0.04,-0.09 -0.03,-0.22 -0.06,-0.35 -0.14,-0.29 -0.27,-0.23 -0.28,-0.14 -0.34,-0.14 -0.24,-0.05 h -0.13 l -0.05,-0.11 -0.06,-0.08 -0.12,-0.07 -0.25,-0.08 -0.19,0.01 -0.13,0.21"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S73-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S73P1-7"
+         d="m 267.02,266.05 -0.04,0.46 -0.04,0.89 -0.04,0.16 -0.2,0.37 -0.22,0.68 -0.07,0.44 -0.07,0.08 -0.77,-0.04 -0.11,0.08 -0.02,0.09 0.03,0.12 -0.02,0.11 -0.07,0.09 0.03,0.15 0.12,0.18 0.24,0.12 0.26,0.02 0.14,-0.01 0.09,0.12 0.09,0.19 -0.02,0.24 -0.05,0.31 -0.14,0.28 -0.38,0.32 -0.16,0.11 -0.16,0.05 -0.07,0.08 -0.04,0.11 v 0.1 l 0.24,0.29 -0.01,0.06 -0.08,0.13 -0.1,0.13 -0.68,0.24 -0.27,-0.04 -0.17,0.13 -0.05,0.02 -0.16,-0.13 -0.38,-0.17 -0.15,0.04 -0.09,0.07 -0.25,0.09 -0.18,0.13 -0.01,0.2 0.28,0.52 0.1,0.1 -0.01,0.19 0.14,0.24 0.14,0.3 v 0.19 l -0.03,0.19 -0.09,0.26 -0.31,0.61 -0.01,0.12 0.02,0.09 0.09,0.03 0.07,0.05 -0.03,0.09 -0.53,0.4 -0.07,0.07 -0.22,-0.03 -0.03,0.07 0.02,0.12 0.07,0.11 0.18,0.06 0.15,0.12 0.12,0.22 -0.21,0.73"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S74-5"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S74P1-3"
+         d="m 273.49,296.1 0.05,-0.09 0.05,-0.14 -0.03,-0.12 -0.09,-0.13 -0.05,-0.13 -0.02,-0.13 -0.03,-0.11 -0.01,-0.09 -0.03,-0.08"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S76-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S76P1-2"
+         d="m 266.08,311.62 v -0.27 l -0.02,-0.2 0.14,-0.21 0.25,-0.25 0.22,-0.32 0.1,-0.23 -0.04,-0.16 -0.09,-0.23 -0.13,-0.03 -0.79,0.17 -0.18,-0.06 -0.57,-0.33 -0.61,-0.4 -0.21,-0.28 -0.08,-0.27 0.07,-0.17 -0.04,-0.17 -0.11,-0.23 0.12,-0.25 0.21,-0.31 0.1,-0.21 0.17,-0.05 0.08,-0.13 -0.11,-0.53 -0.06,-0.09 -0.11,-0.07 -0.17,-0.02 -0.3,-0.12 -0.2,-0.2 -0.03,-0.24 -0.11,-0.25 -0.18,-0.22 -0.01,-0.24 0.22,-0.12 0.3,0.01 0.21,0.06 0.49,-0.36 0.17,-0.02 0.16,-0.08 0.15,-0.51 0.11,-0.15 0.02,-0.09 -0.08,-0.12 -0.37,-0.38 -0.15,-0.39 -0.25,-0.44 -0.25,-0.2 -0.04,-0.15 v -0.19 l 0.06,-0.16 0.47,-0.24 0.28,-0.26"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S77-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S77P1-3"
+         d="m 307.68,188.15 -0.09,0.08 -0.27,0.31 -0.16,0.19 -0.22,0.17 0.11,0.13 0.42,-0.08 0.08,0.02 0.07,0.06 0.04,0.12 0.02,0.19 -0.13,1.15 0.06,0.22 0.34,0.57 0.43,0.66 0.74,0.15 0.56,0.12 0.5,0.5 0.76,0.64 0.37,0.21 0.04,0.08 0.1,0.56 -0.15,0.62 -0.16,0.54 -0.15,0.63 -0.1,0.53 -0.1,0.63 0.02,0.19 0.05,0.17 0.11,0.18 0.57,0.59 0.26,0.31 0.28,0.33 0.28,0.37 0.21,0.35 0.26,0.32 0.15,0.16 0.23,0.21 0.31,0.33 0.16,0.29 0.63,0.97 0.11,0.26 0.06,0.21 -0.11,0.08 -0.27,0.1 -0.25,0.22 v 0.04 l 0.27,0.2 -0.03,0.47 0.17,0.62 -0.08,0.37 0.01,0.08 0.02,0.06 0.05,0.04 0.37,-0.01 0.06,0.08 0.06,0.18 0.02,0.17 -0.13,0.17 -0.13,0.23 0.01,0.18 0.06,0.15 0.14,0.24 0.22,0.26 0.22,0.14 0.61,0.02 0.12,0.13 0.1,0.19 0.05,0.2 -0.14,0.46 0.05,0.15 0.23,0.33 0.24,0.31 0.67,0.22 0.26,0.15 0.11,0.15 0.11,0.26 0.09,0.28 0.04,0.27 -0.06,0.38 -0.2,0.76 -0.33,0.36 -0.01,0.06 0.19,0.18 1,0.62 0.61,0.26 0.82,0.33 0.55,0.3 0.24,0.25 0.29,0.28 0.3,0.21 0.22,0.19 0.11,0.13 0.05,0.17 -0.03,0.55 0.02,0.41 -0.02,0.61 -0.07,0.45 -0.29,0.86 -0.49,1.11 -0.09,0.32 -0.22,0.57 -0.33,1.11 -0.1,0.26 -0.3,0.89 -0.16,0.3 -0.12,0.28 -0.32,0.85 -0.4,0.69 -0.41,0.65 -0.1,0.29 -0.15,0.25 -0.2,0.25 -0.08,0.13 -0.37,0.84 -0.54,1.15 -0.05,0.4"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S78-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S78P1-7"
+         d="m 309.57,184 0.29,0.55 0.07,0.2 0.03,0.2 -0.02,0.12 -0.09,0.07 -0.28,0.06 -0.46,-0.12 -0.31,-0.14 -0.08,0.01 -0.02,0.03 0.13,0.2 0.04,0.17 0.03,0.19 0.01,0.18 -0.03,0.15 -0.09,0.22 -0.2,0.21 -0.62,0.46 -0.02,0.14 0.02,0.82 -0.03,0.13 -0.05,0.11 -0.21,0.19"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S87-6"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S87P1-6"
+         d="m 296.34,297.98 -0.3,-0.1 -0.36,-0.02 -0.06,0.07 -0.13,0.08 -0.07,0.12 0.09,0.45 -0.08,0.08 -0.4,-0.01 -0.13,0.06 -0.19,0.33 -0.22,0.15 -0.27,0.11 -0.21,0.13 -0.25,0.12 -0.23,0.08 -0.08,0.14 -0.04,0.15 0.02,0.15 0.25,0.27 0.05,0.31 v 0.38 l -0.04,0.21 -0.08,0.14 -0.56,0.21 -0.57,0.35 -0.01,0.07 0.29,0.26 0.01,0.07 -0.21,0.17 -0.01,0.16 0.03,0.18 0.13,0.18 0.06,0.16 -0.32,0.14 -0.45,-0.01 -0.53,-0.2 -0.19,0.04 -0.17,0.13 -0.18,-0.04 -0.21,-0.13 -0.3,-0.29 -0.14,-0.17 -0.07,-0.2 -0.08,-0.02 -0.11,0.06 -0.08,0.25 -0.24,0.44 -0.19,0.13 -0.29,-0.01 -0.41,0.02 -0.26,0.05 -0.31,-0.13 -0.08,0.03 0.01,0.1 -0.11,0.16 -0.19,0.11 -0.9,-0.19 -0.13,-0.19"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S88-0"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S88P1-9"
+         d="m 304.45,299.91 h -0.01 l -0.22,0.12 -0.36,0.1 -0.19,-0.02 -0.28,0.49 -0.1,0.09 -0.3,0.17 -0.26,0.1 -0.23,-0.03 h -0.09 l -1,0.08 -0.53,-0.04 -0.35,-0.14 -0.24,-0.18 -0.12,-0.2 -0.27,-0.11 -0.41,-0.01 -0.34,-0.18 -0.26,-0.36 -0.33,-0.28 -0.41,-0.19 -0.33,-0.29 -0.26,-0.39 -0.43,-0.33 -0.61,-0.28 -0.18,-0.05"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S89-5"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S89P1-5"
+         d="m 308.76,298.52 -0.12,-0.07 -0.17,-0.05 h -0.75 l -0.29,0.11 -0.4,0.03 -0.37,-0.04 -0.26,0.1 -0.21,0.35 -0.1,0.12 -0.09,0.09 -0.2,0.12 -0.15,0.14 -0.22,0.12 -0.21,0.01 -0.21,-0.11 -0.07,0.04 -0.04,0.13 -0.1,0.12 -0.27,0.17 -0.08,0.01"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S90-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S90P1-0"
+         d="m 296.34,297.98 -0.05,-0.11 -0.31,-0.38 -0.14,-0.14 v -0.2 l -0.07,-0.11 -0.11,-0.07 -0.07,-0.29 -0.05,-0.21 -0.09,-0.14 -0.63,0.02"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S94-5"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S94P1-9"
+         d="m 338.03,312.99 -0.48,0.03 -0.16,0.07 -0.07,0.13 -0.22,0.03 -0.27,0.07 -0.25,0.2 -0.14,0.09 -0.23,-0.07 -0.46,-0.27 -0.28,-0.2 -0.18,-0.02 -0.16,0.11 -0.61,0.23 -0.11,0.18 -0.26,0.23 -0.27,0.14 -0.41,0.15 -0.22,0.04 -0.1,0.11 -0.06,0.26 -0.03,0.25 -0.04,0.11 -0.5,0.23 -0.09,0.16 -0.01,0.13 0.04,0.13"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S99-7"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S99P1-2"
+         d="m 262.83,277.99 0.03,0.09 0.33,0.28 0.09,0.21 0.24,0.2 -0.22,0.24 0.02,0.11 0.07,0.12 0.27,0.08 0.14,0.17 -0.01,0.24 0.04,0.41 -0.6,0.37 -0.19,0.43 -0.02,0.09"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S109-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S109P1"
+         d="m 276.34,297.04 0.09,0.05 0.33,0.01 0.36,0.03 0.23,0.25 0.23,0.09 0.32,0.03 0.22,-0.04 0.1,-0.1 0.12,-0.3 0.23,-0.37 0.36,-0.19 0.62,-0.04 0.31,-0.07 0.32,-0.01 0.24,0.06 0.25,-0.01 0.63,-0.27 0.65,-0.22 0.09,0.03 0.02,0.07 -0.12,0.16 -0.11,0.21 0.09,0.24 0.38,0.46 0.21,0.36 0.2,0.27 0.3,0.14 0.4,0.07 0.33,0.03 0.35,0.09 1.21,0.21 0.6,0.05 0.46,-0.01 0.7,0.14"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S110-5"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S110P1"
+         d="m 287.06,298.46 -0.06,0.28 -0.14,0.07 -0.23,0.17 -0.28,0.23 -0.25,0.26 -0.06,0.27 0.08,0.17 0.07,0.06 0.1,-0.05 0.14,0.02 0.18,0.09 0.29,0.08 0.01,0.09 -0.05,0.12 -0.22,0.22 -0.2,0.25 -0.01,0.14 0.02,0.11 0.08,0.06 0.3,-0.04 0.05,0.08 -0.12,0.62 0.05,0.1 0.27,0.09 0.2,0.13 0.38,0.37 0.16,0.31 -0.1,0.11 -0.23,0.06 -0.19,-0.02"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S113-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S113P1"
+         d="m 244.58,315.43 -0.23,-0.48 -0.19,-0.12 -0.29,-0.05 -0.32,-0.18 -0.33,-0.22 -0.82,-0.39 -0.24,-0.07 -0.09,0.03 -0.09,0.16 -0.09,0.47 -0.04,0.05 -0.4,-0.04 -0.48,-0.14 -0.22,0.01 -0.2,-0.03 -0.18,-0.15 -0.85,0.02 -0.14,-0.09 -0.17,-0.24 -0.21,-0.21 -0.16,-0.11 -0.14,-0.12 -0.13,-0.04 -0.22,0.07 h -0.29 l -0.24,-0.05 -0.13,-0.01 -0.46,-0.6 -0.05,-0.15 -0.26,-0.08 -0.33,-0.06 -0.78,-0.47 -0.35,-0.24 -0.04,-0.12 0.01,-0.08 h -0.06 l -0.14,0.14 -0.08,0.11 -0.08,0.01 -0.12,-0.03 -0.1,-0.09 -0.06,-0.11 0.1,-0.14 0.16,-0.19 0.08,-0.22 0.02,-0.2 -0.19,-0.16 -0.3,-0.11 -0.22,-0.05 -0.28,-0.17 -0.12,-0.1 -0.1,-0.25 0.02,-0.16"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S114-6"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S114P1"
+         d="m 244.58,315.43 0.12,-0.11 0.15,-0.08 0.23,0.06 0.48,0.21 0.09,0.14 v 0.1 l -0.11,0.13 -0.04,0.1"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S115-2"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S115P1"
+         d="m 245.5,315.98 0.51,0.28 0.23,0.18 0.07,0.17 0.1,0.17 0.16,0.04 0.25,-0.12 0.37,-0.13 0.6,0.22 0.66,0.28 0.29,0.06 0.02,-0.1 0.07,-0.14 0.11,-0.06 0.17,-0.01 0.24,-0.05 0.28,-0.1 0.28,-0.02 0.28,0.12 0.35,0.11 0.2,0.02"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S116-9"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S116P1"
+         d="m 244.58,315.43 -0.08,0.22 0.02,0.08 0.01,0.16 -0.02,0.17 0.06,0.12 0.13,0.03 0.17,-0.01 0.19,-0.04 0.34,-0.16 0.1,-0.02"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S119-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S119P1"
+         d="m 314.28,322.97 0.48,-0.1 0.16,-0.06 0.63,-0.11 0.26,-0.23 0.2,-0.01 0.44,0.1 0.16,-0.16 0.51,-0.33 0.44,-0.82 0.21,-0.15 0.51,-0.12 0.15,-0.11 0.19,-0.02 0.59,0.06 0.34,-0.03 0.37,-0.17 0.4,-0.25 0.02,-0.65 0.09,-0.1 0.26,-0.07 0.2,-0.03"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S120-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S120P1"
+         d="m 315.55,316.11 -0.58,0.22 -0.18,0.18 -0.09,0.29 -0.02,0.14 -0.1,0.02 -0.2,-0.11 -0.25,-0.18 -0.28,0.06 -0.93,0.61 -0.07,0.26 0.04,0.54 -0.05,0.15 -0.09,0.11 h -0.42 l -0.04,-0.03"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S121-4"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S121P1"
+         d="m 318.23,315.37 -0.09,-0.03 -0.16,-0.11 -0.14,-0.01 -0.3,0.2 -0.32,0.15 -0.27,-0.03 -0.25,0.03 -0.17,0.09 -0.13,0.05 -0.24,0.21 -0.41,0.18 -0.2,0.01"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S122-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S122P1"
+         d="m 318.23,315.37 0.26,-0.12 0.07,-0.15 0.21,-0.43 v -0.2 l -0.04,-0.1 -0.21,-0.15 -0.18,-0.39 0.04,-0.39 -0.02,-0.19 -0.12,-0.18 0.06,-0.25 0.18,-0.17 0.11,-0.05 0.51,-0.12 0.25,-0.53 0.17,-0.18 0.16,-0.31 0.08,-0.11 0.06,-0.23 -0.01,-0.22 -0.44,-0.23 -0.17,-0.21 -0.22,-0.22 -0.26,-0.13 -0.53,-0.22 -0.24,-0.27 -0.14,-0.38 -0.17,-0.27 -0.17,-0.17 -0.05,-0.16 -0.09,-0.18 -0.07,-0.38 0.04,-0.52 0.05,-0.19 0.16,-0.08 0.39,-0.34 -0.03,-0.35 0.04,-0.23 0.12,-0.14 0.12,-0.11"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S123-9"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S123P1"
+         d="m 320.89,319.61 0.04,-0.1 -0.1,-1.18 0.11,-0.56 -0.02,-0.1 -0.05,-0.08 -0.18,-0.05 -0.17,-0.26 -0.36,-0.7 -0.16,-0.13 -0.42,-0.09 -0.38,-0.15 -0.33,-0.24 -0.64,-0.6"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S124-0"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S124P1-2"
+         d="m 304.46,316.06 0.03,0.17 0.15,0.19 0.16,0.21"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S125-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S125P1"
+         d="m 304.46,316.06 -0.32,-0.09 -0.16,-0.05 -0.67,-0.36 -0.3,-0.21 -0.46,-0.27 -0.29,-0.15 -0.16,-0.26 -0.22,-0.04 -0.25,0.11"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S127-9"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S127P1"
+         d="m 310.98,313.98 0.41,-0.19 0.05,-0.11 -0.12,-0.2 0.04,-0.15 0.47,-0.45 0.06,-0.18 0.02,-0.15 -0.09,-0.13 -0.12,-0.21 0.03,-0.1 0.25,-0.17 0.2,-0.18 0.13,-0.03 0.09,0.09 0.01,0.12 0.1,0.18 0.17,0.08 0.29,0.13 0.32,0.07 0.27,0.19 0.38,0.36 0.08,0.2 0.32,0.13 0.3,0.17 0.01,0.38 0.98,0.18 0.21,-0.03 0.11,0.04 0.01,0.09 -0.04,0.27 -0.28,0.87 -0.01,0.17 -0.25,0.22 -0.03,0.11 0.11,0.21 0.1,0.15"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S128-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S128P1"
+         d="m 310.98,313.98 -0.43,0.2 -0.06,0.22 -0.22,0.01 -0.26,0.03 -0.07,0.14 0.15,0.2 0.11,0.25 -0.03,0.36 -0.01,0.05"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S129-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S129P1"
+         d="m 306.63,311.16 v 0.06 l 0.03,0.17 0.1,0.15 0.29,0.14 0.44,0.29 0.54,0.56 0.23,0.15 0.2,0.02 0.41,0.21 0.28,0.03 0.3,0.03 0.84,0.43 0.36,0.11 0.28,0.17 0.04,0.19 0.01,0.11"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S138-2"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S138P1"
+         d="m 293.79,190.84 0.5,0.19 0.03,0.05 0.03,0.14 0.04,0.13 0.52,0.29 0.16,0.17 0.33,0.24 0.1,0.14 0.3,0.14 0.22,0.17 0.25,0.12 0.3,0.2 0.38,0.14 0.3,0.01 0.79,0.21 0.15,0.09 0.25,0.19 0.27,0.23 0.27,0.52 0.24,-0.02 0.11,0.18 0.28,0.29 0.35,0.23 0.01,0.09 -0.17,0.31 0.05,0.36 0.12,0.44 0.16,0.36 0.01,0.11 -0.03,0.14 -0.02,0.21 0.01,0.18 0.03,0.08 0.03,0.05 0.13,-0.02 h 0.23 l 0.14,0.05 0.17,0.42 v 0.08 l -0.15,0.23 -0.02,0.16 0.05,0.23 0.08,0.24 0.13,0.27 0.22,0.26 0.27,0.28 0.19,0.23 0.1,0.16 0.05,0.13 -0.05,0.17 -0.01,0.33 0.06,0.36 0.02,0.24 -0.11,0.35 -0.1,0.14 v 0.18 l 0.05,0.28 0.11,0.34 0.06,0.24 0.08,0.16 0.08,0.1 0.34,0.14 0.25,0.37 0.18,0.3 0.39,0.8 v 0.22 l 0.1,0.17 0.13,0.29 0.04,0.21 -0.03,0.49"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S139-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S139P1-4"
+         d="m 257.74,274.56 -0.06,0.18 -0.13,0.19 -0.42,0.25 -0.43,0.15 -0.21,-0.04 -0.14,-0.12 -0.07,-0.11 -0.21,-0.12 -0.3,-0.07 -0.19,0.09 -0.15,0.08 -0.12,-0.02 -0.08,-0.1 -0.05,-0.14 -0.05,-0.42"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S140-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S140P1-0"
+         d="m 262.83,277.99 -0.6,-0.05 -0.15,-0.04 -0.16,-0.08 -0.06,-0.15 -0.08,-0.19 0.03,-0.11 0.29,-0.3 0.05,-0.08 -0.03,-0.05 0.04,-0.13 0.24,-0.46 0.03,-0.18 -0.08,-0.14 -0.13,-0.09 -0.42,-0.17 -0.19,-0.21 -0.08,-0.17 -0.09,-0.06 -0.15,0.05 -0.36,0.04 -0.28,-0.11 -0.32,-0.35 -0.06,-0.3 -0.02,-0.22 -0.08,-0.08 -0.12,0.1 -0.16,0.17 h -0.29 l -0.08,-0.05 v -0.1 l -0.01,-0.1 -0.07,-0.12 -0.08,-0.07 -0.39,0.3 -0.14,-0.01 -0.16,-0.14 -0.07,-0.13 -0.19,0.05 -0.18,0.14 0.03,0.3 -0.09,0.04 -0.21,-0.04 -0.22,-0.14"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S141-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S141P1"
+         d="m 263.54,284.27 0.12,-0.02 0.23,0.09 0.23,0.24 0.08,0.24 0.02,0.13 0.1,0.14 0.37,0.65 0.12,0.04 0.15,-0.09 0.09,-0.13 0.14,-0.02 0.2,0.07 0.14,0.08 0.05,0.27 0.04,0.06 0.09,-0.06 h 0.17 l 0.25,0.07 0.36,-0.06 0.29,-0.1 0.15,0.01 0.22,0.33 0.26,0.13 0.59,0.11 0.63,0.18 0.25,0.12 0.17,0.07 v 0.42 l -0.05,0.06 -0.67,0.81 -0.28,0.29 -0.15,0.43 -0.11,0.65 -0.22,0.61 -0.3,0.58 -0.12,0.44 0.06,0.3 -0.06,0.46 -0.2,0.63 -0.05,0.48 0.1,0.32 0.16,0.07"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S142-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S142P1"
+         d="m 273.33,293.86 -0.56,-0.36 -0.53,-0.35 -0.18,-0.01 -0.8,0.06 -0.02,-0.04 -0.13,-0.19 -0.13,-0.07 -0.07,0.03 -0.05,0.06 -0.09,-0.02 -0.35,-0.32 -0.14,-0.05 -0.2,0.04 -0.25,0.16 -0.11,0.21 0.03,0.12 0.12,0.05 0.33,-0.02 0.05,0.03 0.01,0.07 -0.04,0.07 -0.27,0.04 -0.08,0.08 -0.07,0.02 -0.05,0.01 -0.28,-0.09 -0.42,-0.02 -0.34,0.14 -0.54,0.04 -0.74,-0.06 -0.27,-0.12"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S143-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S143P1-6"
+         d="m 273.33,295.08 0.27,-0.58 0.06,-0.36 -0.23,-0.21 -0.1,-0.07"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S144-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S144P1"
+         d="m 273.49,296.1 -0.26,-0.03 -0.04,0.01 -0.03,-0.17 0.02,-0.36 0.15,-0.47"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S145-5"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S145P1"
+         d="m 264.89,301.26 -0.05,-0.16 -0.16,-0.29 -0.18,-0.17 -0.12,-0.19 -0.16,-0.2 -0.11,-0.17 0.17,-0.52 -0.09,-0.19 -0.05,-0.27 0.04,-0.18 -0.06,-0.04 -0.59,-0.14 -0.49,0.01 -0.36,0.15 -0.31,0.28 -0.04,0.06 0.02,0.05 0.13,0.28 -0.26,0.27 -0.39,0.2 h -0.26 l -0.12,-0.05 0.02,-0.3 0.22,-0.1 0.21,-0.18 0.08,-0.28 0.04,-0.19 -0.2,-0.25 0.04,-0.14 0.14,-0.27 0.09,-0.24 0.11,-0.2 0.43,-0.32 0.43,-0.33 0.08,-0.36 0.05,-0.45 0.07,-0.1 0.56,-0.24 0.14,-0.1 0.08,-0.15 0.46,-0.48 0.45,-0.47 0.09,-0.16 0.08,-0.1 v -0.08 l -0.05,-0.07 -0.2,-0.05 -0.06,-0.16 0.23,-0.27 0.28,-0.16 0.27,0.01 0.11,0.09 -0.01,0.09 0.11,0.1 0.2,0.05 0.25,-0.03 0.25,-0.09 0.17,-0.25 0.09,-0.18 0.4,-0.21"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S146-9"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S146P1-1"
+         d="m 209.13,334.62 v -1.19 l -0.02,-0.46 0.03,-0.29 0.35,-0.59 0.28,-0.21 0.42,-0.47 0.48,-0.36 h 0.43 l 0.19,-0.03 0.22,-0.31 0.14,-0.28 -0.06,-0.05 -0.48,-0.05 -0.6,-1.48 0.07,-0.19 0.16,-0.28 0.15,-0.36 0.08,-0.29 0.27,-0.2 0.39,-0.18 0.35,-0.29 0.21,-0.33 0.1,-0.32 -0.12,-0.27 -0.43,-0.24 -0.28,-1.05 0.01,-0.61 -0.08,-0.08 -0.24,-0.34 -0.18,-0.57 -0.02,-0.08 0.3,-0.02 1.19,0.29 0.27,-0.05 0.04,-0.03 0.3,-0.33 0.35,-0.58 0.13,-0.38 -0.04,-0.18 -0.31,-0.49 0.01,-0.12 0.1,-0.17 0.27,-0.14 0.36,-0.15 0.21,-0.16 -0.01,-0.16 -0.06,-0.18 0.02,-0.15 0.09,-0.17 0.15,-0.62 0.07,-0.16 0.05,-0.58 0.02,-0.48 -0.12,-0.67 0.07,-0.12 0.14,-0.08 0.41,-0.12 0.4,-0.42 0.51,-0.31 0.63,-0.2 0.46,-0.28 0.21,-0.24 0.13,-0.05 -0.01,-0.14 -0.04,-0.21 -0.18,-0.24 -0.27,-0.17 -0.32,-0.07 -0.19,-0.09 -0.02,-0.16 0.1,-0.39 0.06,-0.39 -0.02,-0.2 -0.12,-0.17 -0.3,-0.03 -0.23,-0.17 -0.19,-0.08 -0.12,0.06 -0.56,-0.16 -0.22,-0.12 -0.15,-0.12 -0.11,0.02 -0.08,0.06 -0.03,0.12 -0.07,0.15 -0.23,0.09 -0.49,0.03 -0.37,-0.11 -0.32,-0.19 -0.09,-0.1 -0.15,-0.11 -0.71,-0.09 -0.07,-0.08 -0.27,0.08 -0.39,0.08 -0.2,-0.04 -0.06,-0.05 -0.01,-0.09 -0.09,-0.31 0.07,-0.13 0.38,-0.35 -0.01,-0.11 -0.09,-0.16 -0.06,-0.23 v -0.1 l -0.18,-0.07 -0.21,0.05 -0.78,0.02 -0.19,0.03 -0.36,0.12 -0.39,0.22"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S147-7"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S147P1"
+         d="m 286.98,287.69 -0.04,0.1 v 0.29 l 0.02,0.31 -0.04,0.17 -0.19,0.22 -0.09,0.05 -0.06,0.05 -0.61,-0.26 -0.04,0.05 -0.04,0.04 -0.13,0.82 -0.1,0.17 -0.16,0.15 -0.34,0.15 -0.24,0.07 -0.18,0.07 -0.58,0.37 -0.26,0.21 -0.16,0.26 v 0.15 l 0.3,0.43 0.35,0.44 0.01,0.4 -0.13,0.3 -0.04,0.11 0.1,0.04 0.19,0.01 0.16,0.05 0.07,0.21 -0.01,0.36 -0.04,0.34 -0.05,0.15 -0.15,0.01 -0.29,-0.13 -0.23,-0.17 -0.09,-0.1 -0.01,-0.13 0.04,-0.08 -0.08,-0.15 -0.28,-0.13 -0.3,0.07 -0.21,0.1 h -0.14 l -0.16,-0.14 -0.24,-0.1 -0.3,-0.06 -0.2,-0.07 -0.04,0.05 0.03,0.3 -0.05,0.13 -1.52,0.2 -0.46,0.17 -0.33,0.21 -0.25,0.1 -0.06,0.13 -0.24,0.17 -0.28,0.05 -0.07,-0.05 -0.18,0.08 -0.3,0.08 -0.2,-0.03 -0.1,-0.13 -0.19,-0.21 -0.07,-0.14 v -0.1 l -0.42,-0.01 -0.27,-0.11 -0.57,0.02 -0.14,-0.05 -0.03,0.06 -0.09,0.59 -0.11,0.24 -0.18,0.25 -0.24,0.14 -0.19,0.03 0.01,-0.18 0.05,-0.23 -0.13,-0.05 -0.21,-0.02 -0.09,-0.07 0.02,-0.17 -0.04,-0.1 -0.09,-0.12 -0.2,-0.15 -0.43,-0.23 -0.29,-0.11 -0.11,0.12 -0.21,0.11 -0.33,-0.04 -0.08,0.04"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S148-4"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S148P1-4"
+         d="m 294.82,296.35 -0.18,0.11 -0.18,0.22 0.05,0.45 -0.03,0.05 -0.04,0.09 -0.64,-0.11 h -0.02 l -0.41,0.09 -0.27,0.23 -0.35,0.14 -0.73,-0.01 -0.71,0.12 -0.16,0.07 -0.18,0.05 -0.17,0.13 -0.09,0.18 -0.16,0.23 -0.25,0.18 -0.26,0.15 -0.06,0.11 -0.09,0.07 -0.16,-0.07 -0.12,0.01 -0.16,-0.05 -0.5,-0.04 -0.56,-0.07 -0.27,-0.08 -0.3,-0.07 -0.33,-0.04 -0.29,-0.01 -0.14,-0.02"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S149-6"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S149P1-3"
+         d="m 304.46,316.06 0.06,-0.03 0.09,-0.08 0.17,-0.21 0.03,-0.11 -0.02,-0.15 -0.32,-0.46 -0.07,-0.31 -0.1,-0.58 0.05,-0.15 0.09,-0.08 0.46,-0.12 -0.05,-0.46 0.02,-0.14 0.07,-0.2 0.04,-0.18 0.24,-0.28 0.32,-0.34 0.15,-0.02 0.14,0.02 0.18,0.24 0.16,-0.05 0.01,-0.31 -0.26,-0.38 -0.14,-0.24 0.02,-0.15 0.07,-0.08 0.19,0.02 0.19,0.05 0.1,-0.06 0.18,-0.06 h 0.1"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S150-7"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S150P1-5"
+         d="m 306.63,311.16 0.18,-0.27 0.16,-0.05 0.2,-0.03 0.15,0.1 0.18,0.01 0.08,-0.17 0.03,-0.23 -0.06,-0.29 -0.49,-0.61 -0.42,-0.42 -0.05,-0.1 0.07,-0.1 0.12,-0.06 0.14,0.02 0.36,-0.01 0.34,-0.08 0.1,-0.13 -0.02,-0.15 -0.14,-0.13 -0.44,-0.34 -0.34,-0.29 -0.4,-0.22 -0.28,-0.07 -0.09,-0.12 -0.05,-0.14 v -0.26 l -0.02,-0.33 0.05,-0.22 0.2,-0.41 0.18,-0.45 0.1,-0.41 0.04,-0.38 -0.04,-0.1 -0.13,-0.07 -0.26,-0.04 -0.35,0.11 -0.29,0.17 -0.11,0.02 -0.22,0.05 -0.36,-0.05 -0.18,-0.13 -0.05,-0.15 -0.01,-0.14 -0.14,-0.23 -0.3,-0.21 -0.59,0.03 -0.23,-0.05 -0.23,-0.07 -0.25,-0.04 -0.22,0.03 -0.27,0.1 -0.48,-0.06 -0.15,0.16 -0.23,0.19 -0.21,0.01 -0.44,-0.34 -0.13,-0.01 -0.34,0.23 -0.15,0.02 -0.12,-0.05 -0.5,-0.1 -0.22,-0.01 -0.15,0.09 -0.3,-0.05 -0.73,-0.44 -0.4,0.42 -0.88,-0.02 -0.24,0.28 -0.26,0.52 -0.23,0.25 -0.22,-0.07 -0.26,-0.2 -0.47,-0.52 -0.23,-0.09 h -0.25 l -0.22,0.08 -0.11,0.12 -0.04,0.82 -0.03,0.73 0.03,0.43 0.51,0.36 0.62,0.65 0.19,0.06 0.11,0.22 0.17,0.57 0.2,0.64 0.32,0.4 0.29,0.29 0.35,0.25 0.43,0.39 0.37,0.43 0.11,0.17 0.69,0.56 0.68,0.57 0.59,0.17 0.09,0.11 0.05,0.48 0.08,0.17 0.42,0.47 0.83,0.67 0.11,0.16 0.03,0.12 -0.04,0.11 -0.19,0.12"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S151-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S151P1-9"
+         d="m 305.33,304.91 -0.06,-0.16 0.04,-0.08 h 0.09 l 0.09,0.02 0.07,-0.08 0.03,-0.23 -0.21,-0.76 0.22,-0.1 -0.01,-0.11 0.01,-0.1 0.24,0.11 0.33,-0.04 0.28,-0.06 0.03,-0.08 -0.01,-0.11 -0.07,-0.08 -0.11,-0.06 -0.08,-0.1 -0.2,-0.02 -0.63,-0.21 -0.33,-0.26 -0.02,-0.32 0.06,-0.18 0.1,-0.08 -0.04,-0.05 -0.35,-0.11 -0.14,-0.19 0.07,-0.27 -0.23,-0.51 -0.22,-0.3 0.17,-0.16 v -0.21 -0.11"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S152-0"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S152P1-4"
+         d="m 296.93,287.84 0.07,-0.38 0.21,-0.52 0.2,-0.31 0.16,-0.11 0.34,0.06 0.59,0.01 0.45,-0.11 0.39,-0.26 0.21,-0.22 0.17,-0.22 0.05,-0.14 0.08,-0.07 0.34,-0.15 0.09,-0.15 0.02,-0.26 v -0.29 l 0.05,-0.22 0.07,-0.17 0.6,-0.44 0.04,-0.14 0.09,-0.14 0.17,-0.17 0.16,-0.22 0.17,-0.15 0.25,-0.02 0.22,-0.05 0.17,-0.09 0.08,-0.02"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S153-4"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S153P1-4"
+         d="m 297.79,290.61 -0.21,-0.14 -0.07,-0.2 -0.35,-0.52 -0.42,-0.88 -0.03,-0.25 0.11,-0.31 0.1,-0.24 0.01,-0.18 v -0.05"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S154-7"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S154P1-7"
+         d="m 297.79,290.61 0.09,-0.03 h 0.33 l 0.08,0.05 0.05,0.01 0.57,0.44 0.53,0.32 0.42,0.15 0.6,-0.04 0.63,-0.05 1.05,-0.18 0.79,-0.13 0.04,-0.1 0.09,-0.24 -0.11,-0.17 -0.02,-0.23 0.1,-0.3 0.36,-0.29 1.11,-0.23 0.61,-0.26 0.07,-0.26 0.18,-0.27 0.19,-0.07 0.28,0.08 0.34,0.17 0.3,0.08 0.15,-0.1 0.52,-0.43 0.6,-0.43 0.32,-1.01 0.03,-0.16 0.46,-0.17 0.71,-0.08 0.37,0.07 0.28,0.02 0.4,-0.08 0.55,-0.29 0.22,-0.02 0.18,0.12 0.2,0.09 0.15,0.14 0.12,0.2 0.07,0.07 0.09,0.1 0.17,0.12 0.15,0.02 1.04,-0.43 0.05,-0.07"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S155-0"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S155P1-2"
+         d="m 289.54,277.51 0.01,-0.06 0.27,-0.68 0.12,-0.42 0.11,-0.76 -0.23,-0.59 -0.07,-0.27 -0.09,-0.13 -0.56,-0.26 -0.05,-0.1 0.06,-0.4 -0.05,-0.16 -0.14,-0.17 -0.19,-0.34 -0.08,-0.29 0.2,-0.36 0.04,-0.26 0.07,-0.35 0.06,-0.2 0.01,-0.05 -0.15,-0.13 -0.05,-0.19 0.02,-0.27 -0.08,-0.2 -0.2,-0.12 -0.13,-0.17 -0.07,-0.22 0.02,-0.34 0.12,-0.48 -0.34,-0.54 -0.79,-0.62 -0.38,-0.44 0.02,-0.26 0.14,-0.25 0.28,-0.22 0.19,-0.39 0.1,-0.46 v -0.08 l -0.01,-0.32 -0.4,-1.29 -0.07,-0.33 -0.06,-0.39 -0.25,-1 0.03,-0.15"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S156-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S156P1"
+         d="m 315.98,288.53 -0.08,-0.06 -0.06,-0.16 0.01,-0.16 -0.09,-0.14 -0.19,-0.13 -0.05,-0.07 -0.21,0.05 -0.06,0.03 h -0.02 l -0.32,-0.09 -0.25,-0.31 -0.33,-0.13 -0.24,-0.02 -0.12,-0.13 -0.1,-0.18 -0.09,-0.13 -0.01,-0.02 -0.09,-0.21 -0.07,-0.01 h -0.02 l -0.29,0.08"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S157-2"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S157P1-1"
+         d="m 338.17,304.31 -0.53,0.14 -0.17,0.02 h -0.53 l -0.62,-0.09 -0.43,-0.37 -0.28,-0.26 -0.45,0.26 -0.1,-0.02 -0.16,-0.12 -0.39,-0.02 -0.44,0.11 -1.13,-0.35 -0.13,-0.08 -0.77,0.28 -1.13,0.56 -0.84,0.56 -0.82,0.84 -0.29,0.57 -0.39,0.35 -0.6,0.32 -1.15,0.17 -1.22,-0.01 -1.32,-0.01 -0.66,0.27 -0.95,0.07 -1.45,-0.06 -1.06,0.09 -1,0.37 -0.2,-0.11 -0.06,-0.16 v -0.24 l 0.12,-0.21 0.23,-0.18 0.11,-0.16 -0.01,-0.15 -0.31,-0.19 -0.63,-0.22 -0.26,-0.16"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S158-2"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S158P1-3"
+         d="m 308.76,298.52 0.22,0.25 0.24,0.33 0.28,0.13 0.33,0.15 0.18,0.12 0.29,0.4 0.22,0.18 0.06,-0.02 0.05,-0.06 0.04,-0.05 0.05,0.03 0.02,0.13 0.05,0.28 v 0.31 l 0.1,0.28 0.01,0.09 -0.03,0.09 0.01,0.08 0.08,0.06 0.28,0.16 0.27,0.26 0.3,0.17 0.27,0.09 0.16,-0.01 0.29,0.2 0.54,0.09 0.18,0.04 0.12,0.08 0.1,0.1 0.02,0.12 -0.07,0.07 -0.09,0.18 -0.02,0.21 -0.07,0.06 -0.08,0.02 -0.06,0.07 0.03,0.08 0.08,0.07 0.12,0.06 0.21,0.04 0.22,0.08 0.01,0.09 -0.03,0.1 -0.25,0.07 -0.19,0.05 -0.09,0.05 0.03,0.16"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S159-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S159P1-7"
+         d="m 320.89,319.61 0.39,-0.02 0.46,-0.06 0.26,-0.35 0.46,-0.1 0.21,-0.08 0.36,-0.01 0.35,-0.07 0.43,-0.2 0.38,-0.28 0.33,-0.04 0.13,-0.06 0.06,-0.06 0.04,-0.28 0.61,-0.13 0.21,-0.02 0.34,-0.05 0.33,-0.22 0.1,-0.01 0.25,0.36 0.11,0.1 0.21,0.07 0.48,0.21 0.06,-0.09 0.16,-0.14 0.54,0.04 0.53,0.13 0.46,0.25 0.44,-0.19 0.48,-0.27 0.32,-0.12 0.35,-0.1 0.2,-0.11 0.5,-0.02 0.46,-0.29 0.21,-0.21 0.03,-0.25 -0.12,-0.39 -0.18,-0.38 -0.15,-0.12 -0.06,-0.14 0.04,-0.16 0.05,-0.12 0.31,-0.15 0.44,0.03 0.33,0.03 0.2,0.11 0.14,0.12 0.2,0.08 h 0.13 l 0.17,0.39 0.15,0.5 -0.03,0.24 -0.22,0.1 -0.62,0.64 0.06,0.45 0.05,0.21 0.04,0.15 0.1,0.11 0.04,0.18 -0.05,0.22 -0.25,0.4 -0.17,0.31 -0.18,0.41 -0.13,0.07 -0.1,0.09"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S160-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S160P1-4"
+         d="m 310.16,315.44 -0.07,-0.01 -0.35,0.25 -0.26,0.14 -0.25,0.08 -0.13,-0.09 -0.07,-0.12 -0.03,-0.39 -0.06,-0.12 -0.09,-0.06 -0.16,0.12 -0.17,0.32 -0.15,0.37 -0.24,0.39 -0.19,0.38 -0.2,0.47 -0.13,0.38 0.19,0.18 0.14,0.27 -0.01,0.22 0.05,0.12 -0.02,0.37 0.01,0.24"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S161-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S161P1-2"
+         d="m 327.32,284.76 0.29,-0.09 0.24,-0.01 0.39,0.13 0.3,0.2 0.14,0.19 0.28,0.24 0.31,0.37 0.36,0.49 0.11,0.27 0.16,0.27 0.26,0.33 0.44,0.32 0.07,0.06 0.22,0.25 0.44,0.56 0.32,0.19 0.28,0.22 0.17,0.25 0.22,0.21 0.45,0.24 0.37,0.23 0.44,0.81 0.26,0.36 0.18,0.27 0.09,0.63 0.13,0.25 -0.03,0.52 -0.04,1.04 0.11,0.78 0.14,0.41 0.07,0.27 0.1,0.15 0.15,0.34 0.08,0.3 -0.08,0.11 -0.11,0.11 -0.04,0.07 0.15,0.11 0.22,0.22 0.23,0.25"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S162-1"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S162P1-4"
+         d="m 315.98,288.53 0.1,-0.1 0.41,-0.28 0.08,-0.22 0.12,-0.21 0.2,-0.02 0.72,0.33 0.68,-0.15 0.13,-0.01 0.05,0.01 0.09,0.02 0.95,0.05 0.14,-0.05 0.03,-0.03 0.41,0.12 0.32,-0.09 0.28,-0.19 0.32,-0.1 0.31,0.02 0.27,0.21 0.68,0.43 0.22,0.17 0.26,-0.09 0.28,-0.16 0.22,-0.42 0.84,-0.6 0.68,-0.25 0.65,-0.31 0.76,-0.29 0.16,-0.39 0.08,-0.25 v -0.45 l 0.39,-0.21 0.38,-0.18 0.13,-0.08"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S163-3"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S163P1-0"
+         d="m 314.07,283.38 0.12,-0.04 0.4,0.11 0.35,0.03 0.08,-0.1 0.02,-0.12 -0.03,-0.08 -0.31,-0.22 -0.19,-0.13 -0.03,-0.1 0.02,-0.24 -0.01,-0.27 -0.08,-0.27 -0.28,-0.58 -0.08,-0.26 0.12,-0.34 0.44,-0.86 0.14,-0.31 0.19,-0.39 0.55,-0.94 0.35,-0.56 0.25,-0.31 0.34,-0.54 0.15,-0.27 0.75,-0.3 0.05,-0.24 0.1,-0.27 0.09,-0.12 -0.06,-0.41 -0.24,-0.48 -0.14,-0.15 -0.11,-0.11 0.03,-0.12 0.08,-0.05 0.1,-0.03 0.11,-0.15 -0.05,-0.12 -0.38,-0.26 -0.19,-0.22 -0.33,-0.59 -0.57,-0.57 -0.17,-0.19 -0.06,-0.2 0.03,-0.21 -0.11,-0.24 -0.21,-0.3 -0.28,-0.44 -0.06,-0.44 0.06,-0.26 0.09,-0.25 -0.12,-0.32 0.05,-0.47 -0.06,-0.31 -0.08,-0.13 -0.13,-0.14 -0.31,-0.13 -0.14,-0.11 -0.41,-0.12 -0.42,-0.16 -0.08,-0.13 v -0.1 l 0.04,-0.16 0.2,-0.48 0.24,-0.47 0.16,-0.2 0.94,-0.72 0.13,-0.21 -0.02,-0.33 -0.04,-0.23 -0.1,-0.4 -0.17,-0.56 -0.16,-0.39 -0.33,-0.71 -0.82,-1.45 -0.61,-1.55"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S164-8"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S164P1-9"
+         d="m 304.76,254.65 0.49,0.05 0.6,-0.1 0.24,-0.09 0.18,0.18 0.32,0.14 0.37,0.11 0.56,0.2 0.57,0.09 0.18,-0.01 0.55,-0.11 0.6,-0.07 0.24,0.39 0.33,0.15 0.28,0.23 0.05,0.15 -0.16,1.03 -0.01,0.34 0.04,0.33 0.2,0.39 0.15,0.21"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S165-7"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S165P1-2"
+         d="m 337.76,262.97 -0.05,-0.11 -0.32,-0.37 -0.17,-0.16 -0.16,-0.07 -0.1,-0.1 -0.16,-0.53 -0.12,-0.49 0.06,-0.09 -0.36,-0.33 -0.11,-0.29 0.08,-0.19 -0.04,-0.13 -0.13,-0.15 -0.34,-0.22 -0.34,-0.26 -0.23,-0.21 -0.14,-0.1 0.06,-0.24 0.06,-0.4 v -0.23 l 0.06,-0.08 0.39,-0.15 0.28,-0.07 0.24,0.01 0.13,0.15 0.25,0.12 0.57,-0.09 0.23,-0.08 0.24,-0.26 0.35,-0.52 0.03,-0.31 0.23,-0.28 0.15,-0.14 0.15,-0.08 -0.03,-0.17 -0.08,-0.21 -0.1,-0.12 -0.72,-0.27 -0.12,-0.12 -0.1,-0.16 0.02,-0.19 -0.06,-0.18 -0.78,-0.2 -0.58,0.1 -0.44,0.16 -0.2,-0.03 0.01,-0.23 v -0.4 l -0.06,-0.31 -0.07,-0.13 -0.13,-0.09 -0.51,-0.12 -0.7,-0.21 -0.41,-0.36 -0.28,-0.42 -0.24,-0.24 -0.34,-0.09 -0.02,-0.12 0.06,-0.49 -0.03,-0.06 -0.11,-0.09 -0.42,-0.11 -0.6,-0.26 -0.05,-0.1 -0.04,-0.26 -0.01,-0.27 0.06,-0.15 0.14,-0.58 -0.05,-0.18 -0.12,-0.21 -0.33,-0.33 -0.24,-0.21 -0.04,-0.13 -0.01,-0.11 0.06,-0.17 0.05,-0.2 -0.15,-0.59 -0.07,-0.21 -0.1,-0.1 -0.08,-0.03 -0.13,0.07 -0.23,-0.04 -0.2,-0.11 -0.11,-0.02 -0.14,-0.13 -0.38,-0.24 -0.07,-0.07 -0.64,-0.11 -0.48,0.18 -0.28,0.03 -0.12,0.1 -0.1,0.21 -0.17,0.17 -0.15,0.05 -0.12,0.12 -0.29,0.41 -0.23,-0.14 -0.23,-0.24 -0.01,-0.24 v -0.23 l -0.04,-0.14 -0.09,-0.11 -0.27,-0.07 -0.56,-0.12 -0.15,0.03 -0.19,0.15 -0.31,0.38 -0.16,-0.03 -0.18,-0.18 -0.21,-0.24 -0.23,-0.09 -0.39,0.11 -0.04,0.02 -0.15,0.21 h -0.08 l -0.46,-0.31"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S166-7"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S166P1-4"
+         d="m 337.76,262.97 h 0.05 l 0.3,0.05 0.3,0.03 0.19,-0.05 0.21,-0.1 0.22,-0.22 0.13,-0.2 v -0.8 l 0.04,-0.12 0.11,-0.1 0.19,-0.07 0.42,0.02 0.47,-0.02 0.25,-0.1 0.55,-0.6 0.36,-0.18 0.47,-0.06 0.44,-0.14 0.31,-0.16 0.27,0.06 0.38,0.2 0.39,0.35 0.53,0.71 1.08,0.64 0.07,0.17 -0.02,0.14 -0.35,0.24 -0.3,0.17 0.04,0.16 0.14,0.14 0.23,0.2 0.12,0.3 0.09,0.3 0.15,0.24 0.16,0.06 0.06,0.12 -0.09,0.21 -0.01,0.11 0.08,0.04 0.71,-0.22 0.4,0.04 0.31,0.05 0.13,-0.04 0.27,-0.19 0.31,-0.18 0.2,-0.08 0.12,0.08 0.15,0.25 0.21,0.23 0.14,0.04 0.19,-0.09 0.12,-0.03 0.1,0.09 -0.02,0.18 0.08,0.16 0.15,0.17 0.27,0.44 0.14,0.11 0.13,0.16 0.07,0.21 -0.02,0.21 v 0.16 l 0.16,0.3 0.34,0.28 0.19,0.04 0.24,0.27 0.26,0.02 0.25,-0.39 0.21,-0.24 0.35,-0.04 0.32,-0.06 0.26,0.11 0.24,0.19 0.23,0.08 0.14,-0.14 0.39,-0.06 0.24,0.14 0.21,0.05 0.15,-0.25 0.1,-0.27 0.55,-0.45 0.37,-0.21 0.09,-0.09 0.18,-0.24 0.2,-0.19 0.23,-0.06 0.33,0.23 0.3,0.13 0.19,0.32 0.45,0.37 0.92,0.37 0.34,0.1 0.17,-0.11 0.07,-0.09 0.02,-0.09 -0.08,-0.33 0.04,-0.15 0.13,-0.06 0.68,0.18 0.29,-0.08 0.27,-0.1 0.47,0.16 0.49,0.11 0.3,-0.1 0.2,-0.21 0.14,-0.13 0.14,0.06 0.18,0.19 0.23,0.11 0.2,-0.03 0.26,-0.09 0.58,0.15 0.56,0.16 0.27,-0.09 0.18,-0.2 0.18,-0.11 0.17,0.02 0.1,0.14 -0.02,0.24 0.12,0.29 0.3,0.2 0.12,0.27 0.04,0.27 -0.01,0.27 -0.13,0.43 -0.12,0.39 -0.31,0.28 -0.15,0.22 0.14,0.19 0.21,0.14 0.37,0.03 0.39,-0.03 0.09,0.11 -0.02,0.09 -0.2,0.16 -0.33,0.07 -0.06,0.16 -0.06,0.25 0.04,0.38 0.05,0.35 0.37,-0.06 0.24,0.04 0.17,0.23 0.18,0.26 0.13,0.25 -0.07,0.18 0.05,0.13 0.08,0.04 0.15,-0.03 0.14,0.01 0.06,0.13 -0.09,0.4 0.03,0.68 0.02,0.36 0.14,0.34 -0.04,0.24 -0.21,0.11 -0.75,0.36 -0.66,0.26 -0.3,0.08 -0.46,0.15 -0.19,0.18 -0.09,0.67 -0.14,0.31 -0.3,0.35 -0.38,0.22 -0.15,0.32 0.05,0.39 0.11,0.32 0.02,0.17 -0.04,0.18 0.01,0.11 0.05,0.1 h 0.11 0.14 l 0.03,0.08 -0.01,0.12 -0.09,0.16 v 0.19 l 0.08,0.17 0.1,0.19"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S173-6"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S173P1-4"
+         d="m 372,332 0.27,-0.07 0.66,0.13 0.09,-0.04 0.04,-0.52 0.12,-0.22 0.31,-0.26 -0.11,-0.78 0.12,-0.2 0.17,-0.15 0.29,-0.13 0.25,-0.14 -0.02,-0.14 -0.61,-0.72 -0.02,-0.23 -0.08,-0.92 0.02,-0.38 0.07,-0.15 0.42,-0.12 0.61,-0.06 0.22,0.18 0.35,0.12 0.41,-0.18 0.49,-0.15 0.38,-0.13 0.25,-0.28 0.59,-0.55 0.31,-0.23 0.26,-0.25 0.83,-0.87 0.4,-0.12 0.28,-0.05 0.23,-0.01 0.55,0.14 0.48,0.16 0.29,-0.01 0.47,-0.2 0.71,-0.23 0.83,-0.36 0.46,-0.3 0.57,-0.43 0.99,-0.87 1.18,-1.44 0.72,-0.77 0.35,-0.21 0.47,-0.22 0.5,-0.11 0.56,-0.18 0.25,-0.12 0.55,-0.35 0.69,-0.51 0.42,-0.35 0.49,-0.49 0.23,-0.52 0.1,-0.09 0.17,-0.01 0.07,-0.01 0.22,0.14 0.33,0.45"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S214"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S214P1"
+         d="m 370.91,354.34 0.09,0.12 0.21,0.32 0.52,0.82 0.44,0.63 0.57,0.89 0.19,0.35 0.11,0.25 0.74,0.93 0.49,0.8 0.38,0.66 0.54,0.96 0.22,0.33"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S236"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S236P1"
+         d="m 319.3,241.01 -0.02,-0.11 -0.03,-0.3 v -0.26 l 0.16,-0.33 0.01,-0.19 0.02,-0.18 0.47,-0.32 0.04,-0.08 -0.02,-0.07 -0.04,-0.05 -0.13,-0.08 -0.16,-0.1 -0.16,-0.35 -0.33,-0.53 -0.27,-0.35 -0.09,-0.22 -0.02,-0.27 -0.01,-0.26 -0.06,-0.25 -0.61,-1.32 -0.05,-0.26 0.01,-0.26 0.06,-0.24 0.19,-0.33 0.19,-0.57 0.04,-0.7 0.01,-0.42 0.07,-0.11 0.18,-0.07 0.04,-0.14 0.01,-0.08 0.14,-0.1 0.03,-0.09 -0.07,-0.12 -0.22,-0.19 -0.17,-0.12"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S243"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S243P1"
+         d="m 310.54,258.26 -0.09,0.05 -1.55,0.21 -1.47,0.15 -1.37,0.13 -1.32,0.12 -1.26,0.1 -0.79,0.04 -0.78,0.04 -0.12,-0.05"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S272"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S272P1"
+         d="m 272.43,374.66 -0.25,-1.06 -0.2,-0.91 -0.17,-0.75 -0.29,-1.32 -0.25,-1.12 -0.25,-1.13 -0.22,-1.02 -0.23,-1.03 -0.1,-0.15 -0.7,-0.5 -0.64,-0.46 -0.68,-0.53 -0.72,-0.57 -0.1,-0.7 -0.35,-1.06 -0.39,-0.6 -0.14,-0.16 -0.79,-0.4 -0.45,-0.3 -0.12,-0.17 -0.08,-0.43 -0.3,-0.86 -0.35,-0.79 -0.12,-0.53 v -0.66 l 0.09,-0.47 0.17,-0.2 0.78,-0.57 0.38,-0.7 0.45,-0.25 0.38,-0.19 0.31,-0.23 0.29,-0.37 0.22,-0.39 0.04,-0.44 0.1,-0.69 0.15,-0.48 0.34,-0.54 -0.13,-0.45 -0.16,-0.48 0.07,-0.83 -0.03,-0.33 -0.13,-0.31 -0.13,-0.38 v -0.32 l 0.15,-0.83 0.12,-0.64 0.18,-0.82 -0.05,-0.24 -0.12,-0.17 -0.35,-0.2 v -0.11 l 0.09,-0.12 0.54,-0.39 0.3,-0.59 0.24,-0.11 0.37,-0.21 -0.01,-0.23 -0.07,-0.25"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S310"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S310P1"
+         d="m 261.84,283.76 0.1,0.17 0.23,0.08 0.08,0.07 0.09,0.11 0.16,0.06 0.2,-0.03 0.15,-0.14 0.19,-0.06 0.19,0.04 0.11,0.08 0.2,0.13"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S319"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S319P1"
+         d="m 283.2,310.72 -0.15,0.23 0.11,0.19 0.2,-0.04 0.09,-0.25 -0.04,-0.17 -0.21,0.04 v 0"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S326"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S326P1"
+         d="m 327.32,284.76 0.04,-0.18 0.54,-0.58 0.17,0.03 0.34,-0.05 0.67,-0.17 0.27,-0.37 0.22,0.03 0.13,-0.17 0.24,-0.22 0.05,0.02 0.04,0.02 0.45,-0.03 0.35,0.08 0.27,0.18 0.26,0.1 h 0.24 l 0.15,0.08 0.07,0.18 0.24,0.03 0.4,-0.1 0.2,0.08 -0.01,0.25 0.06,0.07 0.13,-0.12 0.12,0.05 0.1,0.16 0.08,0.07 0.14,-0.33 0.23,-0.03 0.55,-0.02 0.42,0.51 0.22,0.16 0.18,0.04 0.17,-0.14 0.14,-0.15 0.11,0.03 0.31,0.32 0.17,0.49 0.05,0.2 0.01,0.36 -0.02,0.39 -0.03,0.25 0.08,0.18 0.12,0.14 0.14,0.02 0.48,0.21 0.21,0.18 0.26,0.11 0.17,-0.04 0.12,0.07 0.05,0.1 0.05,0.29 -0.03,0.3 0.06,0.16 0.2,0.17 0.07,0.23 0.05,0.15 0.11,0.09 0.44,0.16 0.55,0.11 0.18,0.19 0.14,0.25 0.1,0.46 0.06,0.41 0.78,0.36 -0.05,0.12 -0.07,0.13 -0.59,0.25 -0.12,0.08 -0.37,-0.33 -0.15,-0.01 -0.1,0.18 -0.13,0.13 -0.2,0.01 -0.23,-0.07 -0.12,-0.06 -0.09,0.01 -0.1,0.12 -0.18,0.01 -0.13,-0.08 -0.07,0.39 -0.08,0.1 h -0.06 l -0.16,-0.58 -0.06,-0.07 -0.13,0.02 -0.27,0.21 -0.24,0.26 -0.06,0.18 0.07,0.29 0.13,0.33 0.32,0.47 -0.06,0.25 0.01,0.38 -0.23,0.41 -0.31,0.29 0.06,0.4 -0.13,0.32 -0.27,0.36 -0.15,0.38 0.1,0.21 0.07,0.2 -0.01,0.16 0.02,0.11 -0.08,0.07 -0.51,0.17 -0.13,0.11 -0.13,0.19"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S338"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S338P1"
+         d="m 322.94,246.95 h -0.08 l -0.2,0.11 -0.28,0.35 -0.36,0.75 -0.1,0.17 -0.01,0.51 -0.02,0.06 -0.31,0.05 -0.09,0.01 -0.3,0.08 -0.69,0.03 -0.24,0.14 -0.22,0.56 -0.12,0.1 -0.37,0.16 -0.06,0.07"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S339"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S339P1"
+         d="m 335.19,296.68 0.44,0.4 0.49,0.15 1.06,0.01 0.08,-0.05 v -0.05 l -0.09,-0.06 -0.03,-0.08 0.02,-0.13 0.14,-0.04 0.24,0.04 0.4,-0.25 0.53,-0.55 0.56,-0.23 0.58,0.09 0.33,0.19 0.23,0.21"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S340"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S340P1"
+         d="m 313.24,304.06 0.57,0.09 0.27,0.13 0.16,0.19 0.37,0.09 0.57,-0.02 0.43,0.16 0.27,0.33 0.35,-0.15 0.42,-0.62 0.47,-0.23 0.52,0.18 0.3,0.17 0.07,0.16 -0.1,0.09 -0.28,0.01 -0.2,0.14 -0.14,0.27 0.01,0.26 0.16,0.25 0.2,0.16 0.24,0.06 0.14,0.13 0.04,0.17 0.07,0.04"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S347"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S347P1"
+         d="m 265.89,311.69 -0.01,-0.05 -0.07,-0.05 -0.07,0.02 -0.06,0.06 -0.01,0.1"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S348"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S348P1"
+         d="m 283.39,320.58 h 0.03 v 0.04 h -0.03 l -0.01,-0.01 0.01,-0.03 v 0"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <g
+       id="gF1S354"
+       style="stroke:#ffffff;stroke-width:0.348865;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
+      <path
+         id="polyF1S354P1"
+         d="m 228.95,362.48 0.2,-0.05 0.03,-0.25 -0.08,-0.51 0.12,-0.28 0.34,-0.23 0.42,-0.25 -0.14,-0.41 -0.27,-0.3 -0.4,-0.37 -0.2,-0.16 -0.35,-0.43 -0.18,-0.46 -0.06,-0.91 -0.23,-0.55 -0.14,-0.64 0.33,-1.1 -0.2,-0.72 v -0.3 l 0.04,-0.35 0.16,-0.59 0.05,-0.85 -0.22,-0.93 0.19,-0.27 0.09,-0.14 v -0.13 l -0.27,-0.33 -0.09,-0.25 0.09,-0.21 0.19,-0.28 0.01,-0.14 -0.44,-0.46 -0.72,-0.76 -0.2,-0.3 -0.06,-0.36"
+         class="river"
+         inkscape:connector-curvature="0"
+         style="fill:none;stroke:#ffffff;stroke-width:0.348865;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <circle
+       style="opacity:1;fill:#c0c1c5;fill-opacity:1;stroke:#ffffff;stroke-width:2.534;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path18134"
+       cx="973.45081"
+       cy="396.54477"
+       r="10" />
+    <circle
+       r="10"
+       cy="362.04477"
+       cx="1251.0758"
+       id="circle18137"
+       style="opacity:1;fill:#c0c1c5;fill-opacity:1;stroke:#ffffff;stroke-width:2.534;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#c0c1c5;fill-opacity:1;stroke:#ffffff;stroke-width:2.534;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="circle18139"
+       cx="1179.2633"
+       cy="251.35542"
+       r="10" />
+    <circle
+       r="10"
+       cy="431.66763"
+       cx="1251.5651"
+       id="circle18141"
+       style="opacity:1;fill:#c0c1c5;fill-opacity:1;stroke:#ffffff;stroke-width:2.534;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <circle
+       style="opacity:1;fill:#c0c1c5;fill-opacity:1;stroke:#ffffff;stroke-width:2.534;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="circle18143"
+       cx="1123.4902"
+       cy="367.32092"
+       r="10" />
+    <circle
+       r="10"
+       cy="632.58557"
+       cx="1310.4441"
+       id="circle18141-3"
+       style="display:inline;fill:none;fill-opacity:1;stroke:#c0c1c5;stroke-width:2.534;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Disputed areas"
+     inkscape:label="Disputed areas"
+     transform="translate(-603.68384,1129.1095)"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       id="polyF1S16P1-3"
+       d="m 1614.2438,-334.44921 -0.8717,0.50845 -0.7263,0.36318 1.0169,-2.39698 1.6706,-0.2179 3.9949,-0.14528 3.0507,3.70442 1.598,1.16217 1.3075,0.29054 1.2348,-1.01689 1.0169,-1.08954 0.799,0.21791 2.2517,2.32434 1.2348,3.55914 0.3632,1.45272 0.073,2.61488 -0.1453,2.83279 -0.2179,1.81589 0.5811,1.30744 0.8716,1.0169 1.0169,0.14527 3.4865,1.52535 1.5254,1.30744 1.8885,0.79899 1.2348,-0.29054 0.8716,0.50845 0.3632,0.72636 0.3632,2.10643 -0.2179,2.17907 0.4358,1.16217 1.4527,1.2348 0.5085,1.67062 0.3631,1.08954 0.799,0.65372 3.196,1.16217 3.995,0.79899 1.3074,1.38008 1.0169,1.81589 0.7264,3.34124 0.4358,2.97806 -0.6537,-0.36318 -2.397,-0.36318 -0.9443,-0.43581 -0.2905,-0.58109 -0.5085,-0.58108 -1.4527,-0.50845 -0.6537,-0.72636 0.1453,-0.94426 -0.6538,-1.30744 -1.38,-1.67062 -1.1622,-0.21791 -0.9443,1.23481 -1.0895,-0.72636 -1.3074,-2.61488 -1.4528,-1.16217 -2.6148,0.29054 -0.4359,-0.50845 0.218,-0.79899 0.7989,-1.08953 -0.3631,-1.23481 -1.3801,-1.38008 -1.3801,-0.79899 -1.0895,0.43581 -0.8716,0.50845 -0.799,0.21791 -0.2906,-0.58108 0.073,-1.0169 -0.218,-1.88853 -1.7432,-2.2517 v -1.08954 l -0.1453,-0.94426 -0.5811,-0.72636 -0.5084,-0.87163 0.073,-1.01689 -0.9442,-1.74326 -2.0338,-2.2517 -1.3075,-3.19597 -0.6537,-3.99496 -2.4696,-2.97806 -4.5034,-2.0338 -2.6875,-0.43581 -1.0169,0.58108 -0.8717,-0.43581 -0.2905,-1.45272 z"
+       class="region"
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#ffffff;stroke-width:2.5342;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2.5342;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1747.3923,-304.56515 -2.45,6.93366"
+       id="path15612"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:2.5342;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1777.7623,-297.87062 2.75,-2.80929"
+       id="path15614"
+       inkscape:connector-curvature="0" />
+  </g>
+  <style
+     type="text/css"
+     id="mapStyle">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #646464 -- lake's coast, rivers, sea coasts
+ * political border: #646464 -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #646464;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #646464;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     type="text/css"
+     id="mapStyle-9">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #646464 -- lake's coast, rivers, sea coasts
+ * political border: #646464 -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #646464;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #646464;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     type="text/css"
+     id="mapStyle-3">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #646464 -- lake's coast, rivers, sea coasts
+ * political border: #646464 -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #646464;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #646464;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     type="text/css"
+     id="mapStyle-1">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #646464 -- lake's coast, rivers, sea coasts
+ * political border: #646464 -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #646464;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #646464;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     type="text/css"
+     id="mapStyle-30">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #C7E7FB -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: #1278AB -- land borders
+ * subject land: #C7E7FB -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #1278AB -- lake's coast, rivers, sea coasts
+ * political border: #1278AB -- Other minor political borders
+ * interest border: #1278AB -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #C7E7FB;
+   stroke: #1278AB;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #1278AB;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #C7E7FB;
+   stroke: #1278AB;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #1278AB;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     type="text/css"
+     id="mapStyle-8">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #1278AB -- lake's coast, rivers, sea coasts
+ * political border: #1278AB -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #1278AB;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #1278AB;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     type="text/css"
+     id="mapStyle-98">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #1278AB -- lake's coast, rivers, sea coasts
+ * political border: #1278AB -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #1278AB;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #1278AB;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     id="mapStyle-0"
+     type="text/css">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #646464 -- lake's coast, rivers, sea coasts
+ * political border: #646464 -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #646464;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #646464;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     id="mapStyle-8-8"
+     type="text/css">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #646464 -- lake's coast, rivers, sea coasts
+ * political border: #646464 -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #646464;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #646464;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     id="mapStyle-3-4"
+     type="text/css">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #646464 -- lake's coast, rivers, sea coasts
+ * political border: #646464 -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #646464;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #646464;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     id="mapStyle-4"
+     type="text/css">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #646464 -- lake's coast, rivers, sea coasts
+ * political border: #646464 -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #646464;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #646464;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #646464;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     id="mapStyle-46"
+     type="text/css">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #C7E7FB -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: #1278AB -- land borders
+ * subject land: #C7E7FB -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #1278AB -- lake's coast, rivers, sea coasts
+ * political border: #1278AB -- Other minor political borders
+ * interest border: #1278AB -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #C7E7FB;
+   stroke: #1278AB;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #1278AB;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #C7E7FB;
+   stroke: #1278AB;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #1278AB;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     id="mapStyle-6"
+     type="text/css">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #1278AB -- lake's coast, rivers, sea coasts
+ * political border: #1278AB -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #1278AB;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #1278AB;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+  <style
+     id="mapStyle-31"
+     type="text/css">/* Cascading Style Sheet (CSS) definitions for region colours */
+
+/* land: #FDFBEA -- outside area (or default land colour)
+ * sea: none -- ocean / sea / lake
+ * border: none -- land borders
+ * subject land: #FDFBEA -- subject colour
+ * other land: #C6DEBD -- other lands of the same political unity
+ * coast: #1278AB -- lake's coast, rivers, sea coasts
+ * political border: #1278AB -- Other minor political borders
+ * interest border: none -- border colour for areas of interest
+ */
+
+/* basic styles */
+path{
+   stroke-linejoin: bevel;
+}
+
+path,circle{
+   stroke-width: 0.25;
+}
+
+/* Main region definition */
+
+.region{
+   fill: #FDFBEA;
+   stroke: none;
+   stroke-width: 0.25;
+}
+
+/* Political groupings */
+
+.political{
+   fill: #C6DEBD;
+   stroke: #1278AB;
+}
+
+/* Subject / area of interest */
+
+.subject{
+   fill: #FDFBEA;
+   stroke: none;
+}
+
+circle.highlight{
+   stroke-width: 0.625;
+}
+
+/* Rivers */
+
+.river{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 0.125;
+}
+
+/* Sea and decoration */
+.seabase{
+   fill: none;
+   stroke: none;
+}
+
+.mapborder{
+   fill: none;
+   stroke: #1278AB;
+   stroke-width: 1.25;
+}
+
+.mapshadow{
+  fill: url(#grSea);
+  stroke: none;
+}
+
+/* Grid lines */
+.grid{
+  fill: none;
+  stroke: #1278AB;
+}
+
+/* Colouring a particular country, use '*' with group ID */
+/*
+ * #gNZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+/* ...or '.' with country name */
+/*
+ * .NZL *{
+ *   fill: #ff0000;
+ *   stroke: black;
+ * }
+ */
+</style>
+</svg>


### PR DESCRIPTION
This is just the initial draft for an interactive map that can be used to navigate the countries on the countries page, in addition to the list of countries.

It's the foundation for the map and can be extended by indicating the FIP rating via background color, show additional information on hover or click etc.

Resolves #135

In a later step, we could optimize the behavior and add the CSS classes to available countries in the SVG during build time, not with JavaScript during run time. However, this is more complex, we need to parse the SVG in Go templates.
