### PR TITLE
fix: apply the german styleguide

### DIFF
--- a/content/booking/cp-ticket-office/index.de.md
+++ b/content/booking/cp-ticket-office/index.de.md
@@ -31,5 +31,5 @@ An Ticketschaltern der CP werden FIP Globalpreistickets für den internationalen
 
 ## Reservierungen
 
-Reservierungen für reservierungspflichtige Züge können vor Ort zu einem Preis von 5€ erworben werden.
+Reservierungen für reservierungspflichtige Züge können vor Ort zu einem Preis von 5 € erworben werden.
 {{% /booking-section %}}

--- a/content/booking/fs-ticket-machine/index.de.md
+++ b/content/booking/fs-ticket-machine/index.de.md
@@ -22,9 +22,9 @@ Dafür kann der Tarif _DIRITTO AMMISSIONE_ genutzt werden. Dieser bezieht sich z
 
 **Preise für _DIRITTO AMMISSIONE_:**
 
-Le Frecce: 25€ (1./2. Klasse) \
-InterCity: 3€ (1./2. Klasse) \
-Abweichende Preise für den Fernverkehr Richtung Schweiz/Österreich: z. B. 20€ Chiasso – Milano (`ECE`/`EC`)
+Le Frecce: 25 € (1./2. Klasse) \
+InterCity: 3 € (1./2. Klasse) \
+Abweichende Preise für den Fernverkehr Richtung Schweiz/Österreich: z. B. 20 € Chiasso – Milano (`ECE`/`EC`)
 
 Auf dem Startbildschirm des Automaten "Buy your tickets / Special Discounts" wählen. Anschließend den Tarif über "Diritti di Ammissione" &#10132; "Diritto Ammissione Non FS" auswählen.
 

--- a/content/booking/fs-ticket-office/index.de.md
+++ b/content/booking/fs-ticket-office/index.de.md
@@ -37,9 +37,9 @@ Teilweise wird der Tarif _DIRITTO AMMISSIONE_ verkauft. Dieser bezieht sich zwar
 
 **Preise für _DIRITTO AMMISSIONE_:**
 
-Le Frecce: 25€ (1./2. Klasse) \
-InterCity: 3€ (1./2. Klasse) \
-Abweichende Preise für den Fernverkehr Richtung Schweiz/Österreich: z. B. 20€ Chiasso – Milano (`ECE`/`EC`)
+Le Frecce: 25 € (1./2. Klasse) \
+InterCity: 3 € (1./2. Klasse) \
+Abweichende Preise für den Fernverkehr Richtung Schweiz/Österreich: z. B. 20 € Chiasso – Milano (`ECE`/`EC`)
 
 {{% /float-image %}}
 

--- a/content/booking/fs-website/index.de.md
+++ b/content/booking/fs-website/index.de.md
@@ -24,9 +24,9 @@ Dafür kann der Tarif _DIRITTO AMMISSIONE_ genutzt werden. Dieser bezieht sich z
 
 **Preise für _DIRITTO AMMISSIONE_:**
 
-Le Frecce: 25€ (1./2. Klasse) \
-InterCity: 3€ (1./2. Klasse) \
-Abweichende Preise für den Fernverkehr Richtung Schweiz/Österreich: z. B. 20€ Chiasso – Milano (`ECE`/`EC`)
+Le Frecce: 25 € (1./2. Klasse) \
+InterCity: 3 € (1./2. Klasse) \
+Abweichende Preise für den Fernverkehr Richtung Schweiz/Österreich: z. B. 20 € Chiasso – Milano (`ECE`/`EC`)
 
 Bei der Buchung muss über die Verbindungsauskunft erst eine Verbindung ausgewählt werden. Anschließend kann in der Ticketauswahl über den Button _Weitere Angebote anzeigen_ die Auswahl des Tarifs _DIRITTO AMMISSIONE_ erfolgen. Als Zugangsnummer kann die Nummer des FIP Freifahrtscheins angegeben werden.
 

--- a/content/booking/renfe-ticket-office/index.de.md
+++ b/content/booking/renfe-ticket-office/index.de.md
@@ -18,7 +18,7 @@ aliases:
 ## FIP Globalpreis
 
 In den Verkaufsstellen der Renfe können alle reservierungspflichtigen Tickets zum Globalpreis gebucht werden. \
-Es fällt eine zusätzliche Gebühr von 0,55€ an.
+Es fällt eine zusätzliche Gebühr von 0,55 € an.
 {{% /booking-section %}}
 
 {{% booking-section "fip_50" %}}

--- a/content/generalinformation/_index.de.md
+++ b/content/generalinformation/_index.de.md
@@ -35,7 +35,7 @@ Der FIP Ausweis hat je nach eigener Bahngesellschaft eine unterschiedliche Gült
 Für folgende Bahngesellschaften liegen uns Informationen zur Gültigkeitsdauer vor:
 
 {{% expander "Deutsche Bahn (DB)" info "national" %}}
-Der FIP Ausweis ist immer für eine feste Periode von drei Jahren gültig. Die aktuelle Periode ist 2025-2026-2027.
+Der FIP Ausweis ist immer für eine feste Periode von drei Jahren gültig. Die aktuelle Periode ist 2025–2026–2027.
 {{% /expander %}}
 
 {{% expander "Société nationale des chemins de fer français (SNCF)" info "national" %}}

--- a/content/news/4/index.de.md
+++ b/content/news/4/index.de.md
@@ -12,7 +12,7 @@ operator:
   - eurostar
 ---
 
-Ab dem 1. Mai 2025 erhöht Eurostar die Preise auf alle FIP Fahrkarten um 5€ bzw. 5 £. Die Preiserhöhung betrifft alle FIP Globalpreise bei Eurostar Blue und Eurostar Red (Thalys) in allen Klassen. Die neuen Preise gelten für alle Buchungen, die ab dem 1. Mai 2025 getätigt werden. [^1]
+Ab dem 1. Mai 2025 erhöht Eurostar die Preise auf alle FIP Fahrkarten um 5 € bzw. 5 £. Die Preiserhöhung betrifft alle FIP Globalpreise bei Eurostar Blue und Eurostar Red (Thalys) in allen Klassen. Die neuen Preise gelten für alle Buchungen, die ab dem 1. Mai 2025 getätigt werden. [^1]
 
 **Update 17.06.2025:** \
 Die Ankündingung ist inzwischen von der Seite der Rail Delivery Group entfernt worden. Es ist unklar, ob die Preiserhöhung noch in Kraft tritt oder ob sie zurückgezogen wurde. Wir werden die Situation weiter beobachten und informieren, sobald es Neuigkeiten gibt. Aktuell ist eine Buchung zu den alten Preisen weiterhin möglich.

--- a/content/operator/cd/index.de.md
+++ b/content/operator/cd/index.de.md
@@ -206,7 +206,7 @@ Für reguläre Fahrkarten reisen Kinder bis 6 Jahre in der 2. Klasse kostenlos. 
 
 Auf sogenannten _kommerziellen_ Verbindungen der ČD muss ein Aufschlag gekauft werden. Diese umfassen in der Regel nur bestimmte Züge der Zugkategorien `SC`, `IC` und `Ex`. (Und `R` Züge, die mit "NATO Days" gekennzeichnet sind).[^3]
 
-Die ČD stellt eine Übersicht mit betroffenen Fahrten zur Verfügung: [ČD kommerzielle Zuge und ausgewahlte Linien 2024-2025](https://www.raildeliverygroup.com/images/RST/CD%20kommerzielle%20Zuge%20und%20ausgewahlte%20Linien%202024-2025.pdf)
+Die ČD stellt eine Übersicht mit betroffenen Fahrten zur Verfügung: [ČD kommerzielle Zuge und ausgewahlte Linien 2024–2025](https://www.raildeliverygroup.com/images/RST/CD%20kommerzielle%20Zuge%20und%20ausgewahlte%20Linien%202024-2025.pdf)
 
 Für Reservierungspflichtige Zugverbindungen in der Liste gelten besondere Regeln, siehe [Züge mit Reservierungspflicht](#züge-mit-reservierungspflicht).
 
@@ -235,13 +235,13 @@ Für Verkehre, die von regionalen Gemeinden vergeben werden (Züge der Kategorie
 
 FIP Fahrkarten sind in Regionalzügen in Süd-Mähren nicht gültig, auch wenn diese von der ČD betrieben werden
 
-Übersicht über die Verbindungen: [Sperrliste CD JMK 2024-2025](https://www.raildeliverygroup.com/images/RST/Sperrliste%20CD%20JMK%202024-2025.pdf)
+Übersicht über die Verbindungen: [Sperrliste CD JMK 2024–2025](https://www.raildeliverygroup.com/images/RST/Sperrliste%20CD%20JMK%202024-2025.pdf)
 
 #### Regionalzüge in der Region Pilsen
 
 FIP Fahrkarten sind auf einigen Regionalzügen im Raum Pilsen nicht gültig.
 
-Übersicht über die Verbindungen: [Sperrliste CD Region Pilsen 2024-2025](https://www.raildeliverygroup.com/images/RST/Sperrliste%20CD%20Region%20Pilsen%202024%20-%202025.pdf)
+Übersicht über die Verbindungen: [Sperrliste CD Region Pilsen 2024–2025](https://www.raildeliverygroup.com/images/RST/Sperrliste%20CD%20Region%20Pilsen%202024%20-%202025.pdf)
 
 ### Busse und Ersatzverkehr
 

--- a/content/operator/cp/index.de.md
+++ b/content/operator/cp/index.de.md
@@ -36,7 +36,7 @@ FIP Freifahrtscheine (egal welcher Klasse) sind nur in der zweiten Klasse gülti
 
 **Reservierung möglich:** Ja \
 **Reservierungspflicht:** ⚠️ Ja \
-**Kosten für Reservierung:** 5€
+**Kosten für Reservierung:** 5 €
 {{% /expander %}}
 
 {{% expander "Intercidades (IC) ⚠️" traincategory "category" %}}
@@ -44,7 +44,7 @@ FIP Freifahrtscheine (egal welcher Klasse) sind nur in der zweiten Klasse gülti
 Schnelle nationale Züge mit Reisezugwagen, welche auf den Hauptrelationen verkehren. Die Züge bieten Wi-Fi, Steckdosen an manchen Plätzen in der ersten Klasse sowie ein Bistroangebot. \
 **Reservierung möglich:** Ja \
 **Reservierungspflicht:** ⚠️ Ja \
-**Kosten für Reservierung:** 5€
+**Kosten für Reservierung:** 5 €
 {{% /expander %}}
 
 {{% expander "Serviço InterRegional (IR)" traincategory "category" %}}
@@ -77,7 +77,7 @@ Das [Liniennetz](https://www.cp.pt/info/documents/d/cp/ligacao-cp-metro-lisboa-b
 
 Der Zugang zur Sintra-Linie und Cascais-Linie erfolgt über Ticketschranken.
 
-- Fahrgäste mit ermäßigten Tickets müssen ein Viva Viagem-Ticket für 0,50€ kaufen, um die Ticketschranke passieren zu können.
+- Fahrgäste mit ermäßigten Tickets müssen ein Viva Viagem-Ticket für 0,50 € kaufen, um die Ticketschranke passieren zu können.
 - Fahrgäste mit FIP Freifahrtschein müssen am Zugangspunkt (zwischen 6:00 und 22:00 Uhr) die Hilfe-Taste drücken. Der Anruf wird von einem Mitarbeitenden entgegengenommen, der den Zugang freigibt.
   {{% /highlight %}}
 
@@ -102,7 +102,7 @@ Das Liniennetz umfasst eine Linie zwischen Coimbra und Figueira da Foz.
 Der Celta ist ein internationaler Kooperationszug zwischen der CP und der spanischen Renfe von Porto nach Vigo. FIP Freifahrtscheine werden nicht anerkannt. \
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
-**FIP Globalpreis (Distanzunabhängig):** 4€
+**FIP Globalpreis (Distanzunabhängig):** 4 €
 {{% /expander %}}
 
 ## Klassenkategorien
@@ -122,7 +122,7 @@ Wenn keine Verkaufsstelle der CP am Startbahnhof vorhanden ist oder mehr als 24 
 
 ## Ermäßigungen
 
-Kinder unter 4 Jahren reisen kostenlos ohne eigenen Sitzplatz. Für Kinder unter 12 Jahren gilt eine Ermäßigung von 50%. Ab 12 Jahren wird der volle Preis berechnet. [^1]
+Kinder unter 4 Jahren reisen kostenlos ohne eigenen Sitzplatz. Für Kinder unter 12 Jahren gilt eine Ermäßigung von 50 %. Ab 12 Jahren wird der volle Preis berechnet. [^1]
 
 ## Tarifliche Besonderheiten
 
@@ -133,7 +133,7 @@ Passagiere mit einem in Portugal erworbenen FIP-Ermäßigungsticket dürfen ihre
 ## Empfehlungen
 
 {{% highlight tip %}}
-Bei einer Reise durch Portugal bietet sich ein Besuch des Nationalen Eisenbahnmuseums in Entroncamento an. Besuchende, die mit dem Zug anreisen, erhalten 50% Rabatt auf den Eintrittspreis. [^2]
+Bei einer Reise durch Portugal bietet sich ein Besuch des Nationalen Eisenbahnmuseums in Entroncamento an. Besuchende, die mit dem Zug anreisen, erhalten 50 % Rabatt auf den Eintrittspreis. [^2]
 
 [Weitere Informationen zum Museum](https://www.fmnf.pt/apps/frontend/public/static/site/MNF_DE.pdf) <!-- Link austauschen für jeweilige Sprache -->
 {{% /highlight %}}

--- a/content/operator/db/index.de.md
+++ b/content/operator/db/index.de.md
@@ -79,8 +79,8 @@ Ein internationaler Expresszug zwischen Frankfurt und Mailand sowie zwischen Mü
 
 **Aufschlag/Reservierung Italien:**
 
-- 1\. Klasse: 13€
-- 2\. Klasse: 11€
+- 1\. Klasse: 13 €
+- 2\. Klasse: 11 €
 
 **Reservierung möglich:** Ja \
 **Reservierungspflicht:** Bei grenzüberschreitenden Fahrten nach Italien und der Hochsainson nach Dänemark ⚠️
@@ -235,7 +235,7 @@ In folgendem Beispiel liegt die gewählte Verbindung im Verkehrsverbund _VRS_:
 
 ### Tarifliche Unterscheidung zwischen Nah- und Fernverkehr
 
-Bei FIP 50 Tickets können flexibel Züge auf der gleichen Strecke genutzt werden. Dabei muss aber auf die Zugkategorien geachten werden, da bei der DB wird zwischen Fahrkarten für verschiedene Zugkategorien unterschieden (sogenannte [_Produktklassen_](https://de.wikipedia.org/wiki/Preissystem_der_Deutschen_Bahn#Produktklassen)) wird. Fahrkarten (auch FIP 50 Tickets) gelten nur in der gleichen und niedriegen Produktklassen. Die Produktklasse ist auf Fahrkarten vermerkt (z.B. _ICE Fahrkarte_ oder _IC/EC Fahrkarte_) und richtet sich nach der höchsten Zugkategorie auf der gebuchten Verbindung.
+Bei FIP 50 Tickets können flexibel Züge auf der gleichen Strecke genutzt werden. Dabei muss aber auf die Zugkategorien geachten werden, da bei der DB wird zwischen Fahrkarten für verschiedene Zugkategorien unterschieden (sogenannte [_Produktklassen_](https://de.wikipedia.org/wiki/Preissystem_der_Deutschen_Bahn#Produktklassen)) wird. Fahrkarten (auch FIP 50 Tickets) gelten nur in der gleichen und niedriegen Produktklassen. Die Produktklasse ist auf Fahrkarten vermerkt (z. B. _ICE Fahrkarte_ oder _IC/EC Fahrkarte_) und richtet sich nach der höchsten Zugkategorie auf der gebuchten Verbindung.
 
 Es gibt folgende Produktklassen:
 

--- a/content/operator/renfe/index.de.md
+++ b/content/operator/renfe/index.de.md
@@ -40,9 +40,9 @@ Die internationalen AVE von / nach Frankreich sind zu den gleichen Konditionen w
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
 **FIP Globalpreis (Distanzunabhängig):** \
-Elige: 10€ \
-Elige Confort: 13€ \
-Premium: 23,50€
+Elige: 10 € \
+Elige Confort: 13 € \
+Premium: 23,50 €
 {{% /expander %}}
 
 {{% expander "Avlo ⛔⚠️" traincategory "long-distance" %}}
@@ -59,9 +59,9 @@ Umspurbare Hochgeschwindigkeitszüge (Figueres <-> Alicante). FIP Freifahrtschei
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
 **FIP Globalpreis (Distanzunabhängig):** \
-Elige: 6,50€ \
-Elige Confort: 10€ \
-Premium: 23,50€
+Elige: 6,50 € \
+Elige Confort: 10 € \
+Premium: 23,50 €
 {{% /expander %}}
 
 {{% expander "Alvia ⚠️" traincategory "long-distance" %}}
@@ -70,8 +70,8 @@ Umspurbare Hochgeschwindigkeitszüge (bis 250 km/h). FIP Freifahrtscheine werden
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
 **FIP Globalpreis (Distanzunabhängig):** \
-Elige: 6,50€ \
-Elige Confort: 10€
+Elige: 6,50 € \
+Elige Confort: 10 €
 {{% /expander %}}
 
 {{% expander "Intercity (IC) ⚠️" traincategory "long-distance" %}}
@@ -80,8 +80,8 @@ Reisezüge zwischen Regional- und Hochgeschwindkeitsverkehr (bis 250 km/h). FIP 
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
 **FIP Globalpreis (Distanzunabhängig):** \
-Elige: 6,50€ \
-Elige Confort: 10€
+Elige: 6,50 € \
+Elige Confort: 10 €
 {{% /expander %}}
 
 {{% expander "Celta: Porto - Vigo ⚠️" traincategory "long-distance" %}}
@@ -89,7 +89,7 @@ Elige Confort: 10€
 Der Celta ist ein internationaler Kooperationszug zwischen der Renfe und der portugiesischen CP von Porto nach Vigo. FIP Freifahrtscheine werden nicht anerkannt. \
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
-**FIP Globalpreis (Distanzunabhängig):** 4€
+**FIP Globalpreis (Distanzunabhängig):** 4 €
 {{% /expander %}}
 
 ### Mittelstrecke
@@ -99,7 +99,7 @@ Der Celta ist ein internationaler Kooperationszug zwischen der Renfe und der por
 Hochgeschwindkeitszüge, Reisedauer < 90 Minuten. FIP Freifahrtscheine werden nicht anerkannt. \
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja \
-**FIP Globalpreis (Distanzunabhängig):** 4€
+**FIP Globalpreis (Distanzunabhängig):** 4 €
 {{% /expander %}}
 
 {{% expander "MD ⚠️" traincategory "middle-distance" %}}
@@ -107,7 +107,7 @@ Hochgeschwindkeitszüge, Reisedauer < 90 Minuten. FIP Freifahrtscheine werden ni
 Beschleunigter Regionalverkehr. FIP Freifahrtscheine werden nur auf nicht reservierungspflichtigen Zügen dieser Kategorie anerkannt. Aktuell ist das nur auf der Route Barcelona(-Girona-Figueres)-Port Bou der Fall. \
 **Reservierung möglich:** ja \
 **Reservierungspflicht:** ⚠️ ja (Außnahme: Route Barcelona(-Girona-Figueres)-Port Bou[^1]) \
-**FIP Globalpreis (Distanzunabhängig):** 4€
+**FIP Globalpreis (Distanzunabhängig):** 4 €
 {{% /expander %}}
 
 ### Nahverkehr

--- a/content/operator/sbb/index.de.md
+++ b/content/operator/sbb/index.de.md
@@ -62,8 +62,8 @@ Internationale Züge Richtung Deutschland und Italien.
 
 #### Reservierung
 
-1\. Klasse: 13€ \
-2\. Klasse: 11€
+1\. Klasse: 13 € \
+2\. Klasse: 11 €
 
 Für den italienischen Abschnitt sind eine Reservierung und ein Zuschlag erforderlich. Günstiger ist die Fahrt Richtung Italien mit Umstieg in Chiasso ([Siehe Anreise Italien](/country/switzerland#italien "Anreise Italien")). Der Zuschlag kann am SBB Ticketschalter oder im Zug erworben werden.
 

--- a/content/operator/sncb/index.de.md
+++ b/content/operator/sncb/index.de.md
@@ -48,7 +48,7 @@ Internationaler, zuschlagspflichtiger Zug zwischen Lelystad, Amsterdam und Brüs
 **Reservierungspflicht:** nein \
 **Zuschlag**: ⚠️ \
 Zwischen Rotterdam und Schiphol ist ein [Zuschlag](https://www.ns.nl/en/season-tickets/other/intercity-direct-supplement.html) zum FIP 50 Ticket und FIP Freifahrtschein in Höhe von 3 € zu entrichten. \
-Dieser kann [Online](https://www.ns.nl/en/tickets/icd-supplement) bzw. in der NS-App oder vor Ort am Automaten bzw. Schalter gekauft werden. Dort kann der Aufschlag auf eine OV-Chipkarte geladen werden. Ohne OV-Chipkarte für eine zusätzliche Gebühr von 1,50€ für ein Einmalticket erhoben.
+Dieser kann [Online](https://www.ns.nl/en/tickets/icd-supplement) bzw. in der NS-App oder vor Ort am Automaten bzw. Schalter gekauft werden. Dort kann der Aufschlag auf eine OV-Chipkarte geladen werden. Ohne OV-Chipkarte für eine zusätzliche Gebühr von 1,50 € für ein Einmalticket erhoben.
 Inhaber einer OV-Chipkarte können am Zuschlagsschalter im Bahnhof zu [Off-Peak Zeiten](https://www.ns.nl/en/travel-information/off-peak-hours.html) einen vergünstigten Zuschlag für 1,80 € erwerben. \
 Bei FIP 50 Tickets kommt es allgemein zu abweichenden Preisen für die Zugkategorie.
 {{% /expander %}}
@@ -130,7 +130,7 @@ Ist kein Schalter vorhanden oder dieser nicht geöffnet, kann an Bord des Zuges 
 
 ## Ermäßigungen
 
-Kinder bis 5 Jahren reisen kostenlos in den Zügen der SNCB. Kinder im Alter von 6 bis 11 Jahren sind berechtigt für ein Rabatt von 50% auf den Erwachsenen-Tarif, ab 12 zahlen sie den Erwachsenen-Tarif. Sind sie FIP-berechtigt, zahlen sie entsprechend hier auch bei FIP 50 nur die Hälfte des Normalpreises.[^1]
+Kinder bis 5 Jahren reisen kostenlos in den Zügen der SNCB. Kinder im Alter von 6 bis 11 Jahren sind berechtigt für ein Rabatt von 50 % auf den Erwachsenen-Tarif, ab 12 zahlen sie den Erwachsenen-Tarif. Sind sie FIP-berechtigt, zahlen sie entsprechend hier auch bei FIP 50 nur die Hälfte des Normalpreises.[^1]
 
 ## Tarifliche Besonderheiten
 

--- a/content/operator/sncf/index.de.md
+++ b/content/operator/sncf/index.de.md
@@ -276,7 +276,7 @@ Für Fahrten innerhalb Frankreichs gelten die normalen inländischen `TGV` Reser
   fip_accepted=partially
   reservation_required=true
 %}}
-Grenzüberschreitende `TGV` Verbindungen von Frankreich nach Italien, Spanien oder Belgien sind im gesamten Abschnitt reservierungspflichtig und es gelten keine FIP Freifahrtscheine. Stattdessen können FIP Globalpreise erworben werden. Diese können jedoch teilweise sehr teuer sein (bis zu 130€).
+Grenzüberschreitende `TGV` Verbindungen von Frankreich nach Italien, Spanien oder Belgien sind im gesamten Abschnitt reservierungspflichtig und es gelten keine FIP Freifahrtscheine. Stattdessen können FIP Globalpreise erworben werden. Diese können jedoch teilweise sehr teuer sein (bis zu 130 €).
 {{% /train-category %}}
 
 {{% train-category

--- a/styleguide_de.md
+++ b/styleguide_de.md
@@ -25,6 +25,8 @@ Ein praxisorientierter Leitfaden für einheitliche Texte: Bindestrich/Durchkoppl
 
 **Hinweis:** Non‑breaking hyphen (U+2011) im CMS verwenden, um Zeilenumbruch zu vermeiden.
 
+**Ausnahmen:** Eigennamen und Verbindungen mit Abkürzungen von Bahngesellschaften (z. B. FIP Guide, DB Ticketschalter, SNCB Hotline)
+
 ## 2. Striche — Bindestrich vs. Gedankenstrich
 
 | Strich         | Zeichen | Unicode | Verwendung        | Beispiel                        |


### PR DESCRIPTION
Ich hab Opencode mal den Deutschen Styleguide anwenden lassen. Ich weiß nicht, ob es vollständig ist, aber es ist auf jeden Fall besser als vorher :)

Ich habe in den Stylguide auch noch eine Ausnahme aufgenommen. Bei ersten Versuch wurden nämlich alle möglichen Begriffe plötzlich mit Bindestrich geschrieben. Z. B.:

FIP Guide -> FIP-Guide
SNCF Hotline -> SNCF-Hotline
DB Reisezentrum -> DB-Reisezentrum

Ich war mir nicht sicher, bei den ganzen Buchungswegen und co. Auch bei der korrekten Schreibweise der FIP Tickets.
Also FIP-50-Ticket oder auch FIP-Freifahrtschein oder FIP Freifahrtschein. Ich passe dahingehend gerne noch was an und bin offen. Ich wollte es nur erstmal noch offen lassen :)