### PR TITLE
fix: Use same build options for all FAQ languages

### DIFF
--- a/content/generalinformation/faq/_index.en.md
+++ b/content/generalinformation/faq/_index.en.md
@@ -3,7 +3,7 @@ title: "FAQ"
 
 cascade:
   - build:
-      list: false
+      list: local
       publishResources: false
       render: never
 ---


### PR DESCRIPTION
The build options for the FAQ pages were not properly updated for the English version. It doesn't seem to have any effect, but let's fix it before a new Hugo version actually checks for the build options in all languages.