### PR TITLE
feat: Increase gap between text and image on startpage

### DIFF
--- a/assets/sass/startpage.scss
+++ b/assets/sass/startpage.scss
@@ -7,7 +7,7 @@
   margin-bottom: 2rem;
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 2rem;
+  gap: 4rem;
 
   @media (max-width: #{$breakpoint-md}) {
     display: flex;


### PR DESCRIPTION
On one of my screens, the gap between text and image on the startpage is a bit small:

![Uploading image.png…]()
