### PR TITLE
fix: align English FIP terminology and typo fixes

### DIFF
--- a/content/country/spain/index.en.md
+++ b/content/country/spain/index.en.md
@@ -17,7 +17,7 @@ In Spain, using FIP is not always straightforward, as simply boarding and riding
 
 {{< identify-operator sources="renfe-website,renfe-commuter-website,euskotren-website,db-website" />}}
 
-## Insteresting
+## Interesting
 
 Spain does not have a particularly dense rail network; instead, it mainly consists of new high-speed standard gauge lines and older regional lines in Iberian broad gauge.
 
@@ -56,7 +56,7 @@ There is currently no rail connection between Andorra and Spain.
 
 ### Portugal
 
-Connections between Spain and Portugal are currently very limited. For example, to travel from Lisbon to Madrid, one must change trains and take a long regional journey to the Spanish border at Badajoz, where one of the few trains to Madrid can be caught. This requires FIP Tickets or Coupones from Portuguese rail operator CP, as well as a Renfe ticket for the Spanish section.
+Connections between Spain and Portugal are currently very limited. For example, to travel from Lisbon to Madrid, one must change trains and take a long regional journey to the Spanish border at Badajoz, where one of the few trains to Madrid can be caught. This requires FIP Tickets or Coupons from Portuguese rail operator CP, as well as a Renfe ticket for the Spanish section.
 
 Additionally, there is the Celta connection from Porto to Vigo, although this does not extend further into Spain. A FIP Global Fare is valid for the entire route ([See Renfe – Celta](/operator/renfe#long-distance "Renfe")).
 

--- a/content/country/united-kingdom/index.en.md
+++ b/content/country/united-kingdom/index.en.md
@@ -69,7 +69,7 @@ Additionally, there is a [ferry connection from Stena Line BV](/operator/stl) fr
 
 From Paris Nord, Lille Europe, and Brussels Midi, [Eurostar trains](/operator/eurostar "Eurostar page") run to London St. Pancras International. These trains require reservations and FIP Global Fare tickets must be purchased.
 
-From Calais, there is also the LeShuttle car train through the Eurotunnel, but no FIP discount is granted. Additionally, there are various ferry connections between France/Belgium and Great Britain, but no FIP discount is granted on these.
+From Calais, there is also the LeShuttle Motorail train through the Eurotunnel, but no FIP discount is granted. Additionally, there are various ferry connections between France/Belgium and Great Britain, but no FIP discount is granted on these.
 
 ### Ireland
 

--- a/content/operator/bls/index.en.md
+++ b/content/operator/bls/index.en.md
@@ -15,7 +15,7 @@ The BLS offers a [network map of its routes](https://www.bls.ch/-/media/bls/pdf/
 ## Summary
 
 - BLS accepts FIP Coupon and FIP 50 Tickets.
-- The use of all trains (except for car trains), buses, and ships with FIP is possible.
+- The use of all trains (except for Motorail trains), buses, and ships with FIP is possible.
 - No reservation is required.
 
 ## Validity of FIP Tickets

--- a/content/operator/db/index.en.md
+++ b/content/operator/db/index.en.md
@@ -373,7 +373,7 @@ The following product classes exist:
 
 ### DB Syltshuttle
 
-DB operates the car train _Syltshuttle_, which runs from Niebüll car loading to Westerland (Sylt) car loading. Travel is only possible with a vehicle (car, caravan, motorhome) and requires a [separate ticket](https://ticket.syltshuttle.de/). FIP discounts are not recognized.
+DB operates the Motorail train _Syltshuttle_, which runs from Niebüll car loading to Westerland (Sylt) car loading. Travel is only possible with a vehicle (car, caravan, motorhome) and requires a [separate ticket](https://ticket.syltshuttle.de/). FIP discounts are not recognized.
 
 ### Shipping and Wangerooge Island Railway
 

--- a/content/operator/euskotren/index.en.md
+++ b/content/operator/euskotren/index.en.md
@@ -38,7 +38,7 @@ You use the "Euskotren FIP Ticket" to pass through platform barriers. After expi
 {{% /float-image %}}
 
 {{% highlight tip %}}
-Some train operators also issue FIP Coupones for Euskotren. According to our information, these have no use, as platform barriers cannot be passed with them. Instead, we recommend having the ticket issued on site.
+Some train operators also issue FIP Coupons for Euskotren. According to our information, these have no use, as platform barriers cannot be passed with them. Instead, we recommend having the ticket issued on site.
 {{% /highlight %}}
 
 ## Train Categories and Reservations

--- a/content/operator/oebb/index.en.md
+++ b/content/operator/oebb/index.en.md
@@ -279,7 +279,7 @@ Tickets can be purchased on board if you immediately contact the conductor. Howe
 
 ## Discounts
 
-Children under 6 travel free of charge. From the age of 6, when traveling with a FIP Free Travel Coupon on long-distance trains, the [supplement](#validity-of-fip-tickets) must also be paid for each child.
+Children under 6 travel free of charge. From the age of 6, when traveling with a FIP Coupon on long-distance trains, the [supplement](#validity-of-fip-tickets) must also be paid for each child.
 
 {{% highlight tip %}}
 With children, the ÖBB Vorteilscard Family for € 21 is quickly worthwhile. \


### PR DESCRIPTION
## Summary
- align glossary-critical English wording by replacing `FIP Free Travel Coupon` with `FIP Coupon`
- replace `car train` with `Motorail train` in affected English content pages
- fix visible English typos (`Insteresting`, `Coupones`) in country/operator content