### PR TITLE
fix: Handle multi-line HTML in markdown context

### DIFF
--- a/layouts/partials/helper/stripNewlines.html
+++ b/layouts/partials/helper/stripNewlines.html
@@ -1,0 +1,1 @@
+{{ return replaceRE `\n` "" . }}

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -1,2 +1,9 @@
-<!-- prettier-ignore --><span data-pagefind-ignore="all" class="a-icon" translate="no" aria-hidden="true" data-icon="{{ . }}" style="--icon-url: url('/icons/material-symbols-rounded/{{ . }}.svg');"></span>
+<span
+  data-pagefind-ignore="all"
+  class="a-icon"
+  translate="no"
+  aria-hidden="true"
+  data-icon="{{ . }}"
+  style="--icon-url: url('/icons/material-symbols-rounded/{{ . }}.svg');"
+></span>
 {{- /* Needed, otherwise links break: https://github.com/fipguide/fipguide.github.io/issues/116 */ -}}

--- a/layouts/shortcodes/icon.html
+++ b/layouts/shortcodes/icon.html
@@ -1,1 +1,1 @@
-{{- partial "icon" (.Get 0) | safeHTML -}}
+{{- partial "icon" (.Get 0) | partial "helper/stripNewlines" | safeHTML -}}


### PR DESCRIPTION
With this change, formatting works in markdown without the need of prettier-ignore.