### PR TITLE
fix: Do not translate icons

### DIFF
--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,6 +1,7 @@
 <!-- prettier-ignore --><span
   data-pagefind-ignore="all"
   class="material-symbols-rounded icon-{{ . }}"
+  translate="no"
   aria-hidden="true">
   {{ . }}
 </span>


### PR DESCRIPTION
Do not translate the icon font as this leads to a broken display of icons:
<img width="853" height="318" alt="image" src="https://github.com/user-attachments/assets/92bb6d10-4738-4055-8740-bb687481e285" />
