### PR TITLE
feat: adjusted pagefindUI config

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -31,8 +31,8 @@ const initSearch = () => {
       search_label: searchLabelText,
     },
     ranking: {
-      termSimilarity: 6.0
-    }
+      termSimilarity: 6.0,
+    },
   });
 
   // Close keyboard when touching search results (mobile only)


### PR DESCRIPTION
I’ve played around with the ranking settings of pagefindUI in the playground:

- npx -y pagefind --site public --serve
- http://localhost:1414/pagefind/playground/

I think, we have to increase the **term similarity**, see https://pagefind.app/docs/ranking/

Now for the term "Schweiz" the page "Schweiz" is ranked highest.
We have to test the configuration for several use cases to prove the effect before merging.