### PR TITLE
fix: Remove margins at end of highlight or expander

### DIFF
--- a/assets/sass/expander.scss
+++ b/assets/sass/expander.scss
@@ -45,6 +45,13 @@
 
 .o-expander__content {
   padding: 1.2rem;
+
+  // Remove margins from last elements of expander (up to 3 levels deep)
+  & > *:last-child,
+  & > *:last-child > *:last-child,
+  & > *:last-child > *:last-child > *:last-child {
+    margin-bottom: 0;
+  }
 }
 
 .details-print {

--- a/assets/sass/textHighlight.scss
+++ b/assets/sass/textHighlight.scss
@@ -5,6 +5,12 @@
   border-radius: var(--border-radius-m);
   border-left: var(--bg-neutral) solid 1rem;
 
+  // Remove margins from last elements of expander (up to 2 levels deep)
+  & > *:last-child,
+  & > *:last-child > *:last-child {
+    margin-bottom: 0;
+  }
+
   @media print {
     page-break-inside: avoid;
   }


### PR DESCRIPTION
Resolves #407

Supports nested elements as well, since the the margin sometimes is only applied to a child of the last element.