### PR TITLE
fix: Move dynamic search height to correct class

### DIFF
--- a/assets/sass/search.scss
+++ b/assets/sass/search.scss
@@ -22,6 +22,10 @@
     max-height: 50vh;
     padding: 0 1rem;
     overflow-y: scroll;
+
+    @media (max-width: #{$breakpoint-md}) {
+      max-height: calc(100dvh - 17rem);
+    }
   }
 
   .pagefind-ui__results li:last-child {
@@ -70,15 +74,10 @@
     overscroll-behavior: contain;
     overflow: hidden;
     position: absolute;
-    top: 7rem;
     width: 100%;
     z-index: 6;
     border: var(--border);
     border-radius: 0 0 var(--border-radius-l) var(--border-radius-l);
-
-    @media (max-width: #{$breakpoint-md}) {
-      max-height: calc(100dvh - 17rem);
-    }
   }
 
   .pagefind-ui__result {


### PR DESCRIPTION
In #409, the definition of the max-height was moved to another class, this PR reflects this for the mobile max-height, otherwise it doesn't overwrite the value.

Also remove an unnecessary hard-coded positioning of the search drawer, which led to gaps between drawer and search bar on some devices.