### PR TITLE
fix: Add padding-bottom to mobile menu

### DIFF
--- a/assets/sass/navigation.scss
+++ b/assets/sass/navigation.scss
@@ -178,6 +178,7 @@ menu > li > menu {
 
     > menu {
       margin-top: 4rem;
+      padding-bottom: 1rem;
     }
 
     ul,


### PR DESCRIPTION
Add a missing padding-bottom that caused a cut-off mobile menu:

<img width="396" height="695" alt="image" src="https://github.com/user-attachments/assets/ef9ef710-510b-4cc6-b40d-2efe34096aeb" />
