### PR TITLE
feat: add note to db-website bookingways

### DIFF
--- a/content/booking/db-website-fip-db/index.de.md
+++ b/content/booking/db-website-fip-db/index.de.md
@@ -52,3 +52,7 @@ Der Reservierungspreis wird pro Reise berechnet. So muss bei Verbindungen mit Um
 
 ![DB Reservierung buchen](db_reservation.webp)
 {{% /booking-section %}}
+
+{{% highlight "important" %}}
+Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Dies kann z. B. bei Fahrten mit PKP Intercity auf der [Betreiberwebsite](https://www.intercity.pl/en/) geprüft werden.
+{{% /highlight %}}

--- a/content/booking/db-website-fip-db/index.de.md
+++ b/content/booking/db-website-fip-db/index.de.md
@@ -54,5 +54,5 @@ Der Reservierungspreis wird pro Reise berechnet. So muss bei Verbindungen mit Um
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Dies kann z. B. bei Fahrten mit PKP Intercity auf der [Betreiberwebsite](https://www.intercity.pl/en/) geprüft werden.
+Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Bitte beachte entsprechende Vorverkaufsfristen und probiere es in diesem Fall zu einem späteren Zeitpunkt erneut, prüfe die Verbindung auf der entsprechenden Betreiberwebsite oder nutze andere Buchungswege.
 {{% /highlight %}}

--- a/content/booking/db-website-fip-db/index.en.md
+++ b/content/booking/db-website-fip-db/index.en.md
@@ -52,3 +52,7 @@ Seat reservations can be purchased via the Deutsche Bahn website. To do so, sele
 
 ![Book DB reservation](db_reservation.webp)
 {{% /booking-section %}}
+
+{{% highlight "important" %}}
+If an error occurs during the booking of trains requiring reservations, it may be that reservations are not yet being sold for that connection. This can be checked, for example, for journeys with PKP Intercity on the [operator website](https://www.intercity.pl/en/).
+{{% /highlight %}}

--- a/content/booking/db-website-fip-db/index.en.md
+++ b/content/booking/db-website-fip-db/index.en.md
@@ -54,5 +54,5 @@ Seat reservations can be purchased via the Deutsche Bahn website. To do so, sele
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-If an error occurs during the booking of trains requiring reservations, it may be that reservations are not yet being sold for that connection. This can be checked, for example, for journeys with PKP Intercity on the [operator website](https://www.intercity.pl/en/).
+If an error occurs while booking trains requiring reservations, it may be that reservations are not yet available for that connection. Please observe the relevant advance booking deadlines and, in this case, try again later, check the connection on the operator's website, or use other booking methods.
 {{% /highlight %}}

--- a/content/booking/db-website-fip-db/index.fr.md
+++ b/content/booking/db-website-fip-db/index.fr.md
@@ -52,3 +52,7 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 
 ![Réserver une place DB](db_reservation.webp)
 {{% /booking-section %}}
+
+{{% highlight "important" %}}
+Si une erreur survient lors de la réservation de trains avec réservation obligatoire, il se peut que les réservations ne soient pas encore en vente pour cette liaison. Cela peut être vérifié, par exemple, pour les trajets avec PKP Intercity sur le [site web de l’opérateur](https://www.intercity.pl/en/).
+{{% /highlight %}}

--- a/content/booking/db-website-fip-db/index.fr.md
+++ b/content/booking/db-website-fip-db/index.fr.md
@@ -54,5 +54,5 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-Si une erreur survient lors de la réservation de trains avec réservation obligatoire, il se peut que les réservations ne soient pas encore en vente pour cette liaison. Cela peut être vérifié, par exemple, pour les trajets avec PKP Intercity sur le [site web de l’opérateur](https://www.intercity.pl/en/).
+Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l'opérateur ou utiliser d'autres méthodes de réservation.
 {{% /highlight %}}

--- a/content/booking/db-website-fip-international/index.de.md
+++ b/content/booking/db-website-fip-international/index.de.md
@@ -59,3 +59,7 @@ Der Reservierungspreis wird pro Reise berechnet. So muss bei Verbindungen mit Um
 
 ![DB Reservierung buchen](db_reservation.webp)
 {{% /booking-section %}}
+
+{{% highlight "important" %}}
+Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Dies kann z. B. bei Fahrten mit PKP Intercity auf der [Betreiberwebsite](https://www.intercity.pl/en/) geprüft werden.
+{{% /highlight %}}

--- a/content/booking/db-website-fip-international/index.de.md
+++ b/content/booking/db-website-fip-international/index.de.md
@@ -61,5 +61,5 @@ Der Reservierungspreis wird pro Reise berechnet. So muss bei Verbindungen mit Um
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Dies kann z. B. bei Fahrten mit PKP Intercity auf der [Betreiberwebsite](https://www.intercity.pl/en/) geprüft werden.
+Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Bitte beachte entsprechende Vorverkaufsfristen und probiere es in diesem Fall zu einem späteren Zeitpunkt erneut, prüfe die Verbindung auf der entsprechenden Betreiberwebsite oder nutze andere Buchungswege.
 {{% /highlight %}}

--- a/content/booking/db-website-fip-international/index.en.md
+++ b/content/booking/db-website-fip-international/index.en.md
@@ -59,3 +59,7 @@ Seat reservations can be purchased via the Deutsche Bahn website. To do so, sele
 
 ![Book DB reservation](db_reservation.webp)
 {{% /booking-section %}}
+
+{{% highlight "important" %}}
+If an error occurs during the booking of trains requiring reservations, it may be that reservations are not yet being sold for that connection. This can be checked, for example, for journeys with PKP Intercity on the [operator website](https://www.intercity.pl/en/).
+{{% /highlight %}}

--- a/content/booking/db-website-fip-international/index.en.md
+++ b/content/booking/db-website-fip-international/index.en.md
@@ -61,5 +61,5 @@ Seat reservations can be purchased via the Deutsche Bahn website. To do so, sele
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-If an error occurs during the booking of trains requiring reservations, it may be that reservations are not yet being sold for that connection. This can be checked, for example, for journeys with PKP Intercity on the [operator website](https://www.intercity.pl/en/).
+If an error occurs while booking trains requiring reservations, it may be that reservations are not yet available for that connection. Please observe the relevant advance booking deadlines and, in this case, try again later, check the connection on the operator's website, or use other booking methods.
 {{% /highlight %}}

--- a/content/booking/db-website-fip-international/index.fr.md
+++ b/content/booking/db-website-fip-international/index.fr.md
@@ -59,3 +59,7 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 
 ![Réserver une place DB](db_reservation.webp)
 {{% /booking-section %}}
+
+{{% highlight "important" %}}
+Si une erreur survient lors de la réservation de trains avec réservation obligatoire, il se peut que les réservations ne soient pas encore en vente pour cette liaison. Cela peut être vérifié, par exemple, pour les trajets avec PKP Intercity sur le [site web de l’opérateur](https://www.intercity.pl/en/).
+{{% /highlight %}}

--- a/content/booking/db-website-fip-international/index.fr.md
+++ b/content/booking/db-website-fip-international/index.fr.md
@@ -61,5 +61,5 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-Si une erreur survient lors de la réservation de trains avec réservation obligatoire, il se peut que les réservations ne soient pas encore en vente pour cette liaison. Cela peut être vérifié, par exemple, pour les trajets avec PKP Intercity sur le [site web de l’opérateur](https://www.intercity.pl/en/).
+Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l'opérateur ou utiliser d'autres méthodes de réservation.
 {{% /highlight %}}

--- a/content/booking/db-website/index.de.md
+++ b/content/booking/db-website/index.de.md
@@ -26,3 +26,7 @@ Der Reservierungspreis wird pro Reise berechnet. So muss bei Verbindungen mit Um
 
 ![DB Reservierung buchen](db_reservation.webp)
 {{% /booking-section %}}
+
+{{% highlight "important" %}}
+Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Dies kann z. B. bei Fahrten mit PKP Intercity auf der [Betreiberwebsite](https://www.intercity.pl/en/) geprüft werden.
+{{% /highlight %}}

--- a/content/booking/db-website/index.de.md
+++ b/content/booking/db-website/index.de.md
@@ -28,5 +28,5 @@ Der Reservierungspreis wird pro Reise berechnet. So muss bei Verbindungen mit Um
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Dies kann z. B. bei Fahrten mit PKP Intercity auf der [Betreiberwebsite](https://www.intercity.pl/en/) geprüft werden.
+Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Bitte beachte entsprechende Vorverkaufsfristen und probiere es in diesem Fall zu einem späteren Zeitpunkt erneut, prüfe die Verbindung auf der entsprechenden Betreiberwebsite oder nutze andere Buchungswege.
 {{% /highlight %}}

--- a/content/booking/db-website/index.en.md
+++ b/content/booking/db-website/index.en.md
@@ -26,3 +26,7 @@ Seat reservations can be purchased via the Deutsche Bahn website. To do so, sele
 
 ![Book DB reservation](db_reservation.webp)
 {{% /booking-section %}}
+
+{{% highlight "important" %}}
+If an error occurs during the booking of trains requiring reservations, it may be that reservations are not yet being sold for that connection. This can be checked, for example, for journeys with PKP Intercity on the [operator website](https://www.intercity.pl/en/).
+{{% /highlight %}}

--- a/content/booking/db-website/index.en.md
+++ b/content/booking/db-website/index.en.md
@@ -28,5 +28,5 @@ Seat reservations can be purchased via the Deutsche Bahn website. To do so, sele
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-If an error occurs during the booking of trains requiring reservations, it may be that reservations are not yet being sold for that connection. This can be checked, for example, for journeys with PKP Intercity on the [operator website](https://www.intercity.pl/en/).
+If an error occurs while booking trains requiring reservations, it may be that reservations are not yet available for that connection. Please observe the relevant advance booking deadlines and, in this case, try again later, check the connection on the operator's website, or use other booking methods.
 {{% /highlight %}}

--- a/content/booking/db-website/index.fr.md
+++ b/content/booking/db-website/index.fr.md
@@ -26,3 +26,7 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 
 ![Réserver une place DB](db_reservation.webp)
 {{% /booking-section %}}
+
+{{% highlight "important" %}}
+Si une erreur survient lors de la réservation de trains avec réservation obligatoire, il se peut que les réservations ne soient pas encore en vente pour cette liaison. Cela peut être vérifié, par exemple, pour les trajets avec PKP Intercity sur le [site web de l’opérateur](https://www.intercity.pl/en/).
+{{% /highlight %}}

--- a/content/booking/db-website/index.fr.md
+++ b/content/booking/db-website/index.fr.md
@@ -28,5 +28,5 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-Si une erreur survient lors de la réservation de trains avec réservation obligatoire, il se peut que les réservations ne soient pas encore en vente pour cette liaison. Cela peut être vérifié, par exemple, pour les trajets avec PKP Intercity sur le [site web de l’opérateur](https://www.intercity.pl/en/).
+Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l'opérateur ou utiliser d'autres méthodes de réservation.
 {{% /highlight %}}


### PR DESCRIPTION
Booking on the DB website fails if the reservations of trains, where reservations are required, aren’t available yet. It can be checked on the e. g. PKP Website. I’ve added an highlight-note to the relevant booking ways.