### PR TITLE
fix: removed note for stl fip coupons

### DIFF
--- a/content/operator/stl/index.de.md
+++ b/content/operator/stl/index.de.md
@@ -22,8 +22,6 @@ Die Fährverbindungen auf der irischen See werden als eigenständiger FIP-Betrei
 {{< fip-validity type="fip-coupon" status="valid" >}}
 {{< fip-validity type="fip-reduced-ticket" status="valid" >}}
 
-Der FIP Freifahrtschein für StL umfasst abweichend zum Standard maximal zwei Felder. [^1]
-
 ## Schiffskategorien und Reservierungen
 
 {{% train-category
@@ -184,8 +182,6 @@ Stena Line bietet eine tolle Möglichkeit, um vor 10 Uhr in London zu sein, wenn
 {{% /highlight %}}
 
 ## Quellen
-
-[^1]: DB Reisemarkt
 
 [^2]: [Rail Delivery Group](https://www.raildeliverygroup.com/rst/europe-and-fip.html#uk-accordion-79)
 

--- a/content/operator/stl/index.en.md
+++ b/content/operator/stl/index.en.md
@@ -22,8 +22,6 @@ The ferry connections on the Irish Sea are operated as a separate FIP operator, 
 {{< fip-validity type="fip-coupon" status="valid" >}}
 {{< fip-validity type="fip-reduced-ticket" status="valid" >}}
 
-The FIP Coupon for StL covers, deviating from the standard, a maximum of two fields. [^1]
-
 ## Ship Categories and Reservations
 
 {{% train-category
@@ -184,8 +182,6 @@ Stena Line offers a great way to be in London before 10 am if you invest a littl
 {{% /highlight %}}
 
 ## Sources
-
-[^1]: DB Reisemarkt
 
 [^2]: [Rail Delivery Group](https://www.raildeliverygroup.com/rst/europe-and-fip.html#uk-accordion-79)
 

--- a/content/operator/stl/index.fr.md
+++ b/content/operator/stl/index.fr.md
@@ -22,8 +22,6 @@ Les liaisons maritimes sur la mer d’Irlande sont exploitées comme opérateur 
 {{< fip-validity type="fip-coupon" status="valid" >}}
 {{< fip-validity type="fip-reduced-ticket" status="valid" >}}
 
-Le Coupon FIP pour StL comprend, contrairement à la norme, au maximum deux cases. [^1]
-
 ## Catégories de navires et réservations
 
 {{% train-category
@@ -182,8 +180,6 @@ Stena Line offre une excellente possibilité d’arriver à Londres avant 10h si
 {{% /highlight %}}
 
 ## Sources
-
-[^1]: DB Reisemarkt
 
 [^2]: [Rail Delivery Group](https://www.raildeliverygroup.com/rst/europe-and-fip.html#uk-accordion-79)
 


### PR DESCRIPTION
With the new fip validity dropdown the note isn’t needed anymore