### PR TITLE
fix: Avoid page break after heading in print version

### DIFF
--- a/assets/sass/headings.scss
+++ b/assets/sass/headings.scss
@@ -5,6 +5,7 @@ h1 {
   margin-top: 0;
   font-weight: 700;
   text-wrap: balance;
+  break-after: avoid;
 }
 
 h2 {
@@ -14,6 +15,7 @@ h2 {
   margin-top: 0;
   font-weight: 700;
   text-wrap: balance;
+  break-after: avoid;
 }
 
 h3 {
@@ -23,6 +25,7 @@ h3 {
   margin-top: 0;
   font-weight: 700;
   text-wrap: balance;
+  break-after: avoid;
 }
 
 h4 {
@@ -32,4 +35,5 @@ h4 {
   margin-top: 0;
   font-weight: 700;
   text-wrap: balance;
+  break-after: avoid;
 }


### PR DESCRIPTION
After headings, text is expected that should be rendered on the same page. Avoid page breaks like here: 

<img width="759" height="306" alt="image" src="https://github.com/user-attachments/assets/18e990bc-e351-45dd-97d5-1de9f7d9ba6c" />

Unfortunately, the option is not properly considered in Firefox ([bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=775617) opened 13 years ago :D), but in Chrome it works.