### PR TITLE
fix: Render footnotes in train category expander

### DIFF
--- a/layouts/partials/train-category.html
+++ b/layouts/partials/train-category.html
@@ -108,7 +108,7 @@
   </summary>
   <hr aria-hidden="true" />
   <div class="o-expander__content o-train-category__content">
-    {{- .content -}}
+    {{ .content }}
     {{- if or .route_overview_url .additional_information_url -}}
       <div>
         {{- if .route_overview_url -}}

--- a/layouts/shortcodes/train-category.html
+++ b/layouts/shortcodes/train-category.html
@@ -8,7 +8,7 @@
   "important_info" (strings.Contains .Inner "m-text-highlight--important")
   "route_overview_url" (.Get "route_overview_url")
   "additional_information_url" (.Get "additional_information_url")
-  "content" (.Inner | .Page.RenderString)
+  "content" (.Inner)
 -}}
 
 {{- partial "train-category" $data -}}


### PR DESCRIPTION
Pass the train category expander markdown to the parent page to render it in the page scope, including support for footnotes. To make this possible, the scraping of new lines around the content has been removed. The small detail is described here in the [goldmark docs](https://github.com/yuin/goldmark/blob/master/_benchmark/go/_data.md):

> The only restrictions are that block-level HTML elements —
> e.g. `<div>`, `<table>`, `<pre>`, `<p>`, etc. — must be separated from
> surrounding content by blank lines, and the start and end tags of the
> block should not be indented with tabs or spaces.