### PR TITLE
fix: Remove image borders for teasers in light mode

### DIFF
--- a/assets/sass/teaser.scss
+++ b/assets/sass/teaser.scss
@@ -10,7 +10,7 @@
     border-radius: var(--border-radius-l);
     display: flex;
     flex-direction: column;
-    border: var(--border);
+    outline: var(--border);
 
     &:hover,
     &:focus {


### PR DESCRIPTION
Avoid a white border in the news overview. The border is still shown in the dark mode.

Before:
<img width="892" height="295" alt="image" src="https://github.com/user-attachments/assets/4bed28c2-f0a7-49d1-b3e8-068193cb36f8" />

After:
<img width="760" height="284" alt="image" src="https://github.com/user-attachments/assets/c7456a02-7ef7-4fd4-861d-e10c1bf7dd9b" />
