### PR TITLE
fix: mark Isle of Man, Åland and Faroe Islands as no FIP acceptance

### DIFF
--- a/content/country/_index.de.md
+++ b/content/country/_index.de.md
@@ -7,7 +7,9 @@ params:
     - Andorra
     - Belarus
     - Estland
+    - Färöer
     - Finnland
+    - Isle of Man
     - Island
     - Malta
     - Moldau
@@ -18,6 +20,7 @@ params:
     - Ukraine
     - Vatikanstadt
     - Zypern
+    - Åland
 ---
 
 Finde auf den nachfolgenden Seiten die FIP-Regelungen für Dein Reiseziel.

--- a/content/country/_index.en.md
+++ b/content/country/_index.en.md
@@ -9,8 +9,10 @@ params:
     - Belarus
     - Cyprus
     - Estonia
+    - Faroe Islands
     - Finland
     - Iceland
+    - Isle of Man
     - Malta
     - Moldova
     - Russia
@@ -19,6 +21,7 @@ params:
     - Turkey
     - Ukraine
     - Vatican City
+    - Åland Islands
 ---
 
 Find the FIP regulations for your destination on the following pages.

--- a/content/country/_index.fr.md
+++ b/content/country/_index.fr.md
@@ -10,6 +10,9 @@ params:
     - Estonie
     - Finlande
     - Islande
+    - Île de Man
+    - Îles Féroé
+    - Îles Åland
     - Malte
     - Moldavie
     - Russie

--- a/layouts/country/list.html
+++ b/layouts/country/list.html
@@ -100,15 +100,18 @@
     ];
 
     window.unavailableCountries = [
+      "aland",
       "albania",
       "algeria",
       "andorra",
       "belarus",
       "cyprus",
-      "finland",
       "estonia",
+      "faroe_islands",
+      "finland",
       "greenland",
       "iceland",
+      "isle_of_man",
       "israel",
       "lebanon",
       "malta",

--- a/static/map_europe.svg
+++ b/static/map_europe.svg
@@ -855,7 +855,7 @@
     </g>
     <g
        style="fill:#c0c1c5;fill-opacity:1;stroke:none"
-       id="gIMN"
+       id="isle_of_man"
        transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
       <path
          style="fill:#c0c1c5;fill-opacity:1;stroke:none"
@@ -917,7 +917,7 @@
        transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)"
        style="fill:#c0c1c5;fill-opacity:1;stroke:none">
       <g
-         id="gALD"
+         id="aland"
          style="fill:#c0c1c5;fill-opacity:1;stroke:none">
         <path
            id="polyF1S6P1-9"
@@ -1279,7 +1279,7 @@
     </g>
     <g
        style="fill:#c0c1c5;fill-opacity:1;stroke:none"
-       id="gFRO"
+       id="faroe_islands"
        transform="matrix(7.2635634,0,0,7.2635634,-807.13774,-1896.7703)">
       <path
          style="fill:#c0c1c5;fill-opacity:1;stroke:none"


### PR DESCRIPTION
## Summary

- Renamed SVG group IDs for Isle of Man (`gIMN` → `isle_of_man`), Åland (`gALD` → `aland`), and Faroe Islands (`gFRO` → `faroe_islands`) to match the existing naming convention
- Added all three territories to `window.unavailableCountries` in `layouts/country/list.html` so the JS applies the "No FIP acceptance" styling
- Added all three territories to the "Countries without FIP acceptance" text lists in `_index.de.md`, `_index.en.md`, and `_index.fr.md`

Closes #723