### PR TITLE
fix: Remove announced further VR information

### DIFF
--- a/content/news/3/index.de.md
+++ b/content/news/3/index.de.md
@@ -5,8 +5,6 @@ title: "FIP-Austritt der finnischen Staatsbahn VR"
 description: "Die finnische Bahn VR verlässt zum 1. Januar 2026 das FIP-Programm. FIP-Vergünstigungen sind dann nicht mehr gültig. Hintergründe und Ausblick."
 ---
 
-Die finnische Staatsbahn VR hat angekündigt zum Ende 2025 aus dem FIP-Programm auszutreten. Der Austritt war ursprünglich schon für 2024 geplant, wurde jedoch um ein Jahr verschoben. Ab dem 01.01.2026 sind FIP-Fahrvergünstigungen für die VR somit nicht mehr verfügbar. Ob der Austritt erneut verschoben wird ist bisher nicht bekannt.
+Die finnische Staatsbahn VR hat angekündigt, zum Ende 2025 aus dem FIP-Programm auszutreten. Der Austritt war ursprünglich schon für 2024 geplant, wurde jedoch um ein Jahr verschoben. Ab dem 01.01.2026 sind FIP-Fahrvergünstigungen für die VR somit nicht mehr verfügbar.
 
 Ursache dafür könnte der Austritt der VR aus der UIC (Union Internationale des Chemins de fer – internationaler Verband von Eisenbahnunternehmen) darstellen, um Mitgliedsbeiträge einzusparen. Offizielle Stellungnahmen seitens der VR gibt es bisher nicht. Weitere Informationen sind in [finnischen Eisenbahnforen zu finden](https://vaunut.org/keskustelut/index.php?topic=15586.0).
-
-Wir informieren über weitere Informationen sobald bekannt.

--- a/content/news/3/index.en.md
+++ b/content/news/3/index.en.md
@@ -5,8 +5,6 @@ title: "FIP withdrawal of Finnish State Railways VR"
 description: "Finnish Railways VR will leave the FIP program on January 1, 2026. FIP discounts will no longer apply. Background and future outlook here."
 ---
 
-The Finnish State Railways VR has announced its withdrawal from the FIP program by the end of 2025. The withdrawal was originally planned for 2024 but was postponed by one year. As of 01.01.2026, FIP travel discounts for VR will no longer be available. It is not yet known whether the withdrawal will be postponed again.
+The Finnish State Railways VR has announced its withdrawal from the FIP program by the end of 2025. The withdrawal was originally planned for 2024 but was postponed by one year. As of 01.01.2026, FIP travel discounts for VR will no longer be available.
 
 The reason for this could be VR's withdrawal from the UIC (Union Internationale des Chemins de fer – International Union of Railways) to save membership fees. There have been no official statements from VR so far. More information can be found in [Finnish railway forums](https://vaunut.org/keskustelut/index.php?topic=15586.0).
-
-We will provide further information as soon as it becomes available.

--- a/content/news/3/index.fr.md
+++ b/content/news/3/index.fr.md
@@ -5,8 +5,6 @@ title: "Retrait FIP des chemins de fer finlandais VR"
 description: "Les chemins de fer finlandais VR quitteront le programme FIP le 1er janvier 2026. Les réductions FIP ne seront plus valables. Contexte et perspectives ici."
 ---
 
-Les chemins de fer finlandais VR ont annoncé leur retrait du programme FIP à la fin de 2025. Ce retrait était initialement prévu pour 2024 mais a été reporté d’un an. À partir du 01.01.2026, les réductions FIP pour VR ne seront plus disponibles. On ne sait pas encore si le retrait sera à nouveau reporté.
+Les chemins de fer finlandais VR ont annoncé leur retrait du programme FIP à la fin de 2025. Ce retrait était initialement prévu pour 2024 mais a été reporté d’un an. À partir du 01.01.2026, les réductions FIP pour VR ne seront plus disponibles.
 
 La raison pourrait être le retrait de VR de l’UIC (Union Internationale des Chemins de fer) afin d’économiser les frais d’adhésion. Il n’y a pas encore de déclaration officielle de VR. Plus d’informations sont disponibles sur les [forums ferroviaires finlandais](https://vaunut.org/keskustelut/index.php?topic=15586.0).
-
-Nous fournirons plus d’informations dès qu’elles seront disponibles.


### PR DESCRIPTION
The VR exit did happen and we never provided any additional information. As we don't plan to do so, I have removed the corresponding sentence.