### PR TITLE
fix: Preserve the language on logo click

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,7 @@
   >{{ T "skipToContent" }}</a
 >
 <a
-  href="{{ .Site.BaseURL | relLangURL }}"
+  href="{{ .Site.Home.RelPermalink }}"
   aria-label="{{ T "home-page-text" }}"
   class="o-header__logo"
 >


### PR DESCRIPTION
Avoid language switching when clicking the logo.