### PR TITLE
fix: Clarify free children option for DB

### DIFF
--- a/content/operator/db/index.de.md
+++ b/content/operator/db/index.de.md
@@ -295,7 +295,7 @@ Die kostenlos mitreisenden Kinder müssen nicht mit dem begleitenden Erwachsenen
 
 In Nahverkehrszügen können bis zu 3 Kinder mitgenommen werden und in Fernverkehszügen bis zu 4 Kinder. Bei FIP 50 Tickets, die einen Abschnitt im Fernverkehr haben, können auch in den angegebenen Nahverkehrszügen bis zu 4 Kinder mitgenommen werden.
 
-Kostenlos mitreisende Kinder müssen nicht auf dem Ticket eingetragen werden. Bei FIP 50 Tickets empfiehlt es sich trotzdem, diese kostenlos mitzubuchen, um Probleme bei der Fahrtkartenkontrolle zu vermeiden.
+Kostenlos mitreisende Kinder müssen im Gegensatz zu öffentlichen Tarifen explizit nicht auf dem Ticket eingetragen werden. Sie benötigen kein eigenes Ticket.
 
 Kinder, die nicht von einer über 15 Jahre alten Person mit Reiseberechtigung begleitet werden, müssen ein eigenes Ticket kaufen.
 

--- a/content/operator/db/index.en.md
+++ b/content/operator/db/index.en.md
@@ -296,7 +296,7 @@ Children traveling free do not need to be related to the accompanying adult.
 
 Up to 3 children can be taken on local trains and up to 4 children on long-distance trains. For FIP 50 Tickets that include a long-distance section, up to 4 children can also be taken on the specified local trains.
 
-Children traveling free do not need to be entered on the ticket. For FIP 50 Tickets, it is still recommended to book them free of charge to avoid problems during ticket inspection.
+Unlike public fares, children traveling free explicitly do not need to be entered on the ticket. They do not need their own ticket.
 
 Children not accompanied by a person over 15 years old with travel entitlement must purchase their own ticket.
 

--- a/content/operator/db/index.fr.md
+++ b/content/operator/db/index.fr.md
@@ -296,7 +296,7 @@ Les enfants voyageant gratuitement n’ont pas besoin d’être apparentés à l
 
 Dans les trains locaux, jusqu’à 3 enfants peuvent être emmenés et dans les trains longue distance jusqu’à 4 enfants. Pour les billets FIP 50 comprenant une section en longue distance, jusqu’à 4 enfants peuvent aussi être emmenés dans les trains locaux indiqués.
 
-Les enfants voyageant gratuitement n’ont pas besoin d’être inscrits sur le billet. Pour les billets FIP 50, il est toutefois recommandé de les réserver gratuitement pour éviter des problèmes lors du contrôle.
+Contrairement aux tarifs publics, les enfants voyageant gratuitement n’ont explicitement pas besoin d’être inscrits sur le billet. Ils n’ont pas besoin d’un billet propre.
 
 Les enfants non accompagnés par une personne de plus de 15 ans avec droit de voyage doivent acheter leur propre billet.
 


### PR DESCRIPTION
It's not possible to enter free children on FIP issued tickets when booking online. Since it's not needed, also remove the recommendation that users should do it, this could lead to uncertainty. Also explicitly add that no additional ticket is needed.