### PR TITLE
feat: Map old booking platform links to operator pages

### DIFF
--- a/content/operator/_index.de.md
+++ b/content/operator/_index.de.md
@@ -1,6 +1,9 @@
 ---
 title: "Übersicht der Betreiber"
 description: "Übersicht über die Betreiber, die FIP-Vergünstigungen anbieten."
+
+aliases:
+  - /booking
 ---
 
 Finde auf den nachfolgenden Seiten die FIP-Regelungen für Deinen gewünschten Betreiber.

--- a/content/operator/_index.en.md
+++ b/content/operator/_index.en.md
@@ -1,6 +1,9 @@
 ---
 title: "Overview of operators"
 description: "Overview of the operators providing FIP benefits."
+
+aliases:
+  - /booking
 ---
 
 Find the FIP regulations for your desired operator on the following pages.

--- a/content/operator/_index.fr.md
+++ b/content/operator/_index.fr.md
@@ -1,6 +1,9 @@
 ---
 title: "Liste des opérateurs"
 description: "Liste des opérateurs acceptant les réductions FIP."
+
+aliases:
+  - /booking
 ---
 
 Retrouvez les règles FIP pour l’opérateur souhaité sur les pages suivantes.

--- a/content/operator/attica/index.de.md
+++ b/content/operator/attica/index.de.md
@@ -5,6 +5,11 @@ country:
   - "greece"
   - "italy"
 operator: "attica"
+
+aliases:
+  - /booking/attica-agents
+  - /booking/attica-email
+  - /booking/attica-phone
 ---
 
 Die Attica Group ist ein großer griechischer Fähranbieter und Betreiber mehrerer Marken, darunter Superfast Ferries, Blue Star Ferries, Hellenic Seaways und Anek Lines. Das Unternehmen betreibt nationale sowie internationale Schiffsverbindungen zwischen dem griechischen Festland, Italien und den griechischen Inseln.

--- a/content/operator/attica/index.en.md
+++ b/content/operator/attica/index.en.md
@@ -5,6 +5,11 @@ country:
   - "greece"
   - "italy"
 operator: "attica"
+
+aliases:
+  - /booking/attica-agents
+  - /booking/attica-email
+  - /booking/attica-phone
 ---
 
 The Attica Group is a major Greek ferry operator running several brands, including Superfast Ferries, Blue Star Ferries, Hellenic Seaways and Anek Lines. The company operates domestic and international shipping services between the Greek mainland, Italy and the Greek islands.

--- a/content/operator/attica/index.fr.md
+++ b/content/operator/attica/index.fr.md
@@ -5,6 +5,11 @@ country:
   - "greece"
   - "italy"
 operator: "attica"
+
+aliases:
+  - /booking/attica-agents
+  - /booking/attica-email
+  - /booking/attica-phone
 ---
 
 Le groupe Attica est un important opérateur grec de ferries exploitant plusieurs marques, dont Superfast Ferries, Blue Star Ferries, Hellenic Seaways et Anek Lines. L'entreprise exploite des liaisons maritimes nationales et internationales entre la Grèce continentale, l'Italie et les îles grecques.

--- a/content/operator/bdz/index.de.md
+++ b/content/operator/bdz/index.de.md
@@ -4,6 +4,9 @@ title: "BDŽ"
 country:
   - "bulgaria"
 operator: "bdz"
+
+aliases:
+  - /booking/bdz-ticket-office
 ---
 
 Die Balgarski Darschawni Schelesnizi (BDŽ) ist die staatliche Eisenbahngesellschaft von [Bulgarien](/country/bulgaria "Bulgarien") und betreibt derzeit fast alle Verbindungen im Personenverkehr auf dem bulgarischen Schienennetz.

--- a/content/operator/bdz/index.en.md
+++ b/content/operator/bdz/index.en.md
@@ -4,6 +4,9 @@ title: "BDŽ"
 country:
   - "bulgaria"
 operator: "bdz"
+
+aliases:
+  - /booking/bdz-ticket-office
 ---
 
 Balgarski Darschawni Schelesnizi (BDŽ) is the state railway company of [Bulgaria](/country/bulgaria "Bulgaria") and currently operates almost all passenger services on the Bulgarian rail network.

--- a/content/operator/bdz/index.fr.md
+++ b/content/operator/bdz/index.fr.md
@@ -4,6 +4,9 @@ title: "BDŽ"
 country:
   - "bulgaria"
 operator: "bdz"
+
+aliases:
+  - /booking/bdz-ticket-office
 ---
 
 Balgarski Darschawni Schelesnizi (BDŽ) est la compagnie ferroviaire nationale de [Bulgarie](/country/bulgaria "Bulgarie") et exploite actuellement presque tous les services voyageurs sur le réseau ferroviaire bulgare.

--- a/content/operator/bls/index.de.md
+++ b/content/operator/bls/index.de.md
@@ -3,6 +3,9 @@ draft: false
 title: "BLS"
 country:
   - "switzerland"
+
+aliases:
+  - /booking/bls-ticket-office
 ---
 
 Die BLS (ehemals Bern-Lötschberg-Simplon-Bahn) ist eine öffentliche Eisenbahngesellschaft in der [Schweiz](/country/switzerland "Schweiz"). Sie betreibt viele Zug-, Bus- und Schiffsverbindungen und fährt primär im Kanton Bern.

--- a/content/operator/bls/index.en.md
+++ b/content/operator/bls/index.en.md
@@ -3,6 +3,9 @@ draft: false
 title: "BLS"
 country:
   - "switzerland"
+
+aliases:
+  - /booking/bls-ticket-office
 ---
 
 The BLS (formerly Bern-Lötschberg-Simplon-Bahn) is a public railway company in [Switzerland](/country/switzerland "Switzerland"). It operates many train, bus and ship connections and primarily runs in the Canton of Bern.

--- a/content/operator/bls/index.fr.md
+++ b/content/operator/bls/index.fr.md
@@ -3,6 +3,9 @@ draft: false
 title: "BLS"
 country:
   - "switzerland"
+
+aliases:
+  - /booking/bls-ticket-office
 ---
 
 La BLS (anciennement Bern-Lötschberg-Simplon-Bahn) est une entreprise ferroviaire publique de la [Suisse](/country/switzerland "Suisse"). Elle exploite de nombreuses liaisons de trains, de bus et de bateaux et circule principalement dans le canton de Berne.

--- a/content/operator/bsb/index.de.md
+++ b/content/operator/bsb/index.de.md
@@ -6,6 +6,9 @@ country:
   - "germany"
   - "switzerland"
 operator: "bsb"
+
+aliases:
+  - /booking/bsb-ticket-office
 ---
 
 Die BSB - Bodensee-Schiffsbetriebe (Vereinigten Schifffahrtsunternehmen für den Bodensee und Rhein) betreiben die Fähren auf dem Bodensee zwischen [Deutschland](/country/germany "Deutschland"), [Österreich](/country/austria "Österreich") und der [Schweiz](/country/switzerland "Schweiz").

--- a/content/operator/bsb/index.en.md
+++ b/content/operator/bsb/index.en.md
@@ -6,6 +6,9 @@ country:
   - "germany"
   - "switzerland"
 operator: "bsb"
+
+aliases:
+  - /booking/bsb-ticket-office
 ---
 
 BSB - Bodensee-Schiffsbetriebe (Vereinigten Schifffahrtsunternehmen für den Bodensee und Rhein) operate the ferries on Lake Constance between [Germany](/country/germany "Germany"), [Austria](/country/austria "Austria"), and [Switzerland](/country/switzerland "Switzerland").

--- a/content/operator/bsb/index.fr.md
+++ b/content/operator/bsb/index.fr.md
@@ -6,6 +6,9 @@ country:
   - "germany"
   - "switzerland"
 operator: "bsb"
+
+aliases:
+  - /booking/bsb-ticket-office
 ---
 
 Les BSB - Bodensee-Schiffsbetriebe (Vereinigten Schifffahrtsunternehmen für den Bodensee und Rhein) exploitent les ferries sur le lac de Constance entre l’[Allemagne](/country/germany "Allemagne"), l’[Autriche](/country/austria "Autriche") et la [Suisse](/country/switzerland "Suisse").

--- a/content/operator/cd/index.de.md
+++ b/content/operator/cd/index.de.md
@@ -4,6 +4,10 @@ title: "ČD"
 country:
   - "czechia"
 operator: "cd"
+
+aliases:
+  - /booking/cd-ticket-office
+  - /booking/cd-website
 ---
 
 Die České dráhy (ČD) ist die staatliche Eisenbahngesellschaft der [Tschechischen Republik](/country/czechia "Tschechischen Republik") und betreibt einen großen Teil der Verbindungen im Personenverkehr auf dem tschechischen Schienennetz.

--- a/content/operator/cd/index.en.md
+++ b/content/operator/cd/index.en.md
@@ -4,6 +4,10 @@ title: "ČD"
 country:
   - "czechia"
 operator: "cd"
+
+aliases:
+  - /booking/cd-ticket-office
+  - /booking/cd-website
 ---
 
 České dráhy (ČD) is the state railway company of the [Czech Republic](/country/czechia "Czech Republic") and operates a large part of passenger services on the Czech rail network.

--- a/content/operator/cd/index.fr.md
+++ b/content/operator/cd/index.fr.md
@@ -4,6 +4,10 @@ title: "ČD"
 country:
   - "czechia"
 operator: "cd"
+
+aliases:
+  - /booking/cd-ticket-office
+  - /booking/cd-website
 ---
 
 České dráhy (ČD) est la compagnie ferroviaire nationale de la [République tchèque](/country/czechia "République tchèque") et exploite une grande partie des services voyageurs sur le réseau ferroviaire tchèque.

--- a/content/operator/cfl/index.de.md
+++ b/content/operator/cfl/index.de.md
@@ -4,6 +4,10 @@ title: "CFL"
 country:
   - "luxembourg"
 operator: "cfl"
+
+aliases:
+  - /booking/cfl-phone
+  - /booking/cfl-ticket-office
 ---
 
 Die CFL (Société nationale des chemins de fer luxembourgeois) ist die luxemburgische Staatsbahn und die wichtigste Bahngesellschaft in [Luxemburg](/country/luxembourg "Luxemburg").

--- a/content/operator/cfl/index.en.md
+++ b/content/operator/cfl/index.en.md
@@ -4,6 +4,10 @@ title: "CFL"
 country:
   - "luxembourg"
 operator: "cfl"
+
+aliases:
+  - /booking/cfl-phone
+  - /booking/cfl-ticket-office
 ---
 
 CFL (Société nationale des chemins de fer luxembourgeois) is the Luxembourgish state railway and the main railway company in [Luxembourg](/country/luxembourg "Luxembourg").

--- a/content/operator/cfl/index.fr.md
+++ b/content/operator/cfl/index.fr.md
@@ -4,6 +4,10 @@ title: "CFL"
 country:
   - "luxembourg"
 operator: "cfl"
+
+aliases:
+  - /booking/cfl-phone
+  - /booking/cfl-ticket-office
 ---
 
 La CFL (Société nationale des chemins de fer luxembourgeois) est la compagnie ferroviaire nationale du [Luxembourg](/country/luxembourg "Luxembourg") et la principale société ferroviaire du pays.

--- a/content/operator/cfr/index.de.md
+++ b/content/operator/cfr/index.de.md
@@ -4,6 +4,9 @@ title: "CFR Călători"
 country:
   - "romania"
 operator: "cfr"
+
+aliases:
+  - /booking/cfr-ticket-office
 ---
 
 Die Societatea Natională de Transport Feroviar de Călători “CFR Călători” S.A., kurz CFR Călători ist die staatliche Eisenbahngesellschaft von [Rumänien](/country/romania "Rumänien") und betreibt einen Großteil der Verbindungen im Personenverkehr auf dem rumänischen Schienennetz.

--- a/content/operator/cfr/index.en.md
+++ b/content/operator/cfr/index.en.md
@@ -4,6 +4,9 @@ title: "CFR Călători"
 country:
   - "romania"
 operator: "cfr"
+
+aliases:
+  - /booking/cfr-ticket-office
 ---
 
 The Societatea Natională de Transport Feroviar de Călători "CFR Călători" S.A., or CFR Călători for short, is the state railway company of [Romania](/country/romania "Romania") and operates the majority of passenger services on the Romanian rail network.

--- a/content/operator/cfr/index.fr.md
+++ b/content/operator/cfr/index.fr.md
@@ -4,6 +4,9 @@ title: "CFR Călători"
 country:
   - "romania"
 operator: "cfr"
+
+aliases:
+  - /booking/cfr-ticket-office
 ---
 
 La Societatea Natională de Transport Feroviar de Călători « CFR Călători » S.A., en abrégé CFR Călători, est la compagnie ferroviaire nationale de [Roumanie](/country/romania "Roumanie") et exploite la majorité des services voyageurs sur le réseau ferroviaire roumain.

--- a/content/operator/cie/index.de.md
+++ b/content/operator/cie/index.de.md
@@ -4,6 +4,10 @@ title: "CIE"
 country:
   - "ireland"
 operator: "cie"
+
+aliases:
+  - /booking/irish-rail-ticket-office
+  - /booking/irish-rail-website
 ---
 
 Córas lompair Éireann (CIE) ist die staatliche Bahngesellschaft [Irlands](/country/ireland) und das Mutterunternehmen von Irish Rail (Iarnród Éireann). Die Tochtergesellschaft betreibt den Großteil des Schienenverkehrs in der Republik Irland, einschließlich der Hauptstrecken zwischen Dublin, Cork, Galway und Limerick sowie regionaler Verbindungen in der Gegend von Dublin und Cork.

--- a/content/operator/cie/index.en.md
+++ b/content/operator/cie/index.en.md
@@ -4,6 +4,10 @@ title: "CIE"
 country:
   - "ireland"
 operator: "cie"
+
+aliases:
+  - /booking/irish-rail-ticket-office
+  - /booking/irish-rail-website
 ---
 
 Córas Iompair Éireann (CIE) is the state railway company of [Ireland](/country/ireland) and the parent company of Irish Rail (Iarnród Éireann). The subsidiary operates the majority of rail services in the Republic of Ireland, including the main routes between Dublin, Cork, Galway and Limerick, as well as regional connections in the Dublin and Cork areas.

--- a/content/operator/cie/index.fr.md
+++ b/content/operator/cie/index.fr.md
@@ -4,6 +4,10 @@ title: "CIE"
 country:
   - "ireland"
 operator: "cie"
+
+aliases:
+  - /booking/irish-rail-ticket-office
+  - /booking/irish-rail-website
 ---
 
 Córas Iompair Éireann (CIE) est la compagnie ferroviaire nationale d'[Irlande](/country/ireland) et la société mère d'Irish Rail (Iarnród Éireann). La filiale exploite la majorité du trafic ferroviaire en République d'Irlande, notamment les lignes principales entre Dublin, Cork, Galway et Limerick, ainsi que des liaisons régionales dans les environs de Dublin et Cork.

--- a/content/operator/cp/index.de.md
+++ b/content/operator/cp/index.de.md
@@ -4,6 +4,9 @@ title: "CP"
 country:
   - "portugal"
 operator: "cp"
+
+aliases:
+  - /booking/cp-ticket-office
 ---
 
 Die CP (Comboios de Portugal) ist die portugiesische Staatsbahn und die wichtigste Bahngesellschaft in [Portugal](/country/portugal "Portugal").

--- a/content/operator/cp/index.en.md
+++ b/content/operator/cp/index.en.md
@@ -4,6 +4,9 @@ title: "CP"
 country:
   - "portugal"
 operator: "cp"
+
+aliases:
+  - /booking/cp-ticket-office
 ---
 
 CP (Comboios de Portugal) is the Portuguese state railway and the main railway company in [Portugal](/country/portugal "Portugal").

--- a/content/operator/cp/index.fr.md
+++ b/content/operator/cp/index.fr.md
@@ -4,6 +4,9 @@ title: "CP"
 country:
   - "portugal"
 operator: "cp"
+
+aliases:
+  - /booking/cp-ticket-office
 ---
 
 La CP (Comboios de Portugal) est la compagnie ferroviaire nationale portugaise et la principale société de chemins de fer au [Portugal](/country/portugal "Portugal").

--- a/content/operator/db/index.de.md
+++ b/content/operator/db/index.de.md
@@ -4,6 +4,12 @@ title: "DB"
 country:
   - "germany"
 operator: "db"
+
+aliases:
+  - /booking/db-ticket-office
+  - /booking/db-website
+  - /booking/db-website-fip-db
+  - /booking/db-website-fip-international
 ---
 
 Die Deutsche Bahn (DB) ist das größte Eisenbahnverkehrsunternehmen in [Deutschland](/country/germany "Deutschland") und betreibt den Großteil des Fernverkehrs sowie viele Verbindungen im Regionalverkehr.

--- a/content/operator/db/index.en.md
+++ b/content/operator/db/index.en.md
@@ -4,6 +4,12 @@ title: "DB"
 country:
   - "germany"
 operator: "db"
+
+aliases:
+  - /booking/db-ticket-office
+  - /booking/db-website
+  - /booking/db-website-fip-db
+  - /booking/db-website-fip-international
 ---
 
 Deutsche Bahn (DB) is the largest railway company in [Germany](/country/germany "Germany"), operating most long-distance services as well as many regional connections.

--- a/content/operator/db/index.fr.md
+++ b/content/operator/db/index.fr.md
@@ -4,6 +4,12 @@ title: "DB"
 country:
   - "germany"
 operator: "db"
+
+aliases:
+  - /booking/db-ticket-office
+  - /booking/db-website
+  - /booking/db-website-fip-db
+  - /booking/db-website-fip-international
 ---
 
 La Deutsche Bahn (DB) est la plus grande entreprise ferroviaire d’[Allemagne](/country/germany "Allemagne") et exploite la majorité du trafic longue distance ainsi que de nombreuses liaisons régionales.

--- a/content/operator/dsb/index.de.md
+++ b/content/operator/dsb/index.de.md
@@ -4,6 +4,11 @@ title: "DSB"
 country:
   - "denmark"
 operator: "dsb"
+
+aliases:
+  - /booking/dsb-international-website
+  - /booking/dsb-ticket-office
+  - /booking/dsb-website
 ---
 
 Die DSB (Danske Statsbaner) ist die staatliche Eisenbahngesellschaft in [Dänemark](/country/denmark "Dänemark"). Sie betreibt den Großteil des Personenverkehrs auf dem dänischen Schienennetz.

--- a/content/operator/dsb/index.en.md
+++ b/content/operator/dsb/index.en.md
@@ -4,6 +4,11 @@ title: "DSB"
 country:
   - "denmark"
 operator: "dsb"
+
+aliases:
+  - /booking/dsb-international-website
+  - /booking/dsb-ticket-office
+  - /booking/dsb-website
 ---
 
 The DSB (Danske Statsbaner) is the state-owned railway company in [Denmark](/country/denmark "Denmark"). It operates the majority of passenger traffic on the Danish rail network.

--- a/content/operator/dsb/index.fr.md
+++ b/content/operator/dsb/index.fr.md
@@ -4,6 +4,11 @@ title: "DSB"
 country:
   - "denmark"
 operator: "dsb"
+
+aliases:
+  - /booking/dsb-international-website
+  - /booking/dsb-ticket-office
+  - /booking/dsb-website
 ---
 
 La DSB (Danske Statsbaner) est la compagnie ferroviaire publique du [Danemark](/country/denmark "Danemark"). Elle exploite la majorité du trafic voyageurs sur le réseau ferroviaire danois.

--- a/content/operator/eurostar/index.de.md
+++ b/content/operator/eurostar/index.de.md
@@ -8,6 +8,14 @@ country:
   - "united-kingdom"
   - "france"
 operator: "eurostar"
+
+aliases:
+  - /booking/eurostar-phone
+  - /booking/eurostar-ticket-office
+  - /booking/ffestiniogtravel-email
+  - /booking/ffestiniogtravel-phone
+  - /booking/internationalrail-email
+  - /booking/railtourguide-website
 ---
 
 Eurostar ist ein Betreiber von Hochgeschwindigkeitszügen in Westeuropa. Ursprünglich wurden nur die blauen Züge zwischen London und Paris/Brüssel/Amsterdam durch den Eurotunnel als Eurostar bezeichnet. Nach dem Zusammenschluss zwischen Thalys und Eurostar werden auch die roten Thalys-Züge als Eurostar (Red) bezeichnet. Eurostar verkehrt in [Deutschland](/country/germany "Deutschland"), [Frankreich](/country/france "Frankreich"), dem [Vereinigten Königreich](/country/united-kingdom "Vereinigtes Königreich"), [Belgien](/country/belgium "Belgien") und den [Niederlanden](/country/netherlands "Niederlande").

--- a/content/operator/eurostar/index.en.md
+++ b/content/operator/eurostar/index.en.md
@@ -8,6 +8,14 @@ country:
   - "united-kingdom"
   - "france"
 operator: "eurostar"
+
+aliases:
+  - /booking/eurostar-phone
+  - /booking/eurostar-ticket-office
+  - /booking/ffestiniogtravel-email
+  - /booking/ffestiniogtravel-phone
+  - /booking/internationalrail-email
+  - /booking/railtourguide-website
 ---
 
 Eurostar is an operator of high-speed trains in Western Europe. Originally, only the blue trains between London and Paris/Brussels/Amsterdam through the Eurotunnel were referred to as Eurostar. After the merger between Thalys and Eurostar, the red Thalys trains are now also referred to as Eurostar (Red). Eurostar operates in [Germany](/country/germany "Germany"), [France](/country/france "France"), the [United Kingdom](/country/united-kingdom "United Kingdom"), [Belgium](/country/belgium "Belgium"), and the [Netherlands](/country/netherlands "Netherlands").

--- a/content/operator/eurostar/index.fr.md
+++ b/content/operator/eurostar/index.fr.md
@@ -8,6 +8,14 @@ country:
   - "united-kingdom"
   - "france"
 operator: "eurostar"
+
+aliases:
+  - /booking/eurostar-phone
+  - /booking/eurostar-ticket-office
+  - /booking/ffestiniogtravel-email
+  - /booking/ffestiniogtravel-phone
+  - /booking/internationalrail-email
+  - /booking/railtourguide-website
 ---
 
 Eurostar est un opérateur de trains à grande vitesse en Europe de l’Ouest. À l’origine, seuls les trains bleus entre Londres et Paris/Bruxelles/Amsterdam via l’Eurotunnel étaient désignés comme Eurostar. Depuis la fusion entre Thalys et Eurostar, les anciens trains rouges Thalys sont désormais appelés Eurostar (Rouge). Eurostar circule en [Allemagne](/country/germany "Allemagne"), [France](/country/france "France"), au [Royaume-Uni](/country/united-kingdom "Royaume-Uni"), en [Belgique](/country/belgium "Belgique") et aux [Pays-Bas](/country/netherlands "Pays-Bas").

--- a/content/operator/euskotren/index.de.md
+++ b/content/operator/euskotren/index.de.md
@@ -4,6 +4,9 @@ title: "Euskotren"
 country:
   - "spain"
 operator: "euskotren"
+
+aliases:
+  - /booking/euskotren-ticket-office
 ---
 
 Im Norden [Spaniens](/country/spain "Spaniens") betreibt Euskotren ein Netz der baskischen Eisenbahn, das die malerischen Küstenorte und das gebirgige Hinterland zwischen der französischen Grenze bei Hendaye und der Metropole Bilbao verbindet. Euskotren gehört der baskische Regionalregierung.

--- a/content/operator/euskotren/index.en.md
+++ b/content/operator/euskotren/index.en.md
@@ -4,6 +4,9 @@ title: "Euskotren"
 country:
   - "spain"
 operator: "euskotren"
+
+aliases:
+  - /booking/euskotren-ticket-office
 ---
 
 In northern [Spain](/country/spain "Spain"), Euskotren operates a Basque railway network that connects the picturesque coastal towns and mountainous hinterland between the French border at Hendaye and the metropolis of Bilbao. Euskotren is owned by the Basque regional government.

--- a/content/operator/euskotren/index.fr.md
+++ b/content/operator/euskotren/index.fr.md
@@ -4,6 +4,9 @@ title: "Euskotren"
 country:
   - "spain"
 operator: "euskotren"
+
+aliases:
+  - /booking/euskotren-ticket-office
 ---
 
 Dans le nord de l’[Espagne](/country/spain "Espagne"), Euskotren exploite un réseau ferroviaire basque qui relie les villes côtières pittoresques et l’arrière-pays montagneux entre la frontière française à Hendaye et la métropole de Bilbao. Euskotren appartient au gouvernement régional basque.

--- a/content/operator/fs/index.de.md
+++ b/content/operator/fs/index.de.md
@@ -4,6 +4,11 @@ title: "Trenitalia"
 country:
   - "italy"
 operator: "trenitalia"
+
+aliases:
+  - /booking/fs-ticket-machine
+  - /booking/fs-ticket-office
+  - /booking/fs-website
 ---
 
 Ferrovie dello Stato Italiane (FS) ist die italienische Staatsbahn. FIP Vergünstigungen gelten jedoch nur bei der Tochtergesellschaft Trenitalia in [Italien](/country/italy "Italien").

--- a/content/operator/fs/index.en.md
+++ b/content/operator/fs/index.en.md
@@ -4,6 +4,11 @@ title: "Trenitalia"
 country:
   - "italy"
 operator: "trenitalia"
+
+aliases:
+  - /booking/fs-ticket-machine
+  - /booking/fs-ticket-office
+  - /booking/fs-website
 ---
 
 Ferrovie dello Stato Italiane (FS) is the Italian state railway. FIP discounts only apply to its subsidiary Trenitalia in [Italy](/country/italy "Italy").

--- a/content/operator/fs/index.fr.md
+++ b/content/operator/fs/index.fr.md
@@ -4,6 +4,11 @@ title: "Trenitalia"
 country:
   - "italy"
 operator: "trenitalia"
+
+aliases:
+  - /booking/fs-ticket-machine
+  - /booking/fs-ticket-office
+  - /booking/fs-website
 ---
 
 Ferrovie dello Stato Italiane (FS) est la compagnie ferroviaire nationale italienne. Les rabais FIP ne s’appliquent qu’à sa filiale Trenitalia en [Italie](/country/italy "Italie").

--- a/content/operator/gb/index.de.md
+++ b/content/operator/gb/index.de.md
@@ -4,6 +4,11 @@ title: "National Rail"
 country:
   - "united-kingdom"
 operator: "gb"
+
+aliases:
+  - /booking/caledonian-sleeper-website
+  - /booking/lner-website
+  - /booking/national-rail-ticket-office
 ---
 
 In [Großbritannien](/country/united-kingdom "Großbritannien") gibt es viele verschiedene Eisenbahngesellschaften, die als _National Rail_ zusammengefasst werden. Jedes Bahnunternehmen betreibt dabei seine eigenen Strecken. Die meisten Betreiber fokussieren sich dabei jedoch auf eine Region des Landes.

--- a/content/operator/gb/index.en.md
+++ b/content/operator/gb/index.en.md
@@ -4,6 +4,11 @@ title: "National Rail"
 country:
   - "united-kingdom"
 operator: "gb"
+
+aliases:
+  - /booking/caledonian-sleeper-website
+  - /booking/lner-website
+  - /booking/national-rail-ticket-office
 ---
 
 There are many different railway companies in [Great Britain](/country/united-kingdom "Great Britain"), collectively known as _National Rail_. Each company operates its own routes, mostly focusing on a specific region of the country.

--- a/content/operator/gb/index.fr.md
+++ b/content/operator/gb/index.fr.md
@@ -4,6 +4,11 @@ title: "National Rail"
 country:
   - "united-kingdom"
 operator: "gb"
+
+aliases:
+  - /booking/caledonian-sleeper-website
+  - /booking/lner-website
+  - /booking/national-rail-ticket-office
 ---
 
 Au [Royaume-Uni](/country/united-kingdom "Royaume-Uni"), il existe de nombreuses compagnies ferroviaires différentes, regroupées sous le nom de _National Rail_. Chaque entreprise exploite ses propres lignes, la plupart se concentrant sur une région du pays.

--- a/content/operator/gysev/index.de.md
+++ b/content/operator/gysev/index.de.md
@@ -4,6 +4,11 @@ title: "GySEV / Raaberbahn"
 country:
   - "austria"
 operator: "gysev"
+
+aliases:
+  - /booking/mav-ticket-machine
+  - /booking/mav-ticket-office
+  - /booking/mav-website
 ---
 
 Die Raab-Oedenburg-Ebenfurter Eisenbahn AG (ungarisch Győr-Sopron-Ebenfurti Vasút Zrt.), kurz GySEV oder Raaberbahn ist ein privates ungarisches Eisenbahnunternehmen, welches Regionalzüge in Ungarn und [Österreich](/country/austria "Österreich") betreibt. Die Züge verkehren hauptsächlich südlich und östlich des Neusiedlersees (Westungarn), teilweise sind sie sogar auf eigener Infrastruktur unterwegs.

--- a/content/operator/gysev/index.en.md
+++ b/content/operator/gysev/index.en.md
@@ -4,6 +4,11 @@ title: "GySEV / Raaberbahn"
 country:
   - "austria"
 operator: "gysev"
+
+aliases:
+  - /booking/mav-ticket-machine
+  - /booking/mav-ticket-office
+  - /booking/mav-website
 ---
 
 The Raab-Oedenburg-Ebenfurter Eisenbahn AG (Hungarian: Győr-Sopron-Ebenfurti Vasút Zrt.), short: GySEV or Raaberbahn, is a private Hungarian railway company that operates regional trains in Hungary and [Austria](/country/austria "Austria"). They primarily operate passenger services south and east of Lake Neusiedl (Western Hungary), partly even on their own infrastructure.

--- a/content/operator/gysev/index.fr.md
+++ b/content/operator/gysev/index.fr.md
@@ -4,6 +4,11 @@ title: "GySEV / Raaberbahn"
 country:
   - "austria"
 operator: "gysev"
+
+aliases:
+  - /booking/mav-ticket-machine
+  - /booking/mav-ticket-office
+  - /booking/mav-website
 ---
 
 La Raab-Oedenburg-Ebenfurter Eisenbahn AG (en hongrois Győr-Sopron-Ebenfurti Vasút Zrt.), abrégée GySEV ou Raaberbahn, est une compagnie ferroviaire privée hongroise qui exploite des trains régionaux en Hongrie et en [Autriche](/country/austria "Autriche"). Elle assure principalement le transport de voyageurs au sud et à l’est du lac de Neusiedl (ouest de la Hongrie), parfois même sur sa propre infrastructure.

--- a/content/operator/ht/index.de.md
+++ b/content/operator/ht/index.de.md
@@ -4,6 +4,10 @@ title: "Hellenic Train"
 country:
   - "greece"
 operator: "ht"
+
+aliases:
+  - /booking/ht-ticket-office
+  - /booking/ht-website
 ---
 
 Die Hellenic Train S.A. (Ελληνικοί Σιδηρόδρομοι Α.Ε.) betreibt den gesamten staatlichen Personenverkehr auf dem griechischen Normalspurnetz. Das Unternehmen betreibt Fern-, Regional- und den Vorortverkehr („Proastiakos“). Seit 2017 ist es eine hundertprozentige Tochter der italienischen Staatsbahn Ferrovie dello Stato Italiane (FS).

--- a/content/operator/ht/index.en.md
+++ b/content/operator/ht/index.en.md
@@ -4,6 +4,10 @@ title: "Hellenic Train"
 country:
   - "greece"
 operator: "ht"
+
+aliases:
+  - /booking/ht-ticket-office
+  - /booking/ht-website
 ---
 
 Hellenic Train S.A. (Ελληνικοί Σιδηρόδρομοι Α.Ε.) operates all state passenger services on the Greek standard-gauge network. The company runs long-distance, regional and suburban services ("Proastiakos"). Since 2017, it has been a wholly owned subsidiary of the Italian state railway Ferrovie dello Stato Italiane (FS).

--- a/content/operator/ht/index.fr.md
+++ b/content/operator/ht/index.fr.md
@@ -4,6 +4,10 @@ title: "Hellenic Train"
 country:
   - "greece"
 operator: "ht"
+
+aliases:
+  - /booking/ht-ticket-office
+  - /booking/ht-website
 ---
 
 Hellenic Train S.A. (Ελληνικοί Σιδηρόδρομοι Α.Ε.) exploite l'ensemble du transport de voyageurs de l'État sur le réseau grec à voie normale. L'entreprise exploite des services grandes lignes, régionaux et de banlieue (« Proastiakos »). Depuis 2017, elle est une filiale à 100 % des chemins de fer italiens Ferrovie dello Stato Italiane (FS).

--- a/content/operator/kd/index.de.md
+++ b/content/operator/kd/index.de.md
@@ -4,6 +4,11 @@ title: "KD"
 country:
   - "poland"
 operator: "kd"
+
+aliases:
+  - /booking/kd-ticket-machine
+  - /booking/kd-ticket-office
+  - /booking/kd-website
 ---
 
 Die Koleje Dolnośląskie, kurz KD, ist ein polnisches Eisenbahnverkehrsunternehmen, das hauptsächlich Regionalverkehr in der Woiwodschaft Niederschlesien anbietet. Es ist eines der insgesamt fünf verschiedenen Unternehmen, das in [Polen](/country/poland) FIP anbietet.

--- a/content/operator/kd/index.en.md
+++ b/content/operator/kd/index.en.md
@@ -4,6 +4,11 @@ title: "KD"
 country:
   - "poland"
 operator: "kd"
+
+aliases:
+  - /booking/kd-ticket-machine
+  - /booking/kd-ticket-office
+  - /booking/kd-website
 ---
 
 Koleje Dolnośląskie (KD) is a Polish railway company offering regional services in the Lower Silesia Province. It is one of five different operators in [Poland](/country/poland) which provide FIP benefits.

--- a/content/operator/kd/index.fr.md
+++ b/content/operator/kd/index.fr.md
@@ -4,6 +4,11 @@ title: "KD"
 country:
   - "pologne"
 operator: "kd"
+
+aliases:
+  - /booking/kd-ticket-machine
+  - /booking/kd-ticket-office
+  - /booking/kd-website
 ---
 
 Koleje Dolnośląskie (KD) est une compagnie ferroviaire polonaise assurant principalement des services régionaux dans la voïvodie de Basse-Silésie. C’est l’une des cinq compagnies différentes de [Pologne](/country/poland) qui proposent le FIP.

--- a/content/operator/kml/index.de.md
+++ b/content/operator/kml/index.de.md
@@ -4,6 +4,9 @@ title: "KMŁ"
 country:
   - "poland"
 operator: "kml"
+
+aliases:
+  - /booking/kml-ticket-office
 ---
 
 Die Koleje Małopolskie, kurz KMŁ, ist ein polnisches Eisenbahnverkehrsunternehmen, das hauptsächlich Regionalverkehr in der Woiwodschaft Kleinpolen anbietet. Es ist eines der insgesamt fünf verschiedenen Unternehmen, das in [Polen](/country/poland) FIP anbietet.

--- a/content/operator/kml/index.en.md
+++ b/content/operator/kml/index.en.md
@@ -4,6 +4,9 @@ title: "KMŁ"
 country:
   - "poland"
 operator: "kml"
+
+aliases:
+  - /booking/kml-ticket-office
 ---
 
 Koleje Małopolskie, abbreviated KMŁ, is a Polish railway company that mainly provides regional services in the Lesser Poland Voivodeship. It is one of five different companies offering FIP in [Poland](/country/poland).

--- a/content/operator/kml/index.fr.md
+++ b/content/operator/kml/index.fr.md
@@ -4,6 +4,9 @@ title: "KMŁ"
 country:
   - "poland"
 operator: "kml"
+
+aliases:
+  - /booking/kml-ticket-office
 ---
 
 Les Koleje Małopolskie, abrégées KMŁ, sont une compagnie ferroviaire polonaise qui assure principalement des services régionaux dans la voïvodie de Petite-Pologne. C'est l'une des cinq compagnies différentes proposant la FIP en [Pologne](/country/poland).

--- a/content/operator/ks/index.de.md
+++ b/content/operator/ks/index.de.md
@@ -4,6 +4,11 @@ title: "KŚ"
 country:
   - "poland"
 operator: "ks"
+
+aliases:
+  - /booking/ks-ticket-machine
+  - /booking/ks-ticket-office
+  - /booking/ks-website
 ---
 
 Die Koleje Śląskie, kurz KŚ, ist ein polnisches Eisenbahnverkehrsunternehmen, das hauptsächlich Regionalverkehr in der Woiwodschaft Schlesien anbietet. Es ist eines der insgesamt fünf verschiedenen Unternehmen, das in [Polen](/country/poland) FIP anbietet.

--- a/content/operator/ks/index.en.md
+++ b/content/operator/ks/index.en.md
@@ -4,6 +4,11 @@ title: "KŚ"
 country:
   - "poland"
 operator: "ks"
+
+aliases:
+  - /booking/ks-ticket-machine
+  - /booking/ks-ticket-office
+  - /booking/ks-website
 ---
 
 Koleje Śląskie, short KŚ, is a Polish railway operator that primarily offers regional transport in the Silesian Voivodeship. It is one of five different companies that offers FIP in [Poland](/country/poland).

--- a/content/operator/ks/index.fr.md
+++ b/content/operator/ks/index.fr.md
@@ -4,6 +4,11 @@ title: "KŚ"
 country:
   - "poland"
 operator: "ks"
+
+aliases:
+  - /booking/ks-ticket-machine
+  - /booking/ks-ticket-office
+  - /booking/ks-website
 ---
 
 Koleje Śląskie, abrégées KŚ, est une entreprise de transport ferroviaire polonaise qui propose principalement des services régionaux dans la voïvodie de Silésie. C'est l'une des cinq entreprises différentes qui proposent le FIP en [Pologne](/country/poland).

--- a/content/operator/kw/index.de.md
+++ b/content/operator/kw/index.de.md
@@ -4,6 +4,11 @@ title: "KW"
 country:
   - "poland"
 operator: "kw"
+
+aliases:
+  - /booking/kw-ticket-machine
+  - /booking/kw-ticket-office
+  - /booking/kw-website
 ---
 
 Die Koleje Wielkopolskie, kurz KW, ist ein polnisches Eisenbahnverkehrsunternehmen, das hauptsächlich Regionalverkehr in der Woiwodschaft Großpolen anbietet. Es ist eines der insgesamt fünf verschiedenen Unternehmen, das in [Polen](/country/poland) FIP anbietet.

--- a/content/operator/kw/index.en.md
+++ b/content/operator/kw/index.en.md
@@ -4,6 +4,11 @@ title: "KW"
 country:
   - "poland"
 operator: "kw"
+
+aliases:
+  - /booking/kw-ticket-machine
+  - /booking/kw-ticket-office
+  - /booking/kw-website
 ---
 
 Koleje Wielkopolskie, short KW, is a Polish railway operator that primarily offers regional transport in the Greater Poland Voivodeship. It is one of five different companies that offers FIP in [Poland](/country/poland).

--- a/content/operator/kw/index.fr.md
+++ b/content/operator/kw/index.fr.md
@@ -4,6 +4,11 @@ title: "KW"
 country:
   - "poland"
 operator: "kw"
+
+aliases:
+  - /booking/kw-ticket-machine
+  - /booking/kw-ticket-office
+  - /booking/kw-website
 ---
 
 Koleje Wielkopolskie, abrégées KW, est une entreprise de transport ferroviaire polonaise qui propose principalement des services régionaux dans la voïvodie de Grande-Pologne. C’est l’une des cinq entreprises différentes qui proposent le FIP en [Pologne](/country/poland).

--- a/content/operator/lka/index.de.md
+++ b/content/operator/lka/index.de.md
@@ -4,6 +4,10 @@ title: "ŁKA"
 country:
   - "poland"
 operator: "lka"
+
+aliases:
+  - /booking/lka-ticket-machine
+  - /booking/lka-ticket-office
 ---
 
 Die Łódzka Kolej Aglomeracyjna, kurz ŁKA, ist ein polnisches Eisenbahnverkehrsunternehmen, das hauptsächlich Regionalverkehr in der Woiwodschaft Łódz anbietet. Es ist eines der insgesamt fünf verschiedenen Unternehmen, das in [Polen](/country/poland) FIP anbietet.

--- a/content/operator/lka/index.en.md
+++ b/content/operator/lka/index.en.md
@@ -4,6 +4,10 @@ title: "ŁKA"
 country:
   - "poland"
 operator: "lka"
+
+aliases:
+  - /booking/lka-ticket-machine
+  - /booking/lka-ticket-office
 ---
 
 Łódzka Kolej Aglomeracyjna, short ŁKA, is a Polish railway operator that primarily offers regional transport in the Łódź Voivodeship. It is one of five different companies that offers FIP in [Poland](/country/poland).

--- a/content/operator/lka/index.fr.md
+++ b/content/operator/lka/index.fr.md
@@ -4,6 +4,10 @@ title: "ŁKA"
 country:
   - "poland"
 operator: "lka"
+
+aliases:
+  - /booking/lka-ticket-machine
+  - /booking/lka-ticket-office
 ---
 
 Łódzka Kolej Aglomeracyjna, abrégées ŁKA, est une entreprise de transport ferroviaire polonaise qui propose principalement des services régionaux dans la voïvodie de Łódź. C’est l’une des cinq entreprises différentes qui proposent le FIP en [Pologne](/country/poland).

--- a/content/operator/ltg/index.de.md
+++ b/content/operator/ltg/index.de.md
@@ -5,6 +5,9 @@ country:
   - "lithuania"
   - "latvia"
 operator: "ltg"
+
+aliases:
+  - /booking/ltg-website
 ---
 
 Die LTG ist die staatliche Eisenbahngesellschaft der Republik Litauen und betreibt mit ihrer Tochtergesellschaft LTG-Link alle Verbindungen im Personenverkehr auf dem litauischen Schienennetz sowie ins Ausland.

--- a/content/operator/ltg/index.en.md
+++ b/content/operator/ltg/index.en.md
@@ -5,6 +5,9 @@ country:
   - "lithuania"
   - "latvia"
 operator: "ltg"
+
+aliases:
+  - /booking/ltg-website
 ---
 
 LTG is the state railway company of the Republic of Lithuania and, through its subsidiary LTG-Link, operates all passenger services on the Lithuanian rail network as well as international connections.

--- a/content/operator/ltg/index.fr.md
+++ b/content/operator/ltg/index.fr.md
@@ -5,6 +5,9 @@ country:
   - "lithuania"
   - "latvia"
 operator: "ltg"
+
+aliases:
+  - /booking/ltg-website
 ---
 
 LTG est la compagnie ferroviaire nationale de la République de Lituanie et, avec sa filiale LTG-Link, exploite toutes les liaisons de transport de passagers sur le réseau ferroviaire lituanien ainsi qu’à l’étranger.

--- a/content/operator/nir/index.de.md
+++ b/content/operator/nir/index.de.md
@@ -4,6 +4,10 @@ title: "NIR"
 country:
   - "united-kingdom"
 operator: "nir"
+
+aliases:
+  - /booking/translink-ticket-office
+  - /booking/translink-whatsapp
 ---
 
 Northern Ireland Railways (NIR) ist die staatliche Bahngesellschaft in Nordirland und gehört zu Translink, einem staatlichen Verkehrsunternehmen. Das Zugnetz ist überschaubar und umfasst hauptsächlich Verbindungen von bzw. nach Belfast.

--- a/content/operator/nir/index.en.md
+++ b/content/operator/nir/index.en.md
@@ -4,6 +4,10 @@ title: "NIR"
 country:
   - "united-kingdom"
 operator: "nir"
+
+aliases:
+  - /booking/translink-ticket-office
+  - /booking/translink-whatsapp
 ---
 
 Northern Ireland Railways (NIR) is the state railway company in Northern Ireland and is part of Translink, a state transport company. The rail network is compact and mainly consists of connections to and from Belfast.

--- a/content/operator/nir/index.fr.md
+++ b/content/operator/nir/index.fr.md
@@ -4,6 +4,10 @@ title: "NIR"
 country:
   - "united-kingdom"
 operator: "nir"
+
+aliases:
+  - /booking/translink-ticket-office
+  - /booking/translink-whatsapp
 ---
 
 Northern Ireland Railways (NIR) est la compagnie ferroviaire nationale d'Irlande du Nord et fait partie de Translink, une entreprise de transport public. Le réseau ferroviaire est compact et comprend principalement des liaisons à destination et en provenance de Belfast.

--- a/content/operator/ns/index.de.md
+++ b/content/operator/ns/index.de.md
@@ -4,6 +4,10 @@ title: "NS"
 country:
   - "netherlands"
 operator: "ns"
+
+aliases:
+  - /booking/ns-phone
+  - /booking/ns-ticket-office
 ---
 
 Die Nederlandse Spoorwegen (NS) ist die staatliche Eisenbahngesellschaft der [Niederlande](/country/netherlands "Niederlande") und betreibt den Großteil des Personenverkehrs auf dem niederländischen Schienennetz.

--- a/content/operator/ns/index.en.md
+++ b/content/operator/ns/index.en.md
@@ -4,6 +4,10 @@ title: "NS"
 country:
   - "netherlands"
 operator: "ns"
+
+aliases:
+  - /booking/ns-phone
+  - /booking/ns-ticket-office
 ---
 
 Nederlandse Spoorwegen (NS) is the state railway company of the [Netherlands](/country/netherlands "Netherlands") and operates the majority of passenger traffic on the Dutch rail network.

--- a/content/operator/ns/index.fr.md
+++ b/content/operator/ns/index.fr.md
@@ -4,6 +4,10 @@ title: "NS"
 country:
   - "netherlands"
 operator: "ns"
+
+aliases:
+  - /booking/ns-phone
+  - /booking/ns-ticket-office
 ---
 
 Les Nederlandse Spoorwegen (NS) sont la compagnie ferroviaire nationale des [Pays-Bas](/country/netherlands "Pays-Bas") et assurent la majorité du trafic voyageurs dans le pays.

--- a/content/operator/oebb/index.de.md
+++ b/content/operator/oebb/index.de.md
@@ -8,6 +8,10 @@ operator: "oebb"
 
 aliases:
   - obb
+  - /booking/oebb-phone
+  - /booking/oebb-ticket-machine
+  - /booking/oebb-ticket-office
+  - /booking/oebb-website
 ---
 
 Die ÖBB (Österreichische Bundesbahnen) ist die nationale Eisenbahngesellschaft [Österreich](/country/austria "Österreich") und die wichtigste Bahngesellschaft des Landes. Sie betreiben einen Großteil des Personenverkehrs in Österreich.

--- a/content/operator/oebb/index.en.md
+++ b/content/operator/oebb/index.en.md
@@ -8,6 +8,10 @@ operator: "oebb"
 
 aliases:
   - obb
+  - /booking/oebb-phone
+  - /booking/oebb-ticket-machine
+  - /booking/oebb-ticket-office
+  - /booking/oebb-website
 ---
 
 ÖBB (Austrian Federal Railways) is [Austria](/country/austria "Austria")’s national railway company and the country’s most important rail operator. It operates the majority of passenger services in Austria.

--- a/content/operator/oebb/index.fr.md
+++ b/content/operator/oebb/index.fr.md
@@ -8,6 +8,10 @@ operator: "oebb"
 
 aliases:
   - obb
+  - /booking/oebb-phone
+  - /booking/oebb-ticket-machine
+  - /booking/oebb-ticket-office
+  - /booking/oebb-website
 ---
 
 Les ÖBB (Österreichische Bundesbahnen) sont la compagnie ferroviaire nationale d’[Autriche](/country/austria "Autriche") et l’opérateur ferroviaire le plus important du pays. Elle assure la majorité des services voyageurs.

--- a/content/operator/pkp/index.de.md
+++ b/content/operator/pkp/index.de.md
@@ -4,6 +4,12 @@ title: "PKP"
 country:
   - "poland"
 operator: "pkp"
+
+aliases:
+  - /booking/pkp-ticket-machine
+  - /booking/pkp-ticket-office
+  - /booking/pkp-website
+  - /booking/koleo-website
 ---
 
 Die polnische Staatsbahn PKP (Polskie Koleje Państwowe) betreibt mit ihren Tochtergesellschaften PKP Intercity und Polregio einen Großteil des Schienenpersonenverkehrs in [Polen](/country/poland "Polen").

--- a/content/operator/pkp/index.en.md
+++ b/content/operator/pkp/index.en.md
@@ -4,6 +4,12 @@ title: "PKP"
 country:
   - "poland"
 operator: "pkp"
+
+aliases:
+  - /booking/pkp-ticket-machine
+  - /booking/pkp-ticket-office
+  - /booking/pkp-website
+  - /booking/koleo-website
 ---
 
 The Polish State Railways PKP (Polskie Koleje Państwowe) operates, together with its subsidiaries PKP Intercity and Polregio, a large part of passenger rail transport in [Poland](/country/poland "Poland").

--- a/content/operator/pkp/index.fr.md
+++ b/content/operator/pkp/index.fr.md
@@ -4,6 +4,12 @@ title: "PKP"
 country:
   - "poland"
 operator: "pkp"
+
+aliases:
+  - /booking/pkp-ticket-machine
+  - /booking/pkp-ticket-office
+  - /booking/pkp-website
+  - /booking/koleo-website
 ---
 
 Les chemins de fer polonais PKP (Polskie Koleje Państwowe) exploitent, avec leurs filiales PKP Intercity et Polregio, une grande partie du transport ferroviaire de voyageurs en [Pologne](/country/poland "Pologne").

--- a/content/operator/renfe/index.de.md
+++ b/content/operator/renfe/index.de.md
@@ -5,6 +5,9 @@ country:
   - "spain"
   - "france"
 operator: "renfe"
+
+aliases:
+  - /booking/renfe-ticket-office
 ---
 
 Renfe Operadora ist das staatliche Eisenbahnunternehmen in [Spanien](/country/spain "Spanien"). Hierzu gehören komfortable Hochgeschwindkeitszüge, diverse Regionalzüge und S-Bahnen.

--- a/content/operator/renfe/index.en.md
+++ b/content/operator/renfe/index.en.md
@@ -5,6 +5,9 @@ country:
   - "spain"
   - "france"
 operator: "renfe"
+
+aliases:
+  - /booking/renfe-ticket-office
 ---
 
 Renfe Operadora is the state-owned railroad company in [Spain](/country/spain "Spain"). It operates comfortable high-speed trains, various regional trains and suburban trains.

--- a/content/operator/renfe/index.fr.md
+++ b/content/operator/renfe/index.fr.md
@@ -5,6 +5,9 @@ country:
   - "spain"
   - "france"
 operator: "renfe"
+
+aliases:
+  - /booking/renfe-ticket-office
 ---
 
 Renfe Operadora est la compagnie ferroviaire publique en [Espagne](/country/spain "Espagne"). Elle exploite des trains à grande vitesse confortables, divers trains régionaux et des trains de banlieue.

--- a/content/operator/sbb/index.de.md
+++ b/content/operator/sbb/index.de.md
@@ -3,6 +3,11 @@ draft: false
 title: "SBB CFF FFS"
 country:
   - "switzerland"
+
+aliases:
+  - /booking/sbb-ticket-machine
+  - /booking/sbb-ticket-office
+  - /booking/sbb-website
 ---
 
 Die SBB (Schweizerische Bundesbahnen) – (Chemins de fer fédéraux suisses CFF, Ferrovie federali svizzere FFS) ist die nationale Eisenbahngesellschaft der [Schweiz](/country/switzerland "Schweiz"). Sie betreibt einen Großteil des schweizerischen Schienennetzes. Die SBB ist bekannt für ihre Pünktlichkeit und Zuverlässigkeit.

--- a/content/operator/sbb/index.en.md
+++ b/content/operator/sbb/index.en.md
@@ -3,6 +3,11 @@ draft: false
 title: "SBB CFF FFS"
 country:
   - "switzerland"
+
+aliases:
+  - /booking/sbb-ticket-machine
+  - /booking/sbb-ticket-office
+  - /booking/sbb-website
 ---
 
 SBB (Swiss Federal Railways) – (Chemins de fer fédéraux suisses CFF, Ferrovie federali svizzere FFS) is the national railway company of [Switzerland](/country/switzerland "Switzerland"). It operates most of the Swiss rail network and is known for its punctuality and reliability.

--- a/content/operator/sbb/index.fr.md
+++ b/content/operator/sbb/index.fr.md
@@ -3,6 +3,11 @@ draft: false
 title: "SBB CFF FFS"
 country:
   - "switzerland"
+
+aliases:
+  - /booking/sbb-ticket-machine
+  - /booking/sbb-ticket-office
+  - /booking/sbb-website
 ---
 
 Les CFF (Chemins de fer fédéraux suisses, SBB en allemand, FFS en italien) sont la compagnie ferroviaire nationale de la [Suisse](/country/switzerland "Suisse"). Ils exploitent la majeure partie du réseau ferroviaire suisse et sont réputés pour leur ponctualité et leur fiabilité.

--- a/content/operator/sll/index.de.md
+++ b/content/operator/sll/index.de.md
@@ -5,6 +5,10 @@ country:
   - "ireland"
   - "united-kingdom"
 operator: "sll"
+
+aliases:
+  - /booking/stena-line-limited-email
+  - /booking/stena-line-limited-phone
 ---
 
 Das Unternehmen Stena Line betreibt diverse Personen- und Fahrzeugfähren. Der Betrieb der Strecken auf der irischen See werden im Kontext von FIP als Stena Line Limited (SLL) genannt.

--- a/content/operator/sll/index.en.md
+++ b/content/operator/sll/index.en.md
@@ -5,6 +5,10 @@ country:
   - "ireland"
   - "united-kingdom"
 operator: "sll"
+
+aliases:
+  - /booking/stena-line-limited-email
+  - /booking/stena-line-limited-phone
 ---
 
 The company Stena Line operates various passenger and vehicle ferries. The ferry connections on the Irish Sea are referred to as Stena Line Limited (SLL) in the context of FIP.

--- a/content/operator/sll/index.fr.md
+++ b/content/operator/sll/index.fr.md
@@ -5,6 +5,10 @@ country:
   - "ireland"
   - "united-kingdom"
 operator: "sll"
+
+aliases:
+  - /booking/stena-line-limited-email
+  - /booking/stena-line-limited-phone
 ---
 
 L’entreprise Stena Line exploite divers ferries pour passagers et véhicules. Les liaisons en mer d'Irlande sont assurées par Stena Line Limited (SLL) dans le cadre de l'accord FIP.

--- a/content/operator/sncb/index.de.md
+++ b/content/operator/sncb/index.de.md
@@ -4,6 +4,11 @@ title: "SNCB / NMBS"
 country:
   - "belgium"
 operator: "sncb"
+
+aliases:
+  - /booking/sncb-phone
+  - /booking/sncb-ticket-office
+  - /booking/sncb-website
 ---
 
 Die SNCB (Société nationale des chemins de fer belges) bzw. NMBS (Nationale Maatschappij der Belgische Spoorwegen) ist die belgische Staatsbahn und die wichtigste Bahngesellschaft in [Belgien](/country/belgium "Belgien").

--- a/content/operator/sncb/index.en.md
+++ b/content/operator/sncb/index.en.md
@@ -4,6 +4,11 @@ title: "SNCB / NMBS"
 country:
   - "belgium"
 operator: "sncb"
+
+aliases:
+  - /booking/sncb-phone
+  - /booking/sncb-ticket-office
+  - /booking/sncb-website
 ---
 
 The SNCB (Société nationale des chemins de fer belges) or NMBS (Nationale Maatschappij der Belgische Spoorwegen) is the Belgian national railway operator and the most important railway operator in [Belgium](/country/belgium "Belgium").

--- a/content/operator/sncb/index.fr.md
+++ b/content/operator/sncb/index.fr.md
@@ -4,6 +4,11 @@ title: "SNCB / NMBS"
 country:
   - "belgium"
 operator: "sncb"
+
+aliases:
+  - /booking/sncb-phone
+  - /booking/sncb-ticket-office
+  - /booking/sncb-website
 ---
 
 La SNCB (Société nationale des chemins de fer belges) ou NMBS (Nationale Maatschappij der Belgische Spoorwegen) est l’opérateur ferroviaire national belge et le plus important de [Belgique](/country/belgium "Belgique").

--- a/content/operator/sncf/index.de.md
+++ b/content/operator/sncf/index.de.md
@@ -9,6 +9,11 @@ country:
   - "belgium"
   - "luxembourg"
 operator: "sncf"
+
+aliases:
+  - /booking/sncf-phone
+  - /booking/sncf-ticket-office
+  - /booking/transilien-ticket-office
 ---
 
 Die SNCF (Société Nationale des Chemins de fer Français) ist die französische Staatsbahn und die wichtigste Bahngesellschaft in [Frankreich](/country/france "Frankreich"). Sie betreibt fast alle Fern- und Regionalzüge in Frankreich.

--- a/content/operator/sncf/index.en.md
+++ b/content/operator/sncf/index.en.md
@@ -9,6 +9,11 @@ country:
   - "belgium"
   - "luxembourg"
 operator: "sncf"
+
+aliases:
+  - /booking/sncf-phone
+  - /booking/sncf-ticket-office
+  - /booking/transilien-ticket-office
 ---
 
 SNCF (Société Nationale des Chemins de fer Français) is the French national railway company and the main rail operator in [France](/country/france "France"). It operates almost all long-distance and regional trains in France.

--- a/content/operator/sncf/index.fr.md
+++ b/content/operator/sncf/index.fr.md
@@ -9,6 +9,11 @@ country:
   - "belgium"
   - "luxembourg"
 operator: "sncf"
+
+aliases:
+  - /booking/sncf-phone
+  - /booking/sncf-ticket-office
+  - /booking/transilien-ticket-office
 ---
 
 La SNCF (Société Nationale des Chemins de fer Français) est la compagnie ferroviaire nationale française et le principal opérateur ferroviaire en [France](/country/france "France"). Elle exploite la quasi-totalité des trains grandes lignes et régionaux du pays.

--- a/content/operator/stl/index.de.md
+++ b/content/operator/stl/index.de.md
@@ -5,6 +5,11 @@ country:
   - "netherlands"
   - "united-kingdom"
 operator: "stl"
+
+aliases:
+  - /booking/stena-line-bv-email
+  - /booking/stena-line-bv-phone
+  - /booking/stena-line-bv-ticket-office
 ---
 
 Das Unternehmen Stena Line betreibt diverse Personen- und Fahrzeugfähren. Der Betrieb der Strecke zwischen Harwich ([Vereinigtes Königreich](/country/united-kingdom)) und Hoek van Holland ([Niederlande](/country/netherlands)) wird im Kontext von FIP als Stena Line BV (StL) genannt.

--- a/content/operator/stl/index.en.md
+++ b/content/operator/stl/index.en.md
@@ -5,6 +5,11 @@ country:
   - "netherlands"
   - "united-kingdom"
 operator: "stl"
+
+aliases:
+  - /booking/stena-line-bv-email
+  - /booking/stena-line-bv-phone
+  - /booking/stena-line-bv-ticket-office
 ---
 
 The company Stena Line operates various passenger and vehicle ferries. The service between Harwich ([United Kingdom](/country/united-kingdom)) and Hoek van Holland ([Netherlands](/country/netherlands)) is referred to as Stena Line BV (StL) in the context of FIP.

--- a/content/operator/stl/index.fr.md
+++ b/content/operator/stl/index.fr.md
@@ -5,6 +5,11 @@ country:
   - "netherlands"
   - "united-kingdom"
 operator: "stl"
+
+aliases:
+  - /booking/stena-line-bv-email
+  - /booking/stena-line-bv-phone
+  - /booking/stena-line-bv-ticket-office
 ---
 
 L’entreprise Stena Line exploite divers ferries pour passagers et véhicules. L’exploitation de la ligne entre Harwich ([Royaume-Uni](/country/united-kingdom)) et Hoek van Holland ([Pays-Bas](/country/netherlands)) est désignée dans le contexte FIP sous le nom de Stena Line BV (StL).

--- a/content/operator/vy/index.de.md
+++ b/content/operator/vy/index.de.md
@@ -4,6 +4,11 @@ title: "Vy Group"
 country:
   - "norway"
 operator: "vy"
+
+aliases:
+  - /booking/entur-chat
+  - /booking/entur-phone
+  - /booking/entur-ticket-office
 ---
 
 Die Vy Group (ehemals Norges Statsbaner) ist die staatliche Bahngesellschaft in [Norwegen](/country/norway). Sie betreibt mit ihren Tochtergesellschaften den Großteil des Schienenpersonenverkehrs in Norwegen.

--- a/content/operator/vy/index.en.md
+++ b/content/operator/vy/index.en.md
@@ -4,6 +4,11 @@ title: "Vy Group"
 country:
   - "norway"
 operator: "vy"
+
+aliases:
+  - /booking/entur-chat
+  - /booking/entur-phone
+  - /booking/entur-ticket-office
 ---
 
 Vy Group (formerly Norges Statsbaner) is the state railway company in [Norway](/country/norway). Together with its subsidiaries, it operates most of the passenger rail transport in Norway.

--- a/content/operator/vy/index.fr.md
+++ b/content/operator/vy/index.fr.md
@@ -4,6 +4,11 @@ title: "Vy Group"
 country:
   - "norway"
 operator: "vy"
+
+aliases:
+  - /booking/entur-chat
+  - /booking/entur-phone
+  - /booking/entur-ticket-office
 ---
 
 Vy Group (anciennement Norges Statsbaner) est la compagnie ferroviaire nationale de la [Norvège](/country/norway). Avec ses filiales, elle assure la majeure partie du transport ferroviaire de voyageurs en Norvège.

--- a/content/operator/zssk/index.de.md
+++ b/content/operator/zssk/index.de.md
@@ -7,6 +7,8 @@ operator: "zssk"
 
 aliases:
   - zsr
+  - /booking/zssk-ticket-office
+  - /booking/zssk-website
 ---
 
 Die ŽSR (Železnice Slovenskej republiky) sowie der dazugehörige Zugbetreiber ZSSK (Železničná spoločnosť Slovensko) ist die slowakische Staatsbahn und die wichtigste Bahngesellschaft in der [Slowakei](/country/slovakia "Slowakei").

--- a/content/operator/zssk/index.en.md
+++ b/content/operator/zssk/index.en.md
@@ -6,6 +6,8 @@ country:
 operator: "zssk"
 aliases:
   - zsr
+  - /booking/zssk-ticket-office
+  - /booking/zssk-website
 ---
 
 The ŽSR (Železnice Slovenskej republiky) and its associated train operator ZSSK (Železničná spoločnosť Slovensko) are the Slovak state railways and the most important railway operator in [Slovaika](/country/slovakia "Slovakia").

--- a/content/operator/zssk/index.fr.md
+++ b/content/operator/zssk/index.fr.md
@@ -6,6 +6,8 @@ country:
 operator: "zssk"
 aliases:
   - zsr
+  - /booking/zssk-ticket-office
+  - /booking/zssk-website
 ---
 
 La ŽSR (Železnice Slovenskej republiky) et son exploitant ferroviaire ZSSK (Železničná spoločnosť Slovensko) sont les chemins de fer nationaux slovaques et constituent l’opérateur ferroviaire principal du [Slovaquie](/country/slovakia "Slovaquie").


### PR DESCRIPTION
The booking platforms are no longer rendered as single pages, which leads to 404 pages if old links are used. Instead, redirect to the most relevant operator page.