### PR TITLE
feat: Use full-width tables in expanders

### DIFF
--- a/assets/sass/expander.scss
+++ b/assets/sass/expander.scss
@@ -54,6 +54,11 @@ details {
   border-radius: var(--border-radius-m);
   margin-bottom: 1.2rem;
   border: var(--border);
+
+  table {
+    width: 100%;
+    margin-left: 0;
+  }
 }
 
 details > summary {
@@ -66,10 +71,6 @@ details > summary {
 
 details > div {
   overflow-x: auto;
-}
-
-details > div > * {
-  margin-right: 1rem;
 }
 
 details > summary::-webkit-details-marker {


### PR DESCRIPTION
Full-width tables look a bit better:

<img width="854" height="352" alt="image" src="https://github.com/user-attachments/assets/42b442ce-f7b3-4be1-8c69-5ae7fb0288ce" />

Before:

<img width="848" height="349" alt="image" src="https://github.com/user-attachments/assets/42f073fb-f311-4f2a-8ec1-e8764d0a7e5b" />


Removing the margin-right on inside elements of the expanders, they were introduced because of https://github.com/fipguide/fipguide.github.io/issues/142, but it doesn't seem to be an issue anymore.