### PR TITLE
Fixed z-index in country map

### DIFF
--- a/assets/sass/interactiveMap.scss
+++ b/assets/sass/interactiveMap.scss
@@ -22,7 +22,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    z-index: 10;
+    z-index: 3;
   }
 
   .o-interactive-map__country--available {


### PR DESCRIPTION
## Description

The z-index of the country map was too high, so it was visible in front of the mobile menu. I fixed that.
<img width="1179" height="2556" alt="IMG_8608" src="https://github.com/user-attachments/assets/d87d4f1e-4c66-422e-9b32-98f16daaac49" />


## Checklist
<!-- Check fields with: [x] / Abhaken von Punkten: [x] -->

- [ ] Check the License of new pictures (non-commercial use without attribution) <!-- Die Lizenz neuer Bilder geprüft (nicht-kommerzielle Nutzung ohne Namensnennung) -->

The content was modified in the following languages: <!-- Der Inhalt wurde für die folgenden Sprachen angepasst -->
- [ ] English
- [ ] German
- [ ] French
