### PR TITLE
fix: Generalize scroll-handling to touches on mobile 

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -27,9 +27,9 @@ const initSearch = () => {
     },
   });
 
-  // Close keyboard when scrolling in search results (mobile only)
+  // Close keyboard when touching search results (mobile only)
   const searchDrawer = search.querySelector(".pagefind-ui__drawer");
-  searchDrawer.addEventListener("scroll", () => {
+  searchDrawer.addEventListener("touchstart", () => {
     if (!isMobile) return;
     if (document.activeElement && document.activeElement.blur) {
       document.activeElement.blur();


### PR DESCRIPTION
Before, the behaviour was limited to scroll events. However, if there are not enough search results to show a search bar, the event doesn't trigger. This PR updates the corresponding Javascript to close the keyboard on mobile during touch events.