### PR TITLE
build: Bump hugo version to latest version

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.155.1
+      HUGO_VERSION: 0.160.1
     steps:
       - name: Install Hugo CLI
         run: |

--- a/.github/workflows/pullrequest.yaml
+++ b/.github/workflows/pullrequest.yaml
@@ -26,7 +26,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.155.1
+      HUGO_VERSION: 0.160.1
     steps:
       - name: Install Hugo CLI
         run: |

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,5 +1,3 @@
-baseURL: "https://www.fipguide.org/"
-
 enableRobotsTXT: true
 enableGitInfo: true
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,4 +3,4 @@
   publish = "public"
 
 [build.environment]
-  HUGO_VERSION = "0.155.1"
+  HUGO_VERSION = "0.160.1"


### PR DESCRIPTION
Also remove the base URL. It breaks some references in the local environment if set. In the pipeline, it's overwritten via the `--baseURL` flag anyway.