### PR TITLE
Remove ÖBB IC Bus (ICB) section

### DIFF
--- a/content/operator/oebb/index.de.md
+++ b/content/operator/oebb/index.de.md
@@ -17,7 +17,7 @@ Die ÖBB (Österreichische Bundesbahnen) ist die nationale Eisenbahngesellschaft
 - ÖBB akzeptiert FIP Freifahrt und FIP 50 Tickets.
 - Aufpassen bei Zügen anderer Betreiber ohne FIP Akzeptanz.
 - Kein FIP im Wiener Flughafenexpress `CAT`.
-- Besondere Regeln gelten in Zügen nach Italien, Nightjets, Autozügen und IC Bussen.
+- Besondere Regeln gelten in Zügen nach Italien, Nightjets und Autozügen.
 - FIP Freifahrt der ÖBB gilt auch in Liechtenstein.
 
 ## Gültigkeit FIP Tickets
@@ -309,18 +309,6 @@ Die Schneebergbahn ist zwar kein Teil der ÖBB oder FIP gewährt jedoch bei Vorl
 ### ÖBB Postbus
 
 FIP Fahrkarten sind im ÖBB Postbus nicht gültig, außer bei Schienenersatzverkehren (SEV).
-
-### IC Bus (ICB)
-
-FIP Fahrkarten sind im IC Bus (ICB) nicht gültig, außer bei Schienenersatzverkehren (SEV) und den folgenden Verbindungen:
-
-#### Graz – Klagenfurt
-
-Bis Dezember 2025 gelten FIP Fahrscheine auch im IC Bus zwischen Graz und Klagenfurt.
-
-#### Klagenfurt/Villach – Udine/Venedig
-
-Im IC Bus (ICB) gelten besondere FIP Globalpreise. Eine Sitzplatzreservierung ist verpflichtend und Ticketpreise enthalten.
 
 ### Motorail
 

--- a/content/operator/oebb/index.en.md
+++ b/content/operator/oebb/index.en.md
@@ -17,7 +17,7 @@ aliases:
 - ÖBB accepts FIP Coupons and FIP 50 Tickets.
 - Pay attention to trains of other operators without FIP acceptance.
 - No FIP on Vienna Airport Express `CAT`.
-- Special rules for trains to Italy, Nightjets, Motorail trains, and IC Buses.
+- Special rules for trains to Italy, Nightjets, and Motorail trains.
 - ÖBB FIP Coupon is also valid in Liechtenstein.
 
 ## Validity of FIP Tickets
@@ -318,18 +318,6 @@ The Schneebergbahn is not part of ÖBB or FIP, but showing a FIP ID gives a 50% 
 ### ÖBB Postbus
 
 FIP Tickets are not valid on ÖBB Postbus, except for rail replacement services (SEV).
-
-### IC Bus (ICB)
-
-FIP Tickets are not valid on IC Bus (ICB), except for rail replacement services (SEV) and the following routes:
-
-#### Graz – Klagenfurt
-
-Until December 2025, FIP Tickets are also valid on the IC Bus between Graz and Klagenfurt.
-
-#### Klagenfurt/Villach – Udine/Venice
-
-Special FIP Global Fares apply on IC Bus (ICB). Seat reservation is mandatory and included in the ticket price.
 
 ### Motorail
 

--- a/content/operator/oebb/index.fr.md
+++ b/content/operator/oebb/index.fr.md
@@ -17,7 +17,7 @@ Les ÖBB (Österreichische Bundesbahnen) sont la compagnie ferroviaire nationale
 - Les Coupons FIP et Billets FIP 50 sont acceptés.
 - Attention aux trains d’autres opérateurs qui n’acceptent pas FIP.
 - FIP non valable dans le train express `CAT` vers l’aéroport de Vienne.
-- Règles spécifiques pour les trains vers l’Italie, les Nightjet, les trains auto, et les IC Bus.
+- Règles spécifiques pour les trains vers l’Italie, les Nightjet et les trains auto.
 - Le Coupon FIP ÖBB est aussi valable au Liechtenstein.
 
 ## Validité des Billets FIP
@@ -319,18 +319,6 @@ La Schneebergbahn ne fait pas partie de l’ÖBB ou du FIP, mais la présentatio
 ### ÖBB Postbus
 
 Les Billets FIP ne sont pas valables sur ÖBB Postbus, sauf pour les services de remplacement ferroviaire (SEV).
-
-### IC Bus (ICB)
-
-Les Billets FIP ne sont pas valables sur IC Bus (ICB), sauf pour les services de remplacement ferroviaire (SEV) et les itinéraires suivants :
-
-#### Graz – Klagenfurt
-
-Jusqu’en décembre 2025, les Billets FIP sont également valables sur l’IC Bus entre Graz et Klagenfurt.
-
-#### Klagenfurt/Villach – Udine/Venise
-
-Des Tarifs Globaux FIP spéciaux s’appliquent sur l’IC Bus (ICB). La réservation de siège est obligatoire et incluse dans le prix du billet.
 
 ### Trains auto
 


### PR DESCRIPTION
## Summary

- Removes the entire IC Bus (ICB) section from the ÖBB operator page (de/en/fr)
- Removes IC Bus references from the summary bullet points in all three languages

The ÖBB Intercitybus no longer exists (see https://de.wikipedia.org/wiki/Intercitybus).

Closes #690