### PR TITLE
fix: SNCB Website only sells FIP 50 for cross-border travel

### DIFF
--- a/content/booking/sncb-website/index.de.md
+++ b/content/booking/sncb-website/index.de.md
@@ -1,6 +1,6 @@
 ---
 draft: false
-title: "SNCB Website"
+title: "SNCB International Website"
 description: "Buchungsinformationen für die SNCB Website."
 
 params:
@@ -12,11 +12,13 @@ aliases:
   - sncb_website
 ---
 
+Bei Nutzung einer Freifahrt für die SNCB kann über die Website ein grenzüberschreitendes Ticket gebucht werden, welches die Freifahrt im belgischen Abschnitt berücksichtigt. Dafür bei den Reisenden die Ermäßigung "Freifahrtschein Belgien (SNCB)" angeben. Somit lassen sich z. B. Züge von Belgien nach Lille in Frankreich (außer mit dem `TGV`, der einen Globalpreis besitzt und nicht von der SNCB betrieben wird) sehr günstig buchen.
+
 {{% booking-section "fip_50" %}}
 
 ## FIP 50 Fahrkarten
 
-Die SNCB verkauft online Fahrkarten mit FIP 50 Rabatt. Dazu einfach bei den Reisenden die Ermäßigung "50% Ermäßigung Belgien (SNCB)" auswählen. Hier können auch mehrere Ermäßigungen, z. B. ein gleichzeitig noch vorhandener Freifahrtschein für die CFL (Luxemburg) oder NS (Niederlande) angegeben werden.
+Die SNCB verkauft online Fahrkarten mit FIP 50 Rabatt bei grenzüberschreitenden Verbindungen in die Nachbarländer von Belgien. Dazu einfach bei den Reisenden die Ermäßigung "50% Ermäßigung Belgien (SNCB)" auswählen. Hier können auch mehrere Ermäßigungen, z. B. ein gleichzeitig noch vorhandener Freifahrtschein für die CFL (Luxemburg) oder NS (Niederlande) angegeben werden.
 
 ![SNCB FIP Ticket buchen](fip_sncb_website.webp)
 {{% /booking-section %}}

--- a/content/booking/sncb-website/index.en.md
+++ b/content/booking/sncb-website/index.en.md
@@ -1,6 +1,6 @@
 ---
 draft: false
-title: "SNCB Website"
+title: "SNCB International Website"
 description: "Booking information for the SNCB website."
 
 params:
@@ -12,11 +12,13 @@ aliases:
   - sncb_website
 ---
 
+When using a SNCB FIP Coupon, a cross-border ticket can be booked via the website, which takes the free travel within the Belgian section into account. To do this, select the discount "100% Discount Belgium (SNCB)" for the travelers. This allows, for example, very affordable bookings for trains from Belgium to Lille in France (except for the `TGV`, which has a global price and is not operated by SNCB).
+
 {{% booking-section "fip_50" %}}
 
 ## FIP 50 Tickets
 
-The SNCB sells tickets online with a FIP 50 discount. Simply select the discount "50% Discount Belgium (SNCB)" for the travelers. Multiple discounts can also be specified here, e.g., a simultaneously valid FIP Coupons for CFL (Luxembourg) or NS (Netherlands).
+The SNCB sells tickets online with a FIP 50 discount for cross-border connections to Belgium's neighbouring countries. Simply select the discount "50% Discount Belgium (SNCB)" for the travelers. Multiple discounts can also be specified here, e.g., a simultaneously valid FIP Coupons for CFL (Luxembourg) or NS (Netherlands).
 
 ![Book an SNCB FIP ticket](fip_sncb_website.webp)
 {{% /booking-section %}}

--- a/content/booking/sncb-website/index.fr.md
+++ b/content/booking/sncb-website/index.fr.md
@@ -1,6 +1,6 @@
 ---
 draft: false
-title: "Site web SNCB"
+title: "Site web SNCB International"
 description: "Informations sur la réservation via le site web de la SNCB."
 
 params:
@@ -12,11 +12,13 @@ aliases:
   - sncb_website
 ---
 
+Lorsque vous utilisez un coupon FIP SNCB, un billet transfrontalier peut être réservé via le site web, qui prend en compte le trajet gratuit sur le territoire belge. Pour cela, sélectionnez la réduction "100% Discount Belgium (SNCB)" pour les voyageurs. Cela permet par exemple de réserver très facilement des trajets de la Belgique vers Lille (hors `TGV`, tarif global et non exploité par la SNCB).
+
 {{% booking-section "fip_50" %}}
 
 ## Billets FIP 50
 
-La SNCB propose la vente de billets en ligne avec la réduction FIP 50. Il suffit de sélectionner la réduction « 50% de réduction en Belgique (SNCB) » pour les voyageurs. Il est également possible de combiner plusieurs réductions, par exemple un coupon FIP valable simultanément pour le CFL (Luxembourg) ou NS (Pays-Bas).
+La SNCB vend en ligne des billets avec la réduction FIP 50 pour des trajets transfrontaliers vers les pays voisins de la Belgique. Il suffit de sélectionner pour chaque voyageur la réduction « 50% Réduction Belgique (SNCB) ». Plusieurs réductions peuvent être combinées, par exemple un coupon de libre circulation détenu simultanément pour la CFL (Luxembourg) ou NS (Pays-Bas).
 
 ![Réserver un billet FIP SNCB](fip_sncb_website.webp)
 {{% /booking-section %}}

--- a/content/operator/sncb/index.de.md
+++ b/content/operator/sncb/index.de.md
@@ -101,9 +101,11 @@ Zusätzliche Züge zu bestimmten touristischen Zielen, oft auch einfach als `R` 
 
 ### Online
 
-{{% booking id="sncb-website" %}}
-Bei Nutzung einer Freifahrt für die SNCB kann über die Website ein grenzüberschreitendes Ticket gebucht werden, welches die Freifahrt im belgischen Abschnitt berücksichtigt. Dafür bei den Reisenden die Ermäßigung "Freifahrtschein Belgien (SNCB)" angeben. Somit lassen sich z. B. Züge von Belgien nach Lille in Frankreich (außer mit dem `TGV`, der einen Globalpreis besitzt und nicht von der SNCB betrieben wird) sehr günstig buchen.
-{{% /booking %}}
+Nationale Verbindungen können online leider nicht erworben werden.
+
+{{% booking id="sncb-website"
+    subtitle="Nur für grenzüberschreitende Verbindungen von/nach Belgien"
+/%}}
 
 {{% booking id="db-website-fip-db"
     subtitle="Für nationale und grenzüberschreitende Verbindungen. Grenzüberschreitende FIP 50 Tickets, mit Ticketanteil nur für den belgischen Abschnitt, für Mitarbeiter der Deutschen Bahn"

--- a/content/operator/sncb/index.en.md
+++ b/content/operator/sncb/index.en.md
@@ -101,9 +101,11 @@ Additional trains to certain tourist destinations, often simply referred to as `
 
 ### Online
 
-{{% booking id="sncb-website" %}}
-When using a SNCB FIP Coupon, a cross-border ticket can be booked via the website, which takes the free travel within the Belgian section into account. To do this, select the discount "100% Discount Belgium (SNCB)" for the travelers. This allows, for example, very affordable bookings for trains from Belgium to Lille in France (except for the `TGV`, which has a global price and is not operated by SNCB).
-{{% /booking %}}
+Domestic journeys unfortunately cannot be purchased online.
+
+{{% booking id="sncb-website"
+    subtitle="Only for cross-border journeys to/from Belgium"
+/%}}
 
 {{% booking id="db-website-fip-db"
     subtitle="For domestic and cross-border connections. Cross-border FIP 50 tickets, with ticket portions valid only for the Belgian section, for employees of Deutsche Bahn"

--- a/content/operator/sncb/index.fr.md
+++ b/content/operator/sncb/index.fr.md
@@ -101,9 +101,11 @@ Trains supplémentaires vers certaines destinations touristiques, souvent simple
 
 ### En ligne
 
-{{% booking id="sncb-website" %}}
-Lorsque vous utilisez un coupon FIP SNCB, un billet transfrontalier peut être réservé via le site web, qui prend en compte le trajet gratuit sur le territoire belge. Pour cela, sélectionnez la réduction "100% Discount Belgium (SNCB)" pour les voyageurs. Cela permet par exemple de réserver très facilement des trajets de la Belgique vers Lille (hors `TGV`, tarif global et non exploité par la SNCB).
-{{% /booking %}}
+Les trajets nationaux ne peuvent malheureusement pas être achetés en ligne.
+
+{{% booking id="sncb-website"
+  subtitle="Uniquement pour les trajets transfrontaliers à destination ou en provenance de la Belgique"
+/%}}
 
 {{% booking id="db-website-fip-db"
   subtitle="Pour les trajets nationaux et internationaux. Billets FIP 50 transfrontaliers, avec une portion de billet uniquement pour le tronçon belge, destinés aux employés de la Deutsche Bahn."


### PR DESCRIPTION
Resolves #343

On the national belgianrail.be page, I can't find an option to select the FIP 50 discount.