### PR TITLE
fix: Remove whitespaces from some links

### DIFF
--- a/layouts/news/single.html
+++ b/layouts/news/single.html
@@ -11,7 +11,7 @@
               {{ partial "link"
                 (dict
                 "Destination" .RelPermalink
-                "Text" ((print (partial "icon" "newspaper") (.Title)) | .Page.RenderString)
+                "Text" ((print (partial "icon" "newspaper") (.Title)) | safeHTML)
                 )
               }}
               {{ if eq .Page.Type "news" }}
@@ -28,7 +28,7 @@
         {{ partial "link"
           (dict
           "Destination" (print .Site.Params.githubDevUrl "blob/main/content" .Path "/index." .Language ".md")
-          "Text" ((print (partial "icon" "edit_square") (T "editPage")) | .Page.RenderString)
+          "Text" ((print (partial "icon" "edit_square") (T "editPage")) | safeHTML)
           )
         }}
       </div>

--- a/layouts/partials/contentNavigation.html
+++ b/layouts/partials/contentNavigation.html
@@ -63,7 +63,7 @@
           {{ partial "link"
             (dict
             "Destination" (print .Site.Params.githubDevUrl "blob/main/content" .Path "/index." .Language ".md")
-            "Text" ((print (partial "icon" "edit_square" ) (T "editPage")) | .Page.RenderString)
+            "Text" ((print (partial "icon" "edit_square" ) (T "editPage")) | safeHTML)
             )
           }}
         </li>
@@ -73,7 +73,7 @@
             {{ partial "link"
               (dict
               "Destination" (print .Site.Params.gitHubUrl "/issues/new?title=Issue+with+operator+" .LinkTitle "&labels=content,operator::" $operator)
-              "Text" ((print (partial "icon" "bug_report" ) (T "reportError")) | .Page.RenderString)
+              "Text" ((print (partial "icon" "bug_report" ) (T "reportError")) | safeHTML)
               )
             }}
           {{ end }}
@@ -82,7 +82,7 @@
             {{ partial "link"
               (dict
               "Destination" (print .Site.Params.gitHubUrl "/issues/new?title=Issue+with+country+" .LinkTitle "&labels=content,country::" $country)
-              "Text" ((print (partial "icon" "bug_report" ) (T "reportError")) | .Page.RenderString)
+              "Text" ((print (partial "icon" "bug_report" ) (T "reportError")) | safeHTML)
               )
             }}
           {{ end }}

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,8 +1,8 @@
-<!-- prettier-ignore --><span
+<span
   data-pagefind-ignore="all"
   class="material-symbols-rounded"
   translate="no"
   aria-hidden="true"
-  data-icon="{{ . }}">
-</span>
+  data-icon="{{ . }}"
+></span>
 {{- /* Needed, otherwise links break: https://github.com/fipguide/fipguide.github.io/issues/116 */ -}}

--- a/layouts/partials/link.html
+++ b/layouts/partials/link.html
@@ -1,6 +1,6 @@
 {{- $url := .Destination -}}
 {{- if and (strings.HasPrefix $url "http") (not (strings.HasPrefix $url site.BaseURL)) -}}
-  <!-- Absolute links pointing to external pages, e. g. `https://example.com` -->
+  {{- /* Absolute links pointing to external pages, e. g. `https://example.com` */ -}}
   <a
     href="{{ .Destination }}"
     target="_blank"
@@ -11,7 +11,7 @@
     {{- .Text -}}{{- partial "icon" "arrow_outward" -}}
   </a>
 {{- else if strings.HasPrefix $url "mailto:" -}}
-  <!-- Email links, e. g. `mailto:example@example.com` -->
+  {{- /* Email links, e. g. `mailto:example@example.com` */ -}}
   <a
     href="{{ $url }}"
     class="o-link__mail"
@@ -20,7 +20,7 @@
     {{- partial "icon" "mail" -}}{{- .Text -}}
   </a>
 {{- else if strings.HasPrefix $url "tel:" -}}
-  <!-- Telephone links, e. g. `tel:+1234567890` -->
+  {{- /* Telephone links, e. g. `tel:+1234567890` */ -}}
   <a
     href="{{ $url | safeURL }}"
     class="o-link__tel"
@@ -29,7 +29,7 @@
     {{- partial "icon" "call" -}}{{- .Text -}}
   </a>
 {{- else if .Page.Ref (dict "path" $url) -}}
-  <!-- Internal links, referenced by path (e. g. `/news/1`) -->
+  {{- /* Internal links, referenced by path (e. g. `/news/1`) */ -}}
   <a
     href="{{ .Page.Ref (dict "path" $url) }}"
     {{- with .Title -}}title="{{ . }}"{{- end -}}
@@ -37,13 +37,13 @@
     {{- .Text -}}
   </a>
 {{- else if or (strings.HasPrefix $url "/") (strings.HasPrefix $url site.BaseURL) -}}
-  <!-- Internal links, referenced by URL (e. g. `/en/news/1`) -->
+  {{- /* Internal links, referenced by URL (e. g. `/en/news/1`) */ -}}
   <a
     href="{{ $url | relURL }}"
     {{- with .Title -}}title="{{ . }}"{{- end -}}
   >
     {{- .Text -}}
   </a>
-{{ else }}
+{{- else -}}
   {{- warnf "Link '%s' could not be resolved." .Destination -}}
 {{- end -}}

--- a/layouts/partials/related.html
+++ b/layouts/partials/related.html
@@ -33,7 +33,7 @@
         {{ partial "link" (
           dict
           "Destination" .RelPermalink
-          "Text" ($text | .Page.RenderString)
+          "Text" ($text | safeHTML)
           )
         }}
 


### PR DESCRIPTION
In some links, leading / trailing whitespaces or new lines were added. This is fixed.

<img width="1700" height="222" alt="grafik" src="https://github.com/user-attachments/assets/94319d9e-95be-4cfb-9f46-5cb759fc271e" />

<img width="1712" height="158" alt="grafik" src="https://github.com/user-attachments/assets/7b06d322-2994-4b4c-b1bb-b24ee9efcb2b" />

Note to myself: Use Go templating comments instead of HTML comments because the HTML comments leave an empty new line when stripped out by Hugo.