### PR TITLE
fix: set Stena Line Limited reservations to true

### DIFF
--- a/content/booking/stena-line-limited-email/index.de.md
+++ b/content/booking/stena-line-limited-email/index.de.md
@@ -5,7 +5,7 @@ description: "Buchungsinformationen für die Buchung per E-Mail bei Stena Line L
 params:
   fip_50: true
   fip_global_fare: nil
-  reservations: false
+  reservations: true
   type: "email"
 ---
 

--- a/content/booking/stena-line-limited-email/index.en.md
+++ b/content/booking/stena-line-limited-email/index.en.md
@@ -5,7 +5,7 @@ description: "Booking information for booking by email with Stena Line Limited"
 params:
   fip_50: true
   fip_global_fare: nil
-  reservations: false
+  reservations: true
   type: "email"
 ---
 

--- a/content/booking/stena-line-limited-email/index.fr.md
+++ b/content/booking/stena-line-limited-email/index.fr.md
@@ -5,7 +5,7 @@ description: "Informations relatives à la réservation par e-mail auprès de St
 params:
   fip_50: true
   fip_global_fare: nil
-  reservations: false
+  reservations: true
   type: "email"
 ---
 

--- a/content/booking/stena-line-limited-phone/index.de.md
+++ b/content/booking/stena-line-limited-phone/index.de.md
@@ -5,7 +5,7 @@ description: "Buchungsinformationen für die Buchung per Telefon bei Stena Line 
 params:
   fip_50: true
   fip_global_fare: nil
-  reservations: false
+  reservations: true
   type: "phone"
 ---
 

--- a/content/booking/stena-line-limited-phone/index.en.md
+++ b/content/booking/stena-line-limited-phone/index.en.md
@@ -5,7 +5,7 @@ description: "Booking information for booking by telephone with Stena Line Limit
 params:
   fip_50: true
   fip_global_fare: nil
-  reservations: false
+  reservations: true
   type: "phone"
 ---
 

--- a/content/booking/stena-line-limited-phone/index.fr.md
+++ b/content/booking/stena-line-limited-phone/index.fr.md
@@ -5,7 +5,7 @@ description: "Informations de réservation pour la réservation par téléphone 
 params:
   fip_50: true
   fip_global_fare: nil
-  reservations: false
+  reservations: true
   type: "phone"
 ---
 


### PR DESCRIPTION
## Summary
- Correct `reservations` from `false` to `true` for Stena Line Limited booking pages.
- Update both booking channels (`email`, `phone`) in all three languages (`de`, `en`, `fr`).
- Ensure SLL booking options are shown as reservable in operator booking paths.