### PR TITLE
fix: add corridor traffic Salzburg – Kufstein

### DIFF
--- a/content/operator/oebb/index.de.md
+++ b/content/operator/oebb/index.de.md
@@ -253,6 +253,10 @@ Mit einem FIP Freifahrtschein kann die Autoschleuse Tauerntunnel (Böckstein–M
 
 FIP 50 Ermäßigungen sind nicht erhältlich.
 
+### Korridorverkehr Salzburg - Kufstein
+
+Fernzüge der ÖBB verkehren zwischen Salzburg und Kufstein auf dem deutschen Streckennetz ohne Halt. FIP Freifahrtscheine der ÖBB sind hier gültig.
+
 ### Fahrtunterbrechung
 
 Eine Unterbrechung von einer Fahrt ist nur bei Distanzen von 101 km und mehr möglich und erfordert keine zusätzlichen Formalitäten.

--- a/content/operator/oebb/index.en.md
+++ b/content/operator/oebb/index.en.md
@@ -257,6 +257,10 @@ With a FIP Coupon, the Tauerntunnel car shuttle (Böckstein–Mallnitz-Obervella
 
 FIP 50 discounts are not available.
 
+### Corridor Traffic Salzburg – Kufstein
+
+ÖBB long-distance trains operate between Salzburg and Kufstein on the German rail network without stopping. ÖBB FIP Coupons are valid on this section.
+
 ### Break of journey
 
 Interrupting a journey is only possible for distances of 101 km or more and does not require additional formalities.

--- a/content/operator/oebb/index.fr.md
+++ b/content/operator/oebb/index.fr.md
@@ -257,6 +257,10 @@ Avec un Coupon FIP, la navette auto du tunnel du Tauern (Böckstein–Mallnitz-O
 
 La réduction FIP 50 n’est pas disponible.
 
+### Trafic de corridor Salzbourg – Kufstein
+
+Les trains grandes lignes ÖBB circulent entre Salzbourg et Kufstein sur le réseau ferroviaire allemand sans arrêt. Les Coupons FIP ÖBB y sont valables.
+
 ### Arrêts intermédiaires
 
 Arrêts intermédiaires sont possible uniquement pour les distances de 101 km ou plus et ne nécessite aucune formalité supplémentaire.


### PR DESCRIPTION
add corridor traffic Salzburg – Kufstein on the ÖBB page