### PR TITLE
fix: Clarify internal link to DB Booking Information

### DIFF
--- a/content/news/5/index.de.md
+++ b/content/news/5/index.de.md
@@ -12,6 +12,6 @@ Außerdem steigen die Preise für Sitzplatzreservierungen:
 1. Klasse: 6,90€ (bisher 6,50€) \
 2. Klasse: 5,90€ (bisher 5,50€)
 
-Informationen zur Reservierungen sind [hier auf Bahn.de]({{< ref "/booking/db-website" >}} "DB Website Buchung") zu finden.
+Informationen zur Reservierungen sind [hier]({{< ref "/booking/db-website" >}} "DB Website Buchung") zu finden.
 
 [^1]: [Tagesschau](https://www.tagesschau.de/wirtschaft/verbraucher/bahn-familienreservierung-kritik-100.html)

--- a/content/news/5/index.en.md
+++ b/content/news/5/index.en.md
@@ -12,6 +12,6 @@ Additionally, the prices for seat reservations will increase:
 1st class: €6.90 (previously €6.50) \
 2nd class: €5.90 (previously €5.50)
 
-Information about reservations can be found [here on Bahn.de]({{< ref "/booking/db-website" >}} "DB Website Booking").
+Information about reservations can be found [here]({{< ref "/booking/db-website" >}} "DB Website Booking").
 
 [^1]: [Tagesschau](https://www.tagesschau.de/wirtschaft/verbraucher/bahn-familienreservierung-kritik-100.html)

--- a/content/news/5/index.fr.md
+++ b/content/news/5/index.fr.md
@@ -12,6 +12,6 @@ De plus, les prix des réservations de sièges augmenteront :
 1re classe : 6,90€ (auparavant 6,50€) \
 2e classe : 5,90€ (auparavant 5,50€)
 
-Les informations sur les réservations sont disponibles [ici sur Bahn.de]({{< ref "/booking/db-website" >}} "Réservation DB Website").
+Les informations sur les réservations sont disponibles [ici]({{< ref "/booking/db-website" >}} "Réservation DB Website").
 
 [^1]: [Tagesschau](https://www.tagesschau.de/wirtschaft/verbraucher/bahn-familienreservierung-kritik-100.html)


### PR DESCRIPTION
Previously, it looked like the link in the DB reservation news article would go to bahn.de. Instead, it's just an internal link leading to more information.