### PR TITLE
fix: Improve list formatting in print view of country overview

### DIFF
--- a/assets/sass/styles.scss
+++ b/assets/sass/styles.scss
@@ -188,6 +188,12 @@ img {
   display: flex;
   align-items: center;
   width: fit-content;
+
+  > .o-list__picture {
+    @media print {
+      display: none;
+    }
+  }
 }
 
 .o-list__countries {


### PR DESCRIPTION
One additional commit for #351 to improve the list formatting that I broke in the restructuring: 

<img width="482" height="237" alt="image" src="https://github.com/user-attachments/assets/e9031d3a-79dd-4ebb-a91d-21a3ce13f709" />
