### PR TITLE
fix: Make icons unselectable

### DIFF
--- a/assets/sass/fonts.scss
+++ b/assets/sass/fonts.scss
@@ -145,4 +145,5 @@ button {
   text-decoration: none;
   width: 1em;
   height: 1em;
+  user-select: none;
 }


### PR DESCRIPTION
No longer select icons when marking text, this prevents copying the icon.

Resolves #474