### PR TITLE
fix: Do not break list item text into next column

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -23,6 +23,11 @@ ol {
 ul,
 ol {
   padding-left: 2rem;
+
+  li > small {
+    display: inline-block;
+    line-height: 1.2;
+  }
 }
 
 button {
@@ -168,9 +173,14 @@ img {
 @mixin add-columns($columns) {
   &--columns-#{$columns} {
     columns: $columns;
+    column-gap: 2.4rem;
 
     @media (max-width: #{$breakpoint-md}) {
       columns: 1;
+    }
+
+    li {
+      break-inside: avoid-column;
     }
   }
 }

--- a/content/booking/db-website-fip-db/index.de.md
+++ b/content/booking/db-website-fip-db/index.de.md
@@ -29,7 +29,8 @@ FIP 50 Fahrkarten können für die folgenden Länder erworben werden:
 <!-- prettier-ignore -->
 - Polen
 - Österreich
-- Italien (nur Brennerverkehr mit Österreich und ECE Frankfurt - Mailand)
+- Italien \
+  <small>Nur Brennerverkehr mit Österreich und ECE Frankfurt - Mailand</small>
 - Tschechien
 - Schweiz
 - Luxemburg

--- a/content/booking/db-website-fip-db/index.en.md
+++ b/content/booking/db-website-fip-db/index.en.md
@@ -29,7 +29,8 @@ FIP 50 Tickets can be purchased for the following countries:
 <!-- prettier-ignore -->
 - Poland
 - Austria
-- Italy (only Brenner route with Austria and ECE Frankfurt - Milan)
+- Italy \
+  <small>only Brenner route with Austria and ECE Frankfurt - Milan</small>
 - Czech Republic
 - Switzerland
 - Luxembourg

--- a/content/booking/db-website-fip-db/index.fr.md
+++ b/content/booking/db-website-fip-db/index.fr.md
@@ -29,7 +29,8 @@ Les billets FIP 50 peuvent être achetés pour les pays suivants :
 <!-- prettier-ignore -->
 - Pologne
 - Autriche
-- Italie (uniquement la ligne du Brenner avec l’Autriche et le ECE Francfort – Milan)
+- Italie \
+  <small>uniquement la ligne du Brenner avec l’Autriche et le ECE Francfort – Milan</small>
 - République tchèque
 - Suisse
 - Luxembourg

--- a/content/booking/db-website-fip-international/index.de.md
+++ b/content/booking/db-website-fip-international/index.de.md
@@ -32,7 +32,8 @@ FIP 50 Fahrkarten können für die folgenden Länder erworben werden, solange ei
 - Dänemark
 - Deutschland
 - Frankreich
-- Italien (nur Brennerverkehr mit Österreich und ECE Frankfurt - Mailand)
+- Italien \
+  <small>Nur Brennerverkehr mit Österreich und ECE Frankfurt - Mailand</small>
 - Luxemburg
 - Niederlande
 - Österreich

--- a/content/booking/db-website-fip-international/index.en.md
+++ b/content/booking/db-website-fip-international/index.en.md
@@ -34,7 +34,8 @@ FIP 50 Tickets can be purchased for the following countries, as long as a sectio
 - Denmark
 - France
 - Germany
-- Italy (only Brenner route with Austria and ECE Frankfurt - Milan)
+- Italy \
+  <small>only Brenner route with Austria and ECE Frankfurt - Milan</small>
 - Luxembourg
 - Netherlands
 - Poland

--- a/content/booking/db-website-fip-international/index.fr.md
+++ b/content/booking/db-website-fip-international/index.fr.md
@@ -34,7 +34,8 @@ Les billets FIP 50 peuvent être achetés pour les pays suivants, à condition q
 - Danemark
 - France
 - Allemagne
-- Italie (uniquement ligne du Brenner avec l’Autriche et ECE Francfort – Milan)
+- Italie \
+  <small>uniquement la ligne du Brenner avec l’Autriche et le ECE Francfort – Milan</small>
 - Luxembourg
 - Pays-Bas
 - Pologne


### PR DESCRIPTION
Resolves #338 

The new style avoids column breaking and displays the additional information in a smaller font for better overview:
<img width="1358" height="304" alt="image" src="https://github.com/user-attachments/assets/663ccc94-1fb6-4234-b052-f51a0ac58f1f" />
