### PR TITLE
feat: Improve expander handling in search

### DIFF
--- a/assets/sass/booking.scss
+++ b/assets/sass/booking.scss
@@ -99,3 +99,17 @@
   flex-direction: column;
   gap: 1rem;
 }
+
+.o-booking__content {
+  h4 {
+    @extend %h3;
+  }
+
+  h5 {
+    @extend %h4;
+  }
+
+  h6 {
+    @extend %h5;
+  }
+}

--- a/assets/sass/headings.scss
+++ b/assets/sass/headings.scss
@@ -1,4 +1,4 @@
-h1 {
+%h1 {
   font-size: 3rem;
   line-height: 1.25;
   margin-bottom: 2rem;
@@ -8,7 +8,7 @@ h1 {
   break-after: avoid;
 }
 
-h2 {
+%h2 {
   font-size: 2.2rem;
   line-height: 1.25;
   margin-bottom: 1rem;
@@ -18,7 +18,7 @@ h2 {
   break-after: avoid;
 }
 
-h3 {
+%h3 {
   font-size: 2rem;
   line-height: 1.25;
   margin-bottom: 1rem;
@@ -28,7 +28,7 @@ h3 {
   break-after: avoid;
 }
 
-h4 {
+%h4 {
   font-size: 1.8rem;
   line-height: 1.25;
   margin-bottom: 1rem;
@@ -38,7 +38,7 @@ h4 {
   break-after: avoid;
 }
 
-h5 {
+%h5 {
   font-size: 1.6rem;
   line-height: 1.25;
   margin-bottom: 1rem;
@@ -48,7 +48,7 @@ h5 {
   break-after: avoid;
 }
 
-h6 {
+%h6 {
   font-size: 1.4rem;
   line-height: 1.25;
   margin-bottom: 1rem;
@@ -56,4 +56,28 @@ h6 {
   font-weight: 700;
   text-wrap: balance;
   break-after: avoid;
+}
+
+h1 {
+  @extend %h1;
+}
+
+h2 {
+  @extend %h2;
+}
+
+h3 {
+  @extend %h3;
+}
+
+h4 {
+  @extend %h4;
+}
+
+h5 {
+  @extend %h5;
+}
+
+h6 {
+  @extend %h6;
 }

--- a/assets/sass/trainCategory.scss
+++ b/assets/sass/trainCategory.scss
@@ -37,14 +37,14 @@ details.o-expander--train-category:not([open]) {
 
 .o-train-category__content {
   h4 {
-    @extend %h2;
-  }
-
-  h5 {
     @extend %h3;
   }
 
-  h6 {
+  h5 {
     @extend %h4;
+  }
+
+  h6 {
+    @extend %h5;
   }
 }

--- a/assets/sass/trainCategory.scss
+++ b/assets/sass/trainCategory.scss
@@ -37,14 +37,14 @@ details.o-expander--train-category:not([open]) {
 
 .o-train-category__content {
   h4 {
-    @extend h3;
+    @extend %h2;
   }
 
   h5 {
-    @extend h4;
+    @extend %h3;
   }
 
   h6 {
-    @extend h5;
+    @extend %h4;
   }
 }

--- a/layouts/partials/booking/booking.html
+++ b/layouts/partials/booking/booking.html
@@ -1,4 +1,7 @@
 {{- $iconMapping := dict "website" "computer" "phone" "call" "onsite" "person" "email" "mail" "machine" "confirmation_number" "socialmedia" "add_reaction" -}}
+<h4 style="display: none" id="{{ .id }}">
+  {{- .page.Title -}}
+</h4>
 <summary class="o-expander__summary o-expander__summary--booking">
   <div class="o-booking__header-content">
     <div class="o-booking__title-wrapper">
@@ -11,7 +14,7 @@
           {{- .subtitle -}}
         </div>
       {{- end }}
-      <div class="o-booking__meta">
+      <div class="o-booking__meta" data-pagefind-ignore>
         {{- $metaFields := slice
           (dict "key" "reservations" "value" .reservations "label" "booking.reservation")
           (dict "key" "fip_50" "value" .fip_50 "label" "booking.fip-50")
@@ -33,7 +36,7 @@
       </div>
     </div>
     {{- if and (ne .reservations "nil") (ne .reservations false) .classes -}}
-      <div class="o-booking__classes">
+      <div class="o-booking__classes" data-pagefind-ignore>
         <span class="o-booking__classes-title"
           >{{ T "booking.reservation-costs" }}:</span
         >
@@ -48,7 +51,7 @@
   {{- partial "icon" "keyboard_arrow_down" -}}
 </summary>
 <hr aria-hidden="true" />
-<div class="o-expander__content">
+<div class="o-expander__content o-booking__content">
   {{- if .info -}}
     <div class="o-booking__info">
       {{- .info | .original_page.RenderString -}}
@@ -68,6 +71,7 @@
       >
         {{- $sectionContent := index $section "content" -}}
         {{- $sectionFootnotePrefix := print $.page.File.ContentBaseName "-" $sectionName -}}
+        {{- $sectionContent := partial "pagefind-ignore-headings" (dict "content" $sectionContent) -}}
         {{- $sectionContent | safeHTML -}}
       </div>
     {{- end -}}

--- a/layouts/partials/pagefind-ignore-headings.html
+++ b/layouts/partials/pagefind-ignore-headings.html
@@ -1,0 +1,4 @@
+{{- $pattern := `(<h[1-6])(\s[^>]*?)?>` -}}
+{{- $replacement := `${1}${2} data-pagefind-ignore="index">` -}}
+{{- $content := replaceRE $pattern $replacement .content -}}
+{{- return $content -}}

--- a/layouts/partials/pagefind-ignore-headings.html
+++ b/layouts/partials/pagefind-ignore-headings.html
@@ -1,4 +1,4 @@
-{{- $pattern := `(<h[1-6])(\s[^>]*?)?>` -}}
-{{- $replacement := `${1}${2} data-pagefind-ignore="index">` -}}
+{{- $pattern := `(?m)^(#{1,6}\s+.+?)\s*$` -}}
+{{- $replacement := `${1} {data-pagefind-ignore="all"}` -}}
 {{- $content := replaceRE $pattern $replacement .content -}}
 {{- return $content -}}

--- a/layouts/partials/train-category.html
+++ b/layouts/partials/train-category.html
@@ -3,7 +3,13 @@
   name="train-category"
   id="{{ .id }}"
 >
-  <summary class="o-expander__summary o-expander__summary--train-category">
+  <h3 style="display: none" id="{{ .id }}">
+    {{- .title -}}
+  </h3>
+  <summary
+    class="o-expander__summary o-expander__summary--train-category"
+    data-pagefind-ignore
+  >
     <div class="o-train-category__header">
       <div class="o-train-category__title">
         {{ $iconMapping := dict
@@ -114,9 +120,11 @@
   </summary>
   <hr aria-hidden="true" />
   <div class="o-expander__content o-train-category__content">
-    {{ .content }}
+    {{- $content := partial "increase-headings" (dict "content" .content "offset" 1) -}}
+    {{- $content := partial "pagefind-ignore-headings" (dict "content" $content) -}}
+    {{- $content | safeHTML -}}
     {{- if or .route_overview_url .additional_information_url -}}
-      <div>
+      <div data-pagefind-ignore>
         {{- if .route_overview_url -}}
           {{- partial "button"
             (dict

--- a/layouts/shortcodes/booking-section.html
+++ b/layouts/shortcodes/booking-section.html
@@ -1,6 +1,6 @@
 {{- $content := .Inner -}}
 {{- $content = partial "helper/resolve-images" (dict "content" $content "page" .Page) -}}
-{{- $content = partial "increase-headings" (dict "content" $content "offset" 2) -}}
+{{- $content = partial "increase-headings" (dict "content" $content "offset" 3) -}}
 {{- $sectionName := .Get 0 -}}
 {{- $footnoteId := print .Page.File.ContentBaseName "-" $sectionName -}}
 {{- $content = partial "prefix-footnotes" (dict "content" $content "id" $footnoteId) -}}

--- a/layouts/shortcodes/booking.html
+++ b/layouts/shortcodes/booking.html
@@ -23,6 +23,6 @@
 -}}
 
 
-<details class="o-expander o-expander--booking">
+<details class="o-expander o-expander--booking" id="{{ .Get "id" }}">
   {{- partial "booking/booking" $params -}}
 </details>


### PR DESCRIPTION
Titles of booking expanders and train categories do define a hidden heading. This has a few advantages:

- The heading map is no longer broken, can be checked via the HeadingsMap extension.
- Content of the next expander doesn't count as element from the previous expander.
- Train categories and booking platforms title matches are ranked higher in the search
- If the result targets a booking or train category expander, the page automatically scrolls to it.

Similar to the already existing behaviour with train category expanders, it's now possible to link to booking platforms directly, e. g. https://deploy-preview-888--fipguide.netlify.app/de/operator/oebb/#oebb-website works now.

Resolves #887 
Resolves #462 

TODO: 

- [ ] Handle accessibility 