### PR TITLE
fix: tag text overflow

### DIFF
--- a/assets/sass/tag.scss
+++ b/assets/sass/tag.scss
@@ -1,12 +1,11 @@
 .a-tag {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.4rem;
   padding: 0.4rem 0.8rem;
   border-radius: var(--border-radius-s);
   font-size: 0.7em;
   font-weight: 500;
-  white-space: nowrap;
 
   @each $name, $color in $tag-colors {
     &--#{$name} {


### PR DESCRIPTION
Fixes #896 

Removed `white-space` attribute on tag and set `align-items` for consistent styling (icons before multiline texts are always at the beginning)

<img width="306" height="269" alt="image" src="https://github.com/user-attachments/assets/4a6e7ac1-bbbc-4f7c-bcc1-dfab3b190cd5" />
