### PR TITLE
fix: Add missing train icon for SBB Regio in French translation

### DIFF
--- a/content/operator/sbb/index.fr.md
+++ b/content/operator/sbb/index.fr.md
@@ -74,7 +74,7 @@ Trains nationaux s’arrêtant dans les grandes villes. \
 **Réservation obligatoire :** non
 {{% /expander %}}
 
-{{% expander "Regio (R) / S-Bahn (S)" category %}}
+{{% expander "Regio (R) / S-Bahn (S)" traincategory category %}}
 **Description :** \
 Trains s’arrêtant à toutes les gares. Dans les agglomérations, ils sont aussi appelés S-Bahn. \
 **Réservation possible :** non


### PR DESCRIPTION
Follow-up for https://github.com/fipguide/fipguide.github.io/pull/242, where one train category in the French translation was missing.