### PR TITLE
fix: normalize French apostrophes in content pages

### DIFF
--- a/content/booking/attica-agents/index.fr.md
+++ b/content/booking/attica-agents/index.fr.md
@@ -8,9 +8,9 @@ params:
   type: "onsite"
 ---
 
-Attica dispose d'un réseau mondial de bureaux propres et de Premium Sales Agents qui vendent des Billets FIP 50 :
+Attica dispose d’un réseau mondial de bureaux propres et de Premium Sales Agents qui vendent des Billets FIP 50 :
 
-- [Liste d'adresses pour les routes internationales](https://www.superfast.com/de-de/premium-sales-agents)
-- [Liste d'adresses pour les routes intérieures grecques](https://www.bluestarferries.com/en-gb/network)
+- [Liste d’adresses pour les routes internationales](https://www.superfast.com/de-de/premium-sales-agents)
+- [Liste d’adresses pour les routes intérieures grecques](https://www.bluestarferries.com/en-gb/network)
 
 Les Billets FIP 50 peuvent également être achetés aux bureaux et guichets portuaires.

--- a/content/booking/attica-email/index.fr.md
+++ b/content/booking/attica-email/index.fr.md
@@ -1,7 +1,7 @@
 ---
 draft: false
 title: "Attica E-Mail"
-description: "Informations de réservation pour la réservation par e-mail auprès d'Attica."
+description: "Informations de réservation pour la réservation par e-mail auprès d’Attica."
 params:
   fip_50: true
   reservations: false
@@ -9,6 +9,6 @@ params:
 ---
 
 Les Billets FIP 50 peuvent être commandés par e-mail.
-Pour cela, le [formulaire de réservation FIP](https://www.raildeliverygroup.com/files/Publications/services/rst/RST_90032_Attica.xls) doit être rempli et envoyé à l'adresse e-mail suivante :
+Pour cela, le [formulaire de réservation FIP](https://www.raildeliverygroup.com/files/Publications/services/rst/RST_90032_Attica.xls) doit être rempli et envoyé à l’adresse e-mail suivante :
 
 helpdesk@attica-group.com

--- a/content/booking/attica-phone/index.fr.md
+++ b/content/booking/attica-phone/index.fr.md
@@ -8,7 +8,7 @@ params:
   type: "phone"
 ---
 
-Attica propose une ligne de réservation téléphonique permettant d'acheter des Billets FIP 50. Le FIP doit être explicitement mentionné.
+Attica propose une ligne de réservation téléphonique permettant d’acheter des Billets FIP 50. Le FIP doit être explicitement mentionné.
 
 [+30 (0) 2108919 800](tel:+302108919800)
 

--- a/content/booking/cfr-ticket-office/index.fr.md
+++ b/content/booking/cfr-ticket-office/index.fr.md
@@ -16,7 +16,7 @@ params:
 
 ## Billets FIP 50
 
-Au Guichet CFR Călători, des Billets FIP 50 peuvent être achetés pour les voyages en Roumanie, et aux guichets internationaux également pour les voyages vers la Bulgarie et la Hongrie. La FIP n'étant pas valable en Moldavie et en Ukraine, des billets et réservations peuvent être vendus jusqu'au dernier arrêt en Roumanie pour les voyages vers ces deux pays, avec des billets plein tarif pour le tronçon restant. La situation est similaire pour la Turquie, où les réservations peuvent être effectuées jusqu'au dernier arrêt en Bulgarie.
+Au Guichet CFR Călători, des Billets FIP 50 peuvent être achetés pour les voyages en Roumanie, et aux guichets internationaux également pour les voyages vers la Bulgarie et la Hongrie. La FIP n’étant pas valable en Moldavie et en Ukraine, des billets et réservations peuvent être vendus jusqu’au dernier arrêt en Roumanie pour les voyages vers ces deux pays, avec des billets plein tarif pour le tronçon restant. La situation est similaire pour la Turquie, où les réservations peuvent être effectuées jusqu’au dernier arrêt en Bulgarie.
 
 Un aperçu des guichets internationaux est disponible sur le [Site Web CFR Călători](https://www.cfrcalatori.ro/en/cfr-calatori-stations-and-travel-agencies-that-issue-travel-tickets-in-international-traffic/).
 {{% /booking-section %}}
@@ -25,7 +25,7 @@ Un aperçu des guichets internationaux est disponible sur le [Site Web CFR Căl�
 
 ## Réservations
 
-Des réservations de places assises et debout pour les relations nationales peuvent être achetées en gare au prix de 5 RON pour les trains longue distance et 1 RON pour les trains `R`. Lors de l'utilisation d'un Coupon FIP, celui-ci doit être présenté. Le numéro du Coupon FIP sera alors imprimé sur le billet.
+Des réservations de places assises et debout pour les relations nationales peuvent être achetées en gare au prix de 5 RON pour les trains longue distance et 1 RON pour les trains `R`. Lors de l’utilisation d’un Coupon FIP, celui-ci doit être présenté. Le numéro du Coupon FIP sera alors imprimé sur le billet.
 
-Pour les voitures-couchettes et voitures-lits, les tarifs suivants s'appliquent sur les relations nationales : [Grille tarifaire pour les voitures-couchettes et voitures-lits](https://www.cfrcalatori.ro/en/supplements-sleeping-car-berth-car/)
+Pour les voitures-couchettes et voitures-lits, les tarifs suivants s’appliquent sur les relations nationales : [Grille tarifaire pour les voitures-couchettes et voitures-lits](https://www.cfrcalatori.ro/en/supplements-sleeping-car-berth-car/)
 {{% /booking-section %}}

--- a/content/booking/db-website-fip-db/index.fr.md
+++ b/content/booking/db-website-fip-db/index.fr.md
@@ -55,5 +55,5 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l'opérateur ou utiliser d'autres méthodes de réservation.
+Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l’opérateur ou utiliser d’autres méthodes de réservation.
 {{% /highlight %}}

--- a/content/booking/db-website-fip-international/index.fr.md
+++ b/content/booking/db-website-fip-international/index.fr.md
@@ -37,7 +37,7 @@ Les Billets FIP 50 peuvent être achetés pour les pays suivants, à condition q
 - République tchèque
 - Danemark
 - France \
-  <small>uniquement les trains régionaux entre l'Allemagne et la France</small>
+  <small>uniquement les trains régionaux entre l’Allemagne et la France</small>
 - Allemagne
 - Italie \
   <small>uniquement la ligne du Brenner avec l’Autriche et le ECE Francfort – Milan</small>
@@ -63,5 +63,5 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l'opérateur ou utiliser d'autres méthodes de réservation.
+Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l’opérateur ou utiliser d’autres méthodes de réservation.
 {{% /highlight %}}

--- a/content/booking/db-website/index.fr.md
+++ b/content/booking/db-website/index.fr.md
@@ -28,5 +28,5 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 {{% /booking-section %}}
 
 {{% highlight "important" %}}
-Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l'opérateur ou utiliser d'autres méthodes de réservation.
+Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l’opérateur ou utiliser d’autres méthodes de réservation.
 {{% /highlight %}}

--- a/content/booking/dsb-international-website/index.fr.md
+++ b/content/booking/dsb-international-website/index.fr.md
@@ -19,7 +19,7 @@ params:
 
 Le prix de réservation est calculé par voyage. Ainsi, pour les liaisons avec changement, il suffit de payer une fois le prix pour plusieurs trains.
 
-Sur le site Web de DSB, des réservations de sièges pour des liaisons ferroviaires internationales et transfrontalières peuvent être effectuées. Pour la réservation, l'option _Buy seat ticket only_ doit être spécifiée dans la recherche de connexion.
+Sur le site Web de DSB, des réservations de sièges pour des liaisons ferroviaires internationales et transfrontalières peuvent être effectuées. Pour la réservation, l’option _Buy seat ticket only_ doit être spécifiée dans la recherche de connexion.
 
 Des réservations étrangères pour les pays suivants peuvent être effectuées :
 

--- a/content/booking/ffestiniogtravel-email/index.fr.md
+++ b/content/booking/ffestiniogtravel-email/index.fr.md
@@ -12,11 +12,11 @@ params:
 Ffestiniog Travel a un accès direct aux systèmes de réservation de nombreux opérateurs ferroviaires et peut proposer des billets pour de nombreux trains en Europe.
 Les exceptions sont la France (SNCF) et la Norvège (Vy Group).
 
-Sur demande, le personnel établit l'offre adaptée au voyage :
+Sur demande, le personnel établit l’offre adaptée au voyage :
 
-- La demande doit être envoyée en anglais à l'adresse e-mail suivante : [rail@ffestiniogtravel.co.uk](mailto:rail@ffestiniogtravel.co.uk)
+- La demande doit être envoyée en anglais à l’adresse e-mail suivante : [rail@ffestiniogtravel.co.uk](mailto:rail@ffestiniogtravel.co.uk)
 - Initialement, une photo de votre Carte FIP (ou Staff Travel Card pour Safeguarded) doit être envoyée.
-- **Des frais de réservation de 12 % par personne du montant de la réservation s'appliquent (minimum 5 £, maximum 60 £).**
+- **Des frais de réservation de 12 % par personne du montant de la réservation s’appliquent (minimum 5 £, maximum 60 £).**
 
 {{% booking-section "fip_global_fare" %}}
 

--- a/content/booking/ffestiniogtravel-phone/index.fr.md
+++ b/content/booking/ffestiniogtravel-phone/index.fr.md
@@ -12,13 +12,13 @@ params:
 Ffestiniog Travel a un accès direct aux systèmes de réservation de nombreux opérateurs ferroviaires et peut proposer des billets pour de nombreux trains en Europe.
 Les exceptions sont la France (SNCF) et la Norvège (Vy Group).
 
-Sur demande, le personnel établit l'offre adaptée au voyage : [+44 (0)1766 515630](tel:+441766515630)
+Sur demande, le personnel établit l’offre adaptée au voyage : [+44 (0)1766 515630](tel:+441766515630)
 
 La réservation est possible en anglais. Un alphabet d’épellation peut aider lors de la communication des noms et des adresses.
 
-Pour réserver des billets par téléphone, vous devez d'abord envoyer une photo de votre Carte FIP (ou Staff Travel Card pour Safeguarded) à [rail@ffestiniogtravel.co.uk](mailto:rail@ffestiniogtravel.co.uk).
+Pour réserver des billets par téléphone, vous devez d’abord envoyer une photo de votre Carte FIP (ou Staff Travel Card pour Safeguarded) à [rail@ffestiniogtravel.co.uk](mailto:rail@ffestiniogtravel.co.uk).
 
-**Des frais de réservation de 12 % par personne du montant de la réservation s'appliquent (minimum 5 £, maximum 60 £).**
+**Des frais de réservation de 12 % par personne du montant de la réservation s’appliquent (minimum 5 £, maximum 60 £).**
 {{% booking-section "fip_global_fare" %}}
 
 ## Tarif Global FIP

--- a/content/booking/gwr-whatsapp/index.fr.md
+++ b/content/booking/gwr-whatsapp/index.fr.md
@@ -17,6 +17,6 @@ params:
 
 Des réservations gratuites sont disponibles via le service client GWR WhatsApp.
 
-Pour réserver, envoyez un message au numéro WhatsApp [+44 7890608043](https://wa.me/447890608043) avec vos données de voyage (date, heure, gare de départ et d'arrivée) ainsi que le nombre de passagers. Il est recommandé d'envoyer le message en anglais.
+Pour réserver, envoyez un message au numéro WhatsApp [+44 7890608043](https://wa.me/447890608043) avec vos données de voyage (date, heure, gare de départ et d’arrivée) ainsi que le nombre de passagers. Il est recommandé d’envoyer le message en anglais.
 
 {{% /booking-section %}}

--- a/content/booking/ht-website/index.fr.md
+++ b/content/booking/ht-website/index.fr.md
@@ -45,7 +45,7 @@ Changez la langue en anglais ou en italien si nécessaire.
 
 **Étape 2**
 
-Sélectionnez une correspondance appropriée. Le prix du billet régulier est d'abord affiché.
+Sélectionnez une correspondance appropriée. Le prix du billet régulier est d’abord affiché.
 Les noms de gares doivent être saisis en anglais.
 
 {{% /float-image %}}
@@ -59,10 +59,10 @@ Les noms de gares doivent être saisis en anglais.
 
 **Étape 3**
 
-À l'étape suivante, sélectionnez « FIP CARD » dans le champ « Offer » et saisissez le numéro de la Carte FIP.
+À l’étape suivante, sélectionnez « FIP CARD » dans le champ « Offer » et saisissez le numéro de la Carte FIP.
 Le prix du billet régulier est alors réduit de 50 %.
 
-Pour les services nécessitant une réservation, une réservation est ajoutée gratuitement. Le siège peut optionnellement être choisi en sélectionnant l'option « Choose seat ».
+Pour les services nécessitant une réservation, une réservation est ajoutée gratuitement. Le siège peut optionnellement être choisi en sélectionnant l’option « Choose seat ».
 
 {{% /float-image %}}
 

--- a/content/booking/irish-rail-ticket-office/index.fr.md
+++ b/content/booking/irish-rail-ticket-office/index.fr.md
@@ -10,12 +10,12 @@ params:
   type: "onsite"
 ---
 
-Les guichets Irish Rail sont disponibles dans les grandes gares InterCity. Pour vérifier si une gare dispose d'un guichet, il suffit de sélectionner la gare correspondante dans le [répertoire des gares](https://www.irishrail.ie/en-ie/travel-information/find-a-station). Les horaires d'ouverture sont indiqués dans les sections « General information » et « Opening Hours » si un guichet est disponible. Les guichets sont désignés comme « Station Booking Offices » sur le site web.
+Les guichets Irish Rail sont disponibles dans les grandes gares InterCity. Pour vérifier si une gare dispose d’un guichet, il suffit de sélectionner la gare correspondante dans le [répertoire des gares](https://www.irishrail.ie/en-ie/travel-information/find-a-station). Les horaires d’ouverture sont indiqués dans les sections « General information » et « Opening Hours » si un guichet est disponible. Les guichets sont désignés comme « Station Booking Offices » sur le site web.
 
 {{% booking-section "fip_50" %}}
 
 ## Billets FIP 50
 
-Les Billets FIP 50 peuvent être achetés aux « Station Booking Offices » d'Irish Rail.
+Les Billets FIP 50 peuvent être achetés aux « Station Booking Offices » d’Irish Rail.
 
 {{% /booking-section %}}

--- a/content/booking/irish-rail-website/index.fr.md
+++ b/content/booking/irish-rail-website/index.fr.md
@@ -17,7 +17,7 @@ params:
 
 ## Réservations
 
-Les réservations pour la 2e classe peuvent être achetées en ligne. Pour ce faire, il faut d'abord sélectionner l'option passager :
+Les réservations pour la 2e classe peuvent être achetées en ligne. Pour ce faire, il faut d’abord sélectionner l’option passager :
 
 ![Ouvrir les options passager](./reservation-step-1.png)
 
@@ -28,7 +28,7 @@ Les réservations pour la 2e classe peuvent être achetées en ligne. Pour ce fa
   position="left"
 %}}
 
-Ensuite, la sélection « Adults » peut être désactivée et l'option « Free Travel Pass » sélectionnée.
+Ensuite, la sélection « Adults » peut être désactivée et l’option « Free Travel Pass » sélectionnée.
 
 {{% /float-image %}}
 
@@ -39,7 +39,7 @@ Les prix affichés pour la Premier Class incluent la différence de prix entre l
 Les réservations pour les Coupons FIP de 1re classe ne peuvent pas être effectuées en ligne via Irish Rail.
 
 {{% highlight tip %}}
-En Irlande, le nom des passagers est en principe affiché sur les afficheurs de réservations dans les trains. Si cela n'est pas souhaité, il est possible d'indiquer lors de la réservation que le numéro de billet soit affiché à la place.
+En Irlande, le nom des passagers est en principe affiché sur les afficheurs de réservations dans les trains. Si cela n’est pas souhaité, il est possible d’indiquer lors de la réservation que le numéro de billet soit affiché à la place.
 {{% /highlight %}}
 
 {{% /booking-section %}}

--- a/content/booking/kml-ticket-office/index.fr.md
+++ b/content/booking/kml-ticket-office/index.fr.md
@@ -9,7 +9,7 @@ params:
   type: "onsite"
 ---
 
-La KMŁ exploite un réseau limité de guichets dans les gares les plus importantes. Il est utile de parler un peu polonais ou de disposer d'une application de traduction adaptée, car l'anglais (ou l'allemand) n'est souvent pas très répandu.
+La KMŁ exploite un réseau limité de guichets dans les gares les plus importantes. Il est utile de parler un peu polonais ou de disposer d’une application de traduction adaptée, car l’anglais (ou l’allemand) n’est souvent pas très répandu.
 
 {{% booking-section "fip_50" %}}
 

--- a/content/booking/ks-ticket-office/index.fr.md
+++ b/content/booking/ks-ticket-office/index.fr.md
@@ -9,7 +9,7 @@ params:
   type: "onsite"
 ---
 
-KŚ exploite un vaste réseau de guichets, également dans les petites gares. Il est avantageux de parler un peu polonais ou d'avoir l'application traducteur appropriée, car l'anglais (ou l'allemand) n'est souvent pas très répandu.
+KŚ exploite un vaste réseau de guichets, également dans les petites gares. Il est avantageux de parler un peu polonais ou d’avoir l’application traducteur appropriée, car l’anglais (ou l’allemand) n’est souvent pas très répandu.
 
 {{% booking-section "fip_50" %}}
 

--- a/content/booking/ks-website/index.fr.md
+++ b/content/booking/ks-website/index.fr.md
@@ -9,7 +9,7 @@ params:
   type: "website"
 ---
 
-Le site Web est théoriquement disponible en polonais et en anglais, cependant, l'outil de recherche de connexions ne fonctionne actuellement qu'en polonais.
+Le site Web est théoriquement disponible en polonais et en anglais, cependant, l’outil de recherche de connexions ne fonctionne actuellement qu’en polonais.
 
 {{% booking-section "fip_50" %}}
 
@@ -17,7 +17,7 @@ Le site Web est théoriquement disponible en polonais et en anglais, cependant, 
 
 Sur le site Web de Koleje Śląskie vous pouvez acheter en ligne des billets avec réduction FIP 50 pour les trajets KŚ.
 
-Pour cela, vous devez d'abord sélectionner une connexion, puis lors de l'achat du billet, sélectionner « FIP (50%) » comme option de réduction. La réduction s'applique uniquement aux tarifs normaux (_LINIOWY RELACJA_). Le type de tarif peut être sélectionné dans le champ à côté de l'option de réduction. Pour les autres tarifs, un avertissement s'affiche et l'étape suivante du processus de commande vérifie quel billet est le moins cher.
+Pour cela, vous devez d’abord sélectionner une connexion, puis lors de l’achat du billet, sélectionner « FIP (50%) » comme option de réduction. La réduction s’applique uniquement aux tarifs normaux (_LINIOWY RELACJA_). Le type de tarif peut être sélectionné dans le champ à côté de l’option de réduction. Pour les autres tarifs, un avertissement s’affiche et l’étape suivante du processus de commande vérifie quel billet est le moins cher.
 
 ![Réserver un billet KS FIP 50](ks-discount.webp)
 

--- a/content/booking/lner-website/index.fr.md
+++ b/content/booking/lner-website/index.fr.md
@@ -17,12 +17,12 @@ params:
 
 ## Réservations
 
-Les réservations ne peuvent être effectuées que sur la version britannique du site LNER (www.lner.co.uk). Lors de la visite du site, il faut impérativement sélectionner l'option « Stay on lner.co.uk » dans la fenêtre pop-up.
+Les réservations ne peuvent être effectuées que sur la version britannique du site LNER (www.lner.co.uk). Lors de la visite du site, il faut impérativement sélectionner l’option « Stay on lner.co.uk » dans la fenêtre pop-up.
 
 ![Site Web LNER rester sur lner.co.uk](lner-website.webp)
 
-Sur le site web de LNER, il est possible de réserver gratuitement des places assises pour les services LNER. Pour cela, sélectionnez _Reserve Spaces_ sur la page d'accueil et entrez votre itinéraire. Après avoir sélectionné un train, le site demande une confirmation de réservation. Sélectionnez _My booking is not listed_ puis _Other_. Le formulaire demande également une référence de réservation, mais n'importe quelle valeur peut être saisie. Nous recommandons d'indiquer « FIP Coupon » dans le champ _additional details_.
+Sur le site web de LNER, il est possible de réserver gratuitement des places assises pour les services LNER. Pour cela, sélectionnez _Reserve Spaces_ sur la page d’accueil et entrez votre itinéraire. Après avoir sélectionné un train, le site demande une confirmation de réservation. Sélectionnez _My booking is not listed_ puis _Other_. Le formulaire demande également une référence de réservation, mais n’importe quelle valeur peut être saisie. Nous recommandons d’indiquer « FIP Coupon » dans le champ _additional details_.
 
-Après avoir sélectionné _Reserve a seat_ et/ou _Reserve a bike space_, la réservation est émise sous forme de billet électronique, consultable dans l'application et ajoutée au portefeuille mobile. Une place est automatiquement attribuée, mais peut être modifiée par la suite.
+Après avoir sélectionné _Reserve a seat_ et/ou _Reserve a bike space_, la réservation est émise sous forme de billet électronique, consultable dans l’application et ajoutée au portefeuille mobile. Une place est automatiquement attribuée, mais peut être modifiée par la suite.
 
 {{% /booking-section %}}

--- a/content/booking/ns-phone/index.fr.md
+++ b/content/booking/ns-phone/index.fr.md
@@ -24,7 +24,7 @@ La hotline est joignable tous les jours de 7h à 23h.
 
 ## Billets FIP 50
 
-Les billets FIP 50 peuvent être achetés pour les Pays-Bas et d'autres pays.
+Les billets FIP 50 peuvent être achetés pour les Pays-Bas et d’autres pays.
 
 {{% /booking-section %}}
 
@@ -32,6 +32,6 @@ Les billets FIP 50 peuvent être achetés pour les Pays-Bas et d'autres pays.
 
 ## Réservations
 
-Les réservations peuvent être effectuées pour les Pays-Bas et d'autres pays comme la Belgique, l'Allemagne et la France.
+Les réservations peuvent être effectuées pour les Pays-Bas et d’autres pays comme la Belgique, l’Allemagne et la France.
 
 {{% /booking-section %}}

--- a/content/booking/oebb-phone/index.fr.md
+++ b/content/booking/oebb-phone/index.fr.md
@@ -40,7 +40,7 @@ Les billets sont moins chers s’ils sont achetés à l’avance (1 jour avant l
 
 ## Réservations
 
-Le tarif de réservation est facturé par trajet. Ainsi, pour les correspondances avec changement, il n'est nécessaire de payer qu'une seule fois pour plusieurs trains.
+Le tarif de réservation est facturé par trajet. Ainsi, pour les correspondances avec changement, il n’est nécessaire de payer qu’une seule fois pour plusieurs trains.
 
 Les réservations de sièges ÖBB peuvent être annulées :
 

--- a/content/booking/oebb-ticket-office/index.fr.md
+++ b/content/booking/oebb-ticket-office/index.fr.md
@@ -30,7 +30,7 @@ Les billets (y compris les Billets FIP 50) sont moins chers s’ils sont acheté
 
 ## Réservations
 
-Le tarif de réservation est facturé par trajet. Ainsi, pour les correspondances avec changement, il n'est nécessaire de payer qu'une seule fois pour plusieurs trains.
+Le tarif de réservation est facturé par trajet. Ainsi, pour les correspondances avec changement, il n’est nécessaire de payer qu’une seule fois pour plusieurs trains.
 
 Les réservations de sièges ÖBB peuvent être annulées :
 

--- a/content/booking/oebb-website/index.fr.md
+++ b/content/booking/oebb-website/index.fr.md
@@ -21,9 +21,9 @@ aliases:
 
 ## Réservations
 
-Le tarif de réservation est facturé par trajet. Ainsi, pour les correspondances avec changement, il n'est nécessaire de payer qu'une seule fois pour plusieurs trains.
+Le tarif de réservation est facturé par trajet. Ainsi, pour les correspondances avec changement, il n’est nécessaire de payer qu’une seule fois pour plusieurs trains.
 
-Les réservations effectuées via le site d'ÖBB peuvent être annulées :
+Les réservations effectuées via le site d’ÖBB peuvent être annulées :
 
 - De 180 à 15 jours avant le départ : remboursement de 100 % du prix de la réservation
 - De 14 à 1 jour avant le départ : remboursement de 50 %

--- a/content/booking/railtourguide-website/index.fr.md
+++ b/content/booking/railtourguide-website/index.fr.md
@@ -3,7 +3,7 @@ draft: false
 title: "Site Web RailTourGuide"
 description: "Informations de réservation pour le site web RailTourGuide."
 params:
-  fee: 3 £ (jusqu'au 31.05.2026), ensuite 5 £ / 10 £
+  fee: 3 £ (jusqu’au 31.05.2026), ensuite 5 £ / 10 £
   fip_global_fare: true
   booking_link: "https://www.railtourguide.com/rail-staff-travel-eurostar/"
   type: "website"
@@ -13,13 +13,13 @@ params:
 
 ## Tarif Global FIP
 
-Des billets au Tarif Global FIP peuvent être achetés via RailTourGuide. Les prix sont disponibles sur le site web et varient selon l'itinéraire, la classe de voyage et le statut du passager (personne protégée/non protégée).
+Des billets au Tarif Global FIP peuvent être achetés via RailTourGuide. Les prix sont disponibles sur le site web et varient selon l’itinéraire, la classe de voyage et le statut du passager (personne protégée/non protégée).
 
-Pour obtenir un devis, veuillez remplir le formulaire en ligne et vous inscrire comme client auprès de RailTourGuide. Votre demande sera traitée sous 24 heures, pendant les heures d'ouverture de RailTourGuide. Le paiement sera effectué ultérieurement.
+Pour obtenir un devis, veuillez remplir le formulaire en ligne et vous inscrire comme client auprès de RailTourGuide. Votre demande sera traitée sous 24 heures, pendant les heures d’ouverture de RailTourGuide. Le paiement sera effectué ultérieurement.
 
 {{% /booking-section %}}
 
 **Des frais de réservation sont facturés par réservation :**
 
-- Paiement par virement bancaire : 3 £ (jusqu'au 31.05.2026), ensuite 5 £.
+- Paiement par virement bancaire : 3 £ (jusqu’au 31.05.2026), ensuite 5 £.
 - Paiement par carte de crédit : 10 £.

--- a/content/booking/stena-line-bv-email/index.fr.md
+++ b/content/booking/stena-line-bv-email/index.fr.md
@@ -12,20 +12,20 @@ aliases:
   - stena-line-email
 ---
 
-La réservation auprès de Stena Line peut être effectuée facilement par e-mail. Pour cela, il suffit d'envoyer un e-mail en anglais ou en néerlandais à [contact.nl@stenaline.com](mailto:contact.nl@stenaline.com).
-Les informations suivantes doivent être indiquées dans l'e-mail:
+La réservation auprès de Stena Line peut être effectuée facilement par e-mail. Pour cela, il suffit d’envoyer un e-mail en anglais ou en néerlandais à [contact.nl@stenaline.com](mailto:contact.nl@stenaline.com).
+Les informations suivantes doivent être indiquées dans l’e-mail:
 
 - Date et heure du voyage
 - Type de cabine (Standard, Supérieure et Deluxe)
-- Nom de voyageurs tel qu'il figure sur leur passeport
-- Numéro et date d'expiration du passeport
+- Nom de voyageurs tel qu’il figure sur leur passeport
+- Numéro et date d’expiration du passeport
 - Copie de la Carte FIP (recto et verso)
 
 En règle générale, Stena Line vous envoie deux e-mails de réponse. Le premier e-mail confirme la demande de réservation. Le deuxième e-mail vous propose une option de paiement via pay per link. Vous devez alors saisir les données de votre carte de crédit.
 Une fois le paiement effectué, vous recevez un e-mail avec la confirmation de réservation, qui fait également office de billet. Vous devez bien sûr emporter avec vous les billets FIP.
 
 {{% highlight important %}}
-Le paiement via pay per link n'est possible que le jour même où l'e-mail correspondant à la demande de paiement a été reçu. Le lien expire à minuit. Si tel est le cas, veuillez recontacter Stena Line.
+Le paiement via pay per link n’est possible que le jour même où l’e-mail correspondant à la demande de paiement a été reçu. Le lien expire à minuit. Si tel est le cas, veuillez recontacter Stena Line.
 {{% /highlight %}}
 
 {{% booking-section "fip_50" %}}

--- a/content/booking/stena-line-bv-ticket-office/index.fr.md
+++ b/content/booking/stena-line-bv-ticket-office/index.fr.md
@@ -30,4 +30,4 @@ Les réservations de cabine sont disponibles et obligatoires pour les trajets de
 
 [^1]: [Demande par e-mail de l’équipe FIP Guide à Stena Line](https://github.com/fipguide/fipguide.github.io/issues/528)
 
-[^2]: [Communauté FIP Guide - Retour d'information](https://discord.com/channels/1250522473188032512/1433789686039707688/1491886477347651764)
+[^2]: [Communauté FIP Guide - Retour d’information](https://discord.com/channels/1250522473188032512/1433789686039707688/1491886477347651764)

--- a/content/booking/stena-line-limited-email/index.fr.md
+++ b/content/booking/stena-line-limited-email/index.fr.md
@@ -10,7 +10,7 @@ params:
 ---
 
 La réservation auprès de Stena Line est facilement possible par e-mail. Pour ce faire, envoyez un e-mail à [info.cherbourg@stenaline.com](mailto:info.cherbourg@stenaline.com).[^1]
-L'e-mail doit contenir les informations suivantes:
+L’e-mail doit contenir les informations suivantes:
 
 - Prénom et nom des voyageurs
 - Date de naissance des voyageurs
@@ -31,4 +31,4 @@ Les billets FIP 50 peuvent être réservés.
 
 ## Sources
 
-[^1]: [Communauté FIP Guide - Retour d'information](https://discord.com/channels/1250522473188032512/1433789686039707688/1481942947917467669)
+[^1]: [Communauté FIP Guide - Retour d’information](https://discord.com/channels/1250522473188032512/1433789686039707688/1481942947917467669)

--- a/content/contact/index.fr.md
+++ b/content/contact/index.fr.md
@@ -1,11 +1,11 @@
 ---
 title: "Contact"
-description: "Contactez l'équipe derrière le FIP Guide – nous sommes à votre disposition pour vos questions, remarques ou contributions de contenu."
+description: "Contactez l’équipe derrière le FIP Guide – nous sommes à votre disposition pour vos questions, remarques ou contributions de contenu."
 ---
 
 ## Communauté FIP Guide
 
-Vous pouvez facilement partager vos questions et vos expériences avec l'équipe du FIP Guide et les autres voyageurs FIP via la communauté FIP Guide.
+Vous pouvez facilement partager vos questions et vos expériences avec l’équipe du FIP Guide et les autres voyageurs FIP via la communauté FIP Guide.
 
 La communauté FIP Guide est accessible via la plateforme en ligne _Discord_ et disponible en anglais, allemand et français. Vous pouvez également indiquer pour quelle compagnie ferroviaire vous travaillez, afin que les autres sachent immédiatement dans quel domaine vous êtes particulièrement compétent.
 
@@ -15,6 +15,6 @@ La communauté FIP Guide est accessible via la plateforme en ligne _Discord_ et 
 
 ## Mail
 
-Contactez l'équipe derrière le FIP Guide – nous sommes à votre disposition pour vos questions, remarques ou contributions de contenu.
+Contactez l’équipe derrière le FIP Guide – nous sommes à votre disposition pour vos questions, remarques ou contributions de contenu.
 
 {{< contact-form >}}

--- a/content/country/france/index.fr.md
+++ b/content/country/france/index.fr.md
@@ -62,7 +62,7 @@ Il existe aussi différentes liaisons régionales `TER` entre la Belgique et la 
 
 ### Luxembourg
 
-Depuis le Luxembourg, la SNCF exploite des trains internationaux `TGV` vers Paris, Strasbourg, Lyon, Montpellier et Marseille. Pour ces trains, il faut acheter des billets au Tarif Global FIP, qui sont coûteux. Il existe aussi plusieurs liaisons régionales entre le Luxembourg et la France via Rodange ou Bettembourg, accessibles avec FIP. Dans la section luxembourgeoise, les billets FIP 50 et les Coupons FIP CFL sont valables, et du côté français, les billets FIP de la SNCF sont valables jusqu'au point frontière.
+Depuis le Luxembourg, la SNCF exploite des trains internationaux `TGV` vers Paris, Strasbourg, Lyon, Montpellier et Marseille. Pour ces trains, il faut acheter des billets au Tarif Global FIP, qui sont coûteux. Il existe aussi plusieurs liaisons régionales entre le Luxembourg et la France via Rodange ou Bettembourg, accessibles avec FIP. Dans la section luxembourgeoise, les billets FIP 50 et les Coupons FIP CFL sont valables, et du côté français, les billets FIP de la SNCF sont valables jusqu’au point frontière.
 
 Bien que les voyages en 2ᵉ classe au Luxembourg soient gratuits, un billet ou un Coupon FIP est nécessaire à partir du point-frontière pour les voyages transfrontaliers. Cela signifie qu’il faut disposer soit d’un billet continu, soit au minimum d’un Coupon FIP SNCF valable. En 1ʳᵉ classe, ceci est également requis sur le tronçon luxembourgeois.
 
@@ -76,7 +76,7 @@ Entre la France et l’Allemagne circulent des trains longue distance en coopér
 Une option économique pour rejoindre Strasbourg depuis l’Allemagne est la ligne Ortenau S-Bahn RS4, exploitée par SWEG Südwestdeutsche Landesverkehrs-GmbH, d’Offenburg à Kehl. FIP n’est pas valable sur cette ligne, mais le Deutschlandticket et les réductions nationales DB pour les employés[^3] (TagesTicket M Fern F, DB Job-Ticket M, NetzCard + billet supplémentaire NE) sont acceptés. Depuis Kehl, le tram dessert Strasbourg, pour lequel un ticket de tram bon marché est nécessaire.
 {{% /highlight %}}
 {{% highlight important %}}
-Quelques trains `TGV` circulent de Fribourg à Paris et sont entièrement exploités par la SNCF, y compris en Allemagne. Pour ces trains, seule la SNCF est indiquée comme exploitant, voir [Identifier l'exploitant du train et rechercher des liaisons](#informations-fip). Dans ces trains, les Coupons FIP DB et les réductions nationales pour les employés DB ne sont pas valables en Allemagne. À la place, des billets au Tarif Global FIP de la SNCF peuvent être achetés.
+Quelques trains `TGV` circulent de Fribourg à Paris et sont entièrement exploités par la SNCF, y compris en Allemagne. Pour ces trains, seule la SNCF est indiquée comme exploitant, voir [Identifier l’exploitant du train et rechercher des liaisons](#informations-fip). Dans ces trains, les Coupons FIP DB et les réductions nationales pour les employés DB ne sont pas valables en Allemagne. À la place, des billets au Tarif Global FIP de la SNCF peuvent être achetés.
 {{% /highlight %}}
 Il existe aussi plusieurs liaisons régionales exploitées par la DB et la SNCF entre l’Allemagne et la France, accessibles avec FIP. Les Billets FIP 50 classiques et les Coupons FIP DB sont valables sur le tronçon allemand, et à partir du point-frontière, les Coupons FIP SNCF sont requis. Billets FIP 50 pour ces liaisons peuvent être achetés en ligne, voir [Options de réservation – en ligne](/operator/sncf#en-ligne "Achat de billets et réservations – en ligne").
 

--- a/content/country/germany/index.fr.md
+++ b/content/country/germany/index.fr.md
@@ -235,16 +235,16 @@ Il existe aussi des liaisons régionales transfrontalières. L’Allemagne est �
 
 ### France
 
-Entre la France et l'Allemagne, des trains grandes lignes en coopération SNCF et DB circulent. Il s'agit de `TGV` ou `ICE` reliant Paris à Munich ou Karlsruhe, Mannheim et Francfort (Main) via Strasbourg ou Sarrebruck. En juillet et août, il existe également des [trains directs entre Francfort (Main) et Bordeaux les samedis](https://www.bahn.de/angebot/urlaub/bahnreisen/summerrail/bordeaux).
+Entre la France et l’Allemagne, des trains grandes lignes en coopération SNCF et DB circulent. Il s’agit de `TGV` ou `ICE` reliant Paris à Munich ou Karlsruhe, Mannheim et Francfort (Main) via Strasbourg ou Sarrebruck. En juillet et août, il existe également des [trains directs entre Francfort (Main) et Bordeaux les samedis](https://www.bahn.de/angebot/urlaub/bahnreisen/summerrail/bordeaux).
 
-La réservation est obligatoire uniquement en France. En Allemagne, ces trains peuvent être utilisés sans réservation. Comme l'obligation de réservation s'applique jusqu'au point frontière Kehl (Gr) sur la route via Strasbourg et Karlsruhe, une réservation est également nécessaire pour les trajets entre Strasbourg et l'Allemagne. Ces billets FIP transfrontaliers peuvent être achetés en ligne par les agents DB, voir [Achat en ligne](/operator/sncf#online "Achat en ligne").
+La réservation est obligatoire uniquement en France. En Allemagne, ces trains peuvent être utilisés sans réservation. Comme l’obligation de réservation s’applique jusqu’au point frontière Kehl (Gr) sur la route via Strasbourg et Karlsruhe, une réservation est également nécessaire pour les trajets entre Strasbourg et l’Allemagne. Ces billets FIP transfrontaliers peuvent être achetés en ligne par les agents DB, voir [Achat en ligne](/operator/sncf#online "Achat en ligne").
 
 {{% highlight tip %}}
-Une option économique pour rejoindre l'Allemagne depuis Strasbourg est le tram jusqu'à Kehl, nécessitant un simple billet de tram. À Kehl, correspondance avec la ligne RS4 de l'Ortenau S-Bahn, exploitée par SWEG Südwestdeutsche Landesverkehrs-GmbH, jusqu'à Offenburg. Le FIP n'est pas valable sur cette ligne, mais le Deutschlandticket et les réductions nationales DB pour les employés[^4] (TagesTicket M Fern F, DB Job-Ticket M, NetzCard + billet supplémentaire NE) le sont.
+Une option économique pour rejoindre l’Allemagne depuis Strasbourg est le tram jusqu’à Kehl, nécessitant un simple billet de tram. À Kehl, correspondance avec la ligne RS4 de l’Ortenau S-Bahn, exploitée par SWEG Südwestdeutsche Landesverkehrs-GmbH, jusqu’à Offenburg. Le FIP n’est pas valable sur cette ligne, mais le Deutschlandticket et les réductions nationales DB pour les employés[^4] (TagesTicket M Fern F, DB Job-Ticket M, NetzCard + billet supplémentaire NE) le sont.
 {{% /highlight %}}
 
 {{% highlight important %}}
-Quelques trains `TGV` circulent de Paris à Fribourg et sont entièrement exploités par la SNCF, y compris en Allemagne. Pour ces trains, seule la SNCF est indiquée comme exploitant, voir [Identifier l'exploitant du train et rechercher des liaisons](#informations-fip). Dans ces trains, les Coupons FIP DB et les réductions nationales pour les employés DB ne sont pas valables en Allemagne. À la place, des billets au Tarif Global FIP de la SNCF peuvent être achetés.
+Quelques trains `TGV` circulent de Paris à Fribourg et sont entièrement exploités par la SNCF, y compris en Allemagne. Pour ces trains, seule la SNCF est indiquée comme exploitant, voir [Identifier l’exploitant du train et rechercher des liaisons](#informations-fip). Dans ces trains, les Coupons FIP DB et les réductions nationales pour les employés DB ne sont pas valables en Allemagne. À la place, des billets au Tarif Global FIP de la SNCF peuvent être achetés.
 {{% /highlight %}}
 
 En plus des grandes lignes, plusieurs liaisons régionales existent. Pour les utiliser sur tout le trajet, il faut des Coupons FIP de la DB et de la SNCF ou un billet FIP 50 valable sur toute la ligne. Exemples : Metz – Sarrebruck ou Wissembourg – Neustadt an der Weinstraße. Les trains Strasbourg – Kehl/Offenburg sont exploités côté allemand par la SWEG, où les Coupons FIP DB ne sont pas valables.
@@ -268,10 +268,10 @@ Avec Eurostar (anciennement Thalys), le réseau DB est également accessible dep
 
 #### Régional
 
-Le S41 exploité par la SNCB circule entre Liège-Saint-Lambert et Aix-la-Chapelle. Lors de l'utilisation du S41, il n'est actuellement pas clairement réglementé si un changement tarifaire d'opérateur a lieu à Aachen Süd(Gr).[^5] Il est donc incertain si un billet DB (par ex. Coupon FIP DB, avantage tarifaire national pour les employés DB ou Billet FIP 50) est nécessaire entre Aachen Süd (Gr) et Aachen Hbf, ou si les Coupons FIP de la SNCB sont acceptés jusqu'à Aachen Hbf.
+Le S41 exploité par la SNCB circule entre Liège-Saint-Lambert et Aix-la-Chapelle. Lors de l’utilisation du S41, il n’est actuellement pas clairement réglementé si un changement tarifaire d’opérateur a lieu à Aachen Süd(Gr).[^5] Il est donc incertain si un billet DB (par ex. Coupon FIP DB, avantage tarifaire national pour les employés DB ou Billet FIP 50) est nécessaire entre Aachen Süd (Gr) et Aachen Hbf, ou si les Coupons FIP de la SNCB sont acceptés jusqu’à Aachen Hbf.
 
 {{% highlight tip %}}
-Nous recommandons d'interroger le personnel du train. En cas de doute, le billet pour la courte section allemande peut être acheté auprès du personnel du train au tarif normal de 2,20€ (1re & 2e classe, en vigueur en mars 2026).
+Nous recommandons d’interroger le personnel du train. En cas de doute, le billet pour la courte section allemande peut être acheté auprès du personnel du train au tarif normal de 2,20€ (1re & 2e classe, en vigueur en mars 2026).
 {{% /highlight %}}
 
 ### Pays-Bas
@@ -295,6 +295,6 @@ Sur les `RE` Venlo – Hamm et Arnhem – Düsseldorf, le Deutschlandticket est 
 
 [^3]: [Retour d’expérience Außenfernbahn](https://github.com/fipguide/fipguide.github.io/issues/606)
 
-[^4]: [DB Mobidig - Où ma réduction de voyage s'applique](https://db-mobidig.deutschebahn.com/md-home/Navigation/Wo-gilt-meine-Fahrverguenstigung-9077792#9077818)
+[^4]: [DB Mobidig - Où ma réduction de voyage s’applique](https://db-mobidig.deutschebahn.com/md-home/Navigation/Wo-gilt-meine-Fahrverguenstigung-9077792#9077818)
 
-[^5]: [Communauté FIP Guide - Retour d'information](https://discord.com/channels/1250522473188032512/1480609147828441108/1480609147828441108)
+[^5]: [Communauté FIP Guide - Retour d’information](https://discord.com/channels/1250522473188032512/1480609147828441108/1480609147828441108)

--- a/content/country/greece/index.fr.md
+++ b/content/country/greece/index.fr.md
@@ -10,21 +10,21 @@ params:
 
 ## Informations FIP
 
-En Grèce, les Billets FIP 50 ainsi que les Coupons FIP sont acceptés par les chemins de fer nationaux [Hellenic Train](/operator/ht). Cette acceptation s'applique à la quasi-totalité du réseau exploité par Hellenic Train, y compris les services grandes lignes, régionaux et de banlieue (Proastiakos).
+En Grèce, les Billets FIP 50 ainsi que les Coupons FIP sont acceptés par les chemins de fer nationaux [Hellenic Train](/operator/ht). Cette acceptation s’applique à la quasi-totalité du réseau exploité par Hellenic Train, y compris les services grandes lignes, régionaux et de banlieue (Proastiakos).
 
-Les avantages FIP peuvent également être utilisés sur les navires d'[Attica](/operator/attica).
+Les avantages FIP peuvent également être utilisés sur les navires d’[Attica](/operator/attica).
 
-Les billets FIP ne sont pas acceptés dans les transports urbains d'Athènes (Αθήνα) et de Thessalonique (Θεσσαλονίκη).
+Les billets FIP ne sont pas acceptés dans les transports urbains d’Athènes (Αθήνα) et de Thessalonique (Θεσσαλονίκη).
 
 {{< identify-operator sources="ht-website,db-website" >}}
-À l'exception des transports urbains, Hellenic Train est le seul opérateur de liaisons ferroviaires régulières en Grèce.
+À l’exception des transports urbains, Hellenic Train est le seul opérateur de liaisons ferroviaires régulières en Grèce.
 {{< /identify-operator >}}
 
 ## Informations générales
 
-Le réseau ferroviaire grec fait l'objet d'une expansion et d'une modernisation progressives depuis des années, l'axe Athènes – Thessalonique étant considéré comme la liaison la plus importante. Cette ligne est également électrifiée. Les liaisons régionales en dehors de cet axe principal sont souvent plus lentes et moins fréquentes.
+Le réseau ferroviaire grec fait l’objet d’une expansion et d’une modernisation progressives depuis des années, l’axe Athènes – Thessalonique étant considéré comme la liaison la plus importante. Cette ligne est également électrifiée. Les liaisons régionales en dehors de cet axe principal sont souvent plus lentes et moins fréquentes.
 
-La qualité des trains varie : si des rames électriques modernes circulent sur les lignes principales, de nombreux trains régionaux sont plus anciens. La ponctualité est moyenne à l'échelle européenne et dépend fortement de la ligne concernée. Parmi les itinéraires particulièrement pittoresques, on trouve le chemin de fer du Pélion et la liaison à travers la vallée de Tempé entre Larisa et Katerini. Les gares de Thessalonique et d'Athènes sont considérées comme les principaux nœuds de transport du pays.
+La qualité des trains varie : si des rames électriques modernes circulent sur les lignes principales, de nombreux trains régionaux sont plus anciens. La ponctualité est moyenne à l’échelle européenne et dépend fortement de la ligne concernée. Parmi les itinéraires particulièrement pittoresques, on trouve le chemin de fer du Pélion et la liaison à travers la vallée de Tempé entre Larisa et Katerini. Les gares de Thessalonique et d’Athènes sont considérées comme les principaux nœuds de transport du pays.
 
 ## Arrivée et points frontières
 
@@ -37,25 +37,25 @@ La qualité des trains varie : si des rames électriques modernes circulent sur 
 | Turquie (TCDD)                                        | Pythio (Πύθιο)                  |
 | [Italie](/country/italy) ([Attica](/operator/attica)) | Patras (Πάτρα) [>Ancona, >Bari] |
 
-[>] = En direction de (par ex. Patras [> Ancona] = Patras est le point frontière en direction d'Ancona)
+[>] = En direction de (par ex. Patras [> Ancona] = Patras est le point frontière en direction d’Ancona)
 {{% /expander %}}
 
 ### Macédoine du Nord
 
-Il n'existe pas de service régulier de transport de voyageurs par rail entre la Grèce et la Macédoine du Nord. La liaison historique entre Thessalonique et Gevgelija/Skopje n'est actuellement pas exploitée. Les passages frontaliers ne peuvent donc pas être effectués en train ; les bus longue distance via les routes balkaniques constituent une alternative.
+Il n’existe pas de service régulier de transport de voyageurs par rail entre la Grèce et la Macédoine du Nord. La liaison historique entre Thessalonique et Gevgelija/Skopje n’est actuellement pas exploitée. Les passages frontaliers ne peuvent donc pas être effectués en train ; les bus longue distance via les routes balkaniques constituent une alternative.
 
 ### Bulgarie
 
-Il n'existe actuellement aucune liaison ferroviaire entre la Bulgarie et la Grèce. Les lignes exploitées par le passé, comme Sofia – Thessalonique, ont été supprimées. Le passage entre les deux pays doit donc se faire par bus longue distance ou par avion.
+Il n’existe actuellement aucune liaison ferroviaire entre la Bulgarie et la Grèce. Les lignes exploitées par le passé, comme Sofia – Thessalonique, ont été supprimées. Le passage entre les deux pays doit donc se faire par bus longue distance ou par avion.
 
 ### Turquie
 
-Il n'existe actuellement aucune liaison directe de transport de voyageurs entre la Grèce et la Turquie. L'ancienne liaison ferroviaire via Pythio vers Edirne/Istanbul n'est pas desservie par des trains internationaux. De plus, les avantages FIP ne sont pas valables en Turquie. Il est donc recommandé aux voyageurs d'utiliser les bus internationaux ou les vols entre les deux pays.
+Il n’existe actuellement aucune liaison directe de transport de voyageurs entre la Grèce et la Turquie. L’ancienne liaison ferroviaire via Pythio vers Edirne/Istanbul n’est pas desservie par des trains internationaux. De plus, les avantages FIP ne sont pas valables en Turquie. Il est donc recommandé aux voyageurs d’utiliser les bus internationaux ou les vols entre les deux pays.
 
 ### Italie
 
-Les liaisons par ferry d'[Attica](/operator/attica) peuvent être utilisées entre l'Italie et la Grèce.
+Les liaisons par ferry d’[Attica](/operator/attica) peuvent être utilisées entre l’Italie et la Grèce.
 
 ### Albanie
 
-Il n'existe pas de liaison ferroviaire entre l'Albanie et la Grèce.
+Il n’existe pas de liaison ferroviaire entre l’Albanie et la Grèce.

--- a/content/country/ireland/index.fr.md
+++ b/content/country/ireland/index.fr.md
@@ -9,17 +9,17 @@ params:
 
 ## Informations FIP
 
-Le réseau ferroviaire irlandais est exploité par la compagnie ferroviaire nationale [Irish Rail](/operator/cie) (Iarnród Éireann). Les réductions FIP s'appliquent à tous les trains d'Irish Rail.
+Le réseau ferroviaire irlandais est exploité par la compagnie ferroviaire nationale [Irish Rail](/operator/cie) (Iarnród Éireann). Les réductions FIP s’appliquent à tous les trains d’Irish Rail.
 
 {{< identify-operator sources="irish-rail-website,db-website" >}}
-À l'exception des services spéciaux, Irish Rail est le seul opérateur de liaisons ferroviaires régulières en Irlande.
+À l’exception des services spéciaux, Irish Rail est le seul opérateur de liaisons ferroviaires régulières en Irlande.
 {{< /identify-operator >}}
 
 ## Informations générales
 
 Le réseau ferroviaire irlandais est organisé en étoile autour de Dublin, depuis où partent des liaisons vers de nombreuses régions du pays. La fréquence entre les grandes villes est généralement bonne. Dans les régions plus rurales, la fréquence est parfois nettement plus faible.
 
-Les réservations ne sont pas obligatoires, mais sont recommandées en raison du taux d'occupation souvent élevé.
+Les réservations ne sont pas obligatoires, mais sont recommandées en raison du taux d’occupation souvent élevé.
 
 ## Arrivée et points frontières
 
@@ -34,14 +34,14 @@ Les réservations ne sont pas obligatoires, mais sont recommandées en raison du
 
 ### Royaume-Uni
 
-Il existe une liaison ferroviaire directe entre l'Irlande du Nord et la République d'Irlande entre Belfast et Dublin, connue sous le nom d'_Enterprise_, exploitée par [Irish Rail](/operator/cie) et les [Northern Ireland Railways](/operator/nir). Entre Dublin et Dundalk, les trains peuvent être empruntés avec les Coupons FIP CIE ; entre Dundalk et Belfast, les Coupons FIP NIR sont requis. Il est également possible d'acheter des Billets FIP 50 pour l'ensemble du trajet.
+Il existe une liaison ferroviaire directe entre l’Irlande du Nord et la République d’Irlande entre Belfast et Dublin, connue sous le nom d’_Enterprise_, exploitée par [Irish Rail](/operator/cie) et les [Northern Ireland Railways](/operator/nir). Entre Dublin et Dundalk, les trains peuvent être empruntés avec les Coupons FIP CIE ; entre Dundalk et Belfast, les Coupons FIP NIR sont requis. Il est également possible d’acheter des Billets FIP 50 pour l’ensemble du trajet.
 
-Outre le service Enterprise, il n'existe aucune autre liaison ferroviaire transfrontalière.
+Outre le service Enterprise, il n’existe aucune autre liaison ferroviaire transfrontalière.
 
 Depuis Dublin et Rosslare, des ferries Irish Ferries et Stena Line Limited relient Holyhead et Fishguard au Pays de Galles. Les liaisons par ferry de [Stena Line Limited](/operator/sll) sont accessibles à tarif réduit avec les Coupons FIP Stena Line Limited ou les Billets FIP 50.
 
 {{% highlight tip %}}
-Stena Line Limited et Irish Ferries proposent des billets permettant un voyage combiné train et ferry à prix réduit. Aucun rabais FIP supplémentaire n'est accordé sur ces billets.
+Stena Line Limited et Irish Ferries proposent des billets permettant un voyage combiné train et ferry à prix réduit. Aucun rabais FIP supplémentaire n’est accordé sur ces billets.
 
 - [Informations chez Stena Line (Rail & Sail)](https://www.stenaline.co.uk/rail-and-sail)
 - [Informations chez Irish Ferries (Sail & Rail)](https://www.irishferries.com/uk-en/special-offer-pages/ferry-rail)

--- a/content/country/romania/index.fr.md
+++ b/content/country/romania/index.fr.md
@@ -14,17 +14,17 @@ params:
 
 ## Informations FIP
 
-La Roumanie se prête globalement bien au voyage avec la FIP. Sur les axes principaux, c'est essentiellement la compagnie ferroviaire nationale roumaine [CFR Călători](/operator/cfr "CFR") qui assure les services, et les Coupons FIP ainsi que les Billets FIP 50 y sont acceptés. Il faut toutefois noter que sur certaines lignes, d'autres opérateurs circulent en parallèle et ne peuvent pas être utilisés avec la FIP.
+La Roumanie se prête globalement bien au voyage avec la FIP. Sur les axes principaux, c’est essentiellement la compagnie ferroviaire nationale roumaine [CFR Călători](/operator/cfr "CFR") qui assure les services, et les Coupons FIP ainsi que les Billets FIP 50 y sont acceptés. Il faut toutefois noter que sur certaines lignes, d’autres opérateurs circulent en parallèle et ne peuvent pas être utilisés avec la FIP.
 
-Les réservations sont obligatoires sur la plupart des lignes, mais elles sont relativement bon marché. Pour les Billets FIP 50 et les réservations, le guichet en gare est souvent le seul endroit où ceux-ci peuvent être achetés. Pour les liaisons internationales, les billets nécessaires ne sont disponibles qu'aux guichets internationaux spécialisés dans les grandes gares.
+Les réservations sont obligatoires sur la plupart des lignes, mais elles sont relativement bon marché. Pour les Billets FIP 50 et les réservations, le guichet en gare est souvent le seul endroit où ceux-ci peuvent être achetés. Pour les liaisons internationales, les billets nécessaires ne sont disponibles qu’aux guichets internationaux spécialisés dans les grandes gares.
 
 {{< identify-operator sources="cfr-website,cfr-international-website,db-website,vagonweb" />}}
 
 ## Informations générales
 
-Le réseau ferroviaire roumain s'étend sur environ 10 000 kilomètres et relie les principales villes entre elles. L'une des routes les plus importantes est la liaison est-ouest venant de Hongrie jusqu'à Constanța, sur la mer Noire. La plus grande gare du pays est București Nord, dans la capitale Bucarest. De là, des liaisons existent dans toutes les directions, y compris des services internationaux vers la Hongrie, la Bulgarie, la Moldavie et l'Ukraine.
+Le réseau ferroviaire roumain s’étend sur environ 10 000 kilomètres et relie les principales villes entre elles. L’une des routes les plus importantes est la liaison est-ouest venant de Hongrie jusqu’à Constanța, sur la mer Noire. La plus grande gare du pays est București Nord, dans la capitale Bucarest. De là, des liaisons existent dans toutes les directions, y compris des services internationaux vers la Hongrie, la Bulgarie, la Moldavie et l’Ukraine.
 
-Le réseau roumain, en grande partie vieillissant, est actuellement modernisé par endroits pour des vitesses plus élevées et pour répondre aux besoins futurs. La ligne la plus rapide à ce jour est celle entre Bucarest et Constanța, où des vitesses de 160 km/h sont possibles. Il n'y a souvent pas de véritable service cadencé, mais au moins sur les axes principaux, plusieurs liaisons sont réparties tout au long de la journée.
+Le réseau roumain, en grande partie vieillissant, est actuellement modernisé par endroits pour des vitesses plus élevées et pour répondre aux besoins futurs. La ligne la plus rapide à ce jour est celle entre Bucarest et Constanța, où des vitesses de 160 km/h sont possibles. Il n’y a souvent pas de véritable service cadencé, mais au moins sur les axes principaux, plusieurs liaisons sont réparties tout au long de la journée.
 
 Les lignes longeant les Carpates sont particulièrement pittoresques, par exemple entre Ploiești et Brașov. La gare de Sinaia, située sur cette ligne, est également un lieu de tournage prisé. Une scène de la série américaine Wednesday y a notamment été filmée.
 
@@ -43,17 +43,17 @@ Les lignes longeant les Carpates sont particulièrement pittoresques, par exempl
 
 ### Ukraine
 
-Par le passé, des trains directs ont été proposés de temps à autre via la frontière ukraino-roumaine, mais ceux-ci sont actuellement suspendus. À la place, un train direct circule actuellement entre Kyiv et Bucarest via la Moldavie. Les billets FIP ne peuvent être achetés que pour la section roumaine. Il peut toutefois être plus judicieux d'acheter un billet de train de nuit continu pour l'ensemble du trajet en ligne.
+Par le passé, des trains directs ont été proposés de temps à autre via la frontière ukraino-roumaine, mais ceux-ci sont actuellement suspendus. À la place, un train direct circule actuellement entre Kyiv et Bucarest via la Moldavie. Les billets FIP ne peuvent être achetés que pour la section roumaine. Il peut toutefois être plus judicieux d’acheter un billet de train de nuit continu pour l’ensemble du trajet en ligne.
 
 ### Moldavie
 
-Un train de nuit circule une fois par jour entre la capitale moldave Chișinău et Bucarest. En Roumanie, il est exploité par la CFR, mais en Moldavie par la CFM. Cette dernière n'étant pas membre de la FIP, les billets FIP ne sont valables qu'en Roumanie. Un billet au tarif normal doit donc être acheté pour la section moldave. Il peut toutefois être plus judicieux d'acheter un billet de train de nuit continu pour l'ensemble du trajet en ligne.
+Un train de nuit circule une fois par jour entre la capitale moldave Chișinău et Bucarest. En Roumanie, il est exploité par la CFR, mais en Moldavie par la CFM. Cette dernière n’étant pas membre de la FIP, les billets FIP ne sont valables qu’en Roumanie. Un billet au tarif normal doit donc être acheté pour la section moldave. Il peut toutefois être plus judicieux d’acheter un billet de train de nuit continu pour l’ensemble du trajet en ligne.
 
 ### Bulgarie
 
-Quelques trains circulent quotidiennement entre la Roumanie et la Bulgarie. C'est surtout en haute saison que ces trains sont importants, car il existe alors une paire de trains directs par jour entre les deux capitales Bucarest et Sofia, avec des voitures directes vers la mer Noire à Varna et même de nuit jusqu'à Istanbul en Turquie. Hors saison, cette paire de trains ne circule qu'entre Bucarest et Ruse, le premier arrêt en Bulgarie, où un changement est nécessaire.
+Quelques trains circulent quotidiennement entre la Roumanie et la Bulgarie. C’est surtout en haute saison que ces trains sont importants, car il existe alors une paire de trains directs par jour entre les deux capitales Bucarest et Sofia, avec des voitures directes vers la mer Noire à Varna et même de nuit jusqu’à Istanbul en Turquie. Hors saison, cette paire de trains ne circule qu’entre Bucarest et Ruse, le premier arrêt en Bulgarie, où un changement est nécessaire.
 
-Pour utiliser ces trains transfrontaliers avec la FIP, il faut soit un Coupon FIP pour chaque pays, soit un Billet FIP 50 continu. Une réservation est également obligatoire pour l'ensemble du trajet. Hors saison, une réservation pour la section bulgare à partir de Ruse suffit. Pour le train de nuit, une place en voiture-couchettes ou en voiture-lits peut également être réservée moyennant un supplément.
+Pour utiliser ces trains transfrontaliers avec la FIP, il faut soit un Coupon FIP pour chaque pays, soit un Billet FIP 50 continu. Une réservation est également obligatoire pour l’ensemble du trajet. Hors saison, une réservation pour la section bulgare à partir de Ruse suffit. Pour le train de nuit, une place en voiture-couchettes ou en voiture-lits peut également être réservée moyennant un supplément.
 
 Une autre liaison quotidienne entre les deux pays existe via le passage frontalier de Vidin. Un train circule quotidiennement de Vidin en Bulgarie à Craiova en Roumanie. Pour cette liaison, des Coupons FIP pour les deux pays ou un Billet FIP 50 continu suffisent.
 
@@ -63,4 +63,4 @@ Actuellement, aucun train de voyageurs ne circule entre la Serbie et la Roumanie
 
 ### Hongrie
 
-La plupart des liaisons internationales vers la Roumanie proviennent de Hongrie. Parmi celles-ci, on trouve aussi bien des trains de jour que des trains de nuit, comme le célèbre _Dacia_, qui relie Vienne en Autriche à Bucarest via Budapest. Ces liaisons peuvent être utilisées avec la FIP sur l'ensemble du trajet. Pour cela, il faut soit un Billet FIP 50 continu, soit des Coupons FIP de la CFR et de MÁV (en cas de départ depuis l'Autriche, un billet pour la section ÖBB est également nécessaire).
+La plupart des liaisons internationales vers la Roumanie proviennent de Hongrie. Parmi celles-ci, on trouve aussi bien des trains de jour que des trains de nuit, comme le célèbre _Dacia_, qui relie Vienne en Autriche à Bucarest via Budapest. Ces liaisons peuvent être utilisées avec la FIP sur l’ensemble du trajet. Pour cela, il faut soit un Billet FIP 50 continu, soit des Coupons FIP de la CFR et de MÁV (en cas de départ depuis l’Autriche, un billet pour la section ÖBB est également nécessaire).

--- a/content/country/spain/index.fr.md
+++ b/content/country/spain/index.fr.md
@@ -42,7 +42,7 @@ Pour les voyages longue distance, des contrôles de bagages sont effectués à l
 
 Depuis Paris, des `TGV` directs opérés par la SNCF rejoignent Barcelone. La Renfe propose également des liaisons transfrontalières entre Lyon et Barcelone, ainsi que Marseille et Madrid. Des Tarifs Globaux FIP sont disponibles chez les deux opérateurs, mais les prix SNCF sont souvent très élevés.
 
-Des Tarifs Globaux FIP sont disponibles auprès des deux opérateurs, mais ceux de la SNCF sont souvent très élevés (voir [TGV vers l'Italie, l'Espagne et la Belgique](/operator/sncf#tgv-italy-spain-belgium)). Pour les trains `AVE` exploités par Renfe, des billets au Tarif Global FIP sont disponibles à 25 € / 28 € (à jour : mai 2026), voir [Renfe – AVE](/operator/renfe#ave "Renfe – AVE"). Ces billets peuvent être achetés aux guichets Renfe en Espagne. Pour les trajets en provenance de France, il est également possible d’acheter ces billets à bord : il faut alors s’adresser au personnel du train, qui accepte le paiement par carte. [^1]
+Des Tarifs Globaux FIP sont disponibles auprès des deux opérateurs, mais ceux de la SNCF sont souvent très élevés (voir [TGV vers l’Italie, l’Espagne et la Belgique](/operator/sncf#tgv-italy-spain-belgium)). Pour les trains `AVE` exploités par Renfe, des billets au Tarif Global FIP sont disponibles à 25 € / 28 € (à jour : mai 2026), voir [Renfe – AVE](/operator/renfe#ave "Renfe – AVE"). Ces billets peuvent être achetés aux guichets Renfe en Espagne. Pour les trajets en provenance de France, il est également possible d’acheter ces billets à bord : il faut alors s’adresser au personnel du train, qui accepte le paiement par carte. [^1]
 
 Avec [Euskotren](/operator/euskotren), il est possible de voyager depuis Hendaye avec le Billet FIP spécial.
 

--- a/content/country/switzerland/index.fr.md
+++ b/content/country/switzerland/index.fr.md
@@ -104,4 +104,4 @@ Les trains `TER` de Lyon à Genève peuvent être utilisés jusqu’à Genève a
 
 [^1]: [SBB Deutschlandticket](https://www.sbb-deutschland.de/gilt-das-deutschlandticket-auf-unseren-strecken/)
 
-[^2]: [Communauté FIP Guide - Retour d'information](https://discord.com/channels/1250522473188032512/1441391294189408269/1453338148678664284)
+[^2]: [Communauté FIP Guide - Retour d’information](https://discord.com/channels/1250522473188032512/1441391294189408269/1453338148678664284)

--- a/content/general/faq/what-rules-apply-to-fip-coupons/_index.fr.md
+++ b/content/general/faq/what-rules-apply-to-fip-coupons/_index.fr.md
@@ -3,6 +3,6 @@ title: "Quelles règles s’appliquent aux Coupons FIP ?"
 weight: 8
 ---
 
-L'émission des Coupons FIP dépend de votre employeur. En règle générale, en un an civil, vous pouvez demander un Coupon FIP avec une à quatre cases par membre FIP. Des informations plus détaillées sont disponibles sur la [Demande FIP](/general/fip-validity/).
+L’émission des Coupons FIP dépend de votre employeur. En règle générale, en un an civil, vous pouvez demander un Coupon FIP avec une à quatre cases par membre FIP. Des informations plus détaillées sont disponibles sur la [Demande FIP](/general/fip-validity/).
 
 En règle générale, un délai de traitement s’applique lors de la demande.

--- a/content/general/generalinformation/index.fr.md
+++ b/content/general/generalinformation/index.fr.md
@@ -108,7 +108,7 @@ Pour certains trains, des tarifs spéciaux et des règles spéciales s’appliqu
 
 Les réductions FIP ne s’appliquent jamais sur les trains exploités par votre propre entreprise ferroviaire. Par conséquent, un billet différent est nécessaire dans votre pays d’origine.
 
-Ce n'est pas toujours le voyage avec des billets FIP qui est la solution la moins chère. Les billets FIP réduits accordent généralement une réduction sur le prix du billet flexible. Cependant, les billets liés aux trains, comme les tarifs réduits, peuvent néanmoins être moins chers.
+Ce n’est pas toujours le voyage avec des billets FIP qui est la solution la moins chère. Les billets FIP réduits accordent généralement une réduction sur le prix du billet flexible. Cependant, les billets liés aux trains, comme les tarifs réduits, peuvent néanmoins être moins chers.
 
 De plus, certaines compagnies ferroviaires accordent à leurs propres employés des billets à tarif réduit pour les trajets transfrontaliers vers l’étranger ou jusqu’à la frontière. L’utilisation de ces billets peut parfois être moins chère que l’utilisation du FIP pour le voyage à l’étranger. Vous trouverez plus d’informations sur ces offres dans la [Demande FIP](/general/fip-validity).
 

--- a/content/identify-operator/_index.fr.md
+++ b/content/identify-operator/_index.fr.md
@@ -1,5 +1,5 @@
 ---
-title: "Identifier l'opérateur"
+title: "Identifier l’opérateur"
 
 cascade:
   - build:

--- a/content/identify-operator/irish-rail-website/index.fr.md
+++ b/content/identify-operator/irish-rail-website/index.fr.md
@@ -4,4 +4,4 @@ params:
   url: "https://www.irishrail.ie/en-ie/"
 ---
 
-Le site web d'Irish Rail répertorie toutes les liaisons ferroviaires exploitées par Irish Rail. Le service Enterprise entre Dublin et Belfast y est également listé, mais il n'est exploité par Irish Rail qu'entre Dublin et Dundalk, voir aussi [Arrivée et points frontières](/country/ireland#royaume-uni).
+Le site web d’Irish Rail répertorie toutes les liaisons ferroviaires exploitées par Irish Rail. Le service Enterprise entre Dublin et Belfast y est également listé, mais il n’est exploité par Irish Rail qu’entre Dublin et Dundalk, voir aussi [Arrivée et points frontières](/country/ireland#royaume-uni).

--- a/content/identify-operator/translink-website/index.fr.md
+++ b/content/identify-operator/translink-website/index.fr.md
@@ -4,4 +4,4 @@ params:
   url: "https://www.translink.co.uk/"
 ---
 
-Le site web de Translink répertorie toutes les liaisons ferroviaires exploitées par Translink. Le service Enterprise entre Belfast et Dublin y est également listé, mais il n'est exploité par Translink qu'entre Belfast et Dundalk, voir aussi [Arrivée et points frontières](/country/united-kingdom#voyages-entre-la-grande-bretagne-et-lirlande-du-nord).
+Le site web de Translink répertorie toutes les liaisons ferroviaires exploitées par Translink. Le service Enterprise entre Belfast et Dublin y est également listé, mais il n’est exploité par Translink qu’entre Belfast et Dundalk, voir aussi [Arrivée et points frontières](/country/united-kingdom#voyages-entre-la-grande-bretagne-et-lirlande-du-nord).

--- a/content/news/10/index.fr.md
+++ b/content/news/10/index.fr.md
@@ -2,7 +2,7 @@
 date: "2026-05-02"
 draft: false
 title: "Mise à jour : Belgique : la SNCB met fin à la vente de billets à bord à partir du 1er juillet 2026"
-description: "À partir du 1er juillet 2026, la SNCB ne vendra plus de billets à bord de ses trains. Cela concerne également l'achat de billets FIP à tarif réduit."
+description: "À partir du 1er juillet 2026, la SNCB ne vendra plus de billets à bord de ses trains. Cela concerne également l’achat de billets FIP à tarif réduit."
 country:
   - belgium
 operator:
@@ -13,13 +13,13 @@ operator:
 
 ### Ce que cela signifie pour la FIP
 
-À partir du 1er juillet 2026, il ne sera plus possible d'acheter des billets à bord des trains de la SNCB en Belgique -- y compris les billets FIP à tarif réduit. Tous les voyageurs devront être en possession d'un billet valable avant de monter à bord.
+À partir du 1er juillet 2026, il ne sera plus possible d’acheter des billets à bord des trains de la SNCB en Belgique -- y compris les billets FIP à tarif réduit. Tous les voyageurs devront être en possession d’un billet valable avant de monter à bord.
 
 ### Billets FIP 50 aux distributeurs automatiques
 
-Il est prévu de rendre disponibles des billets avec une réduction de 50 % aux distributeurs de billets SNCB pour le personnel de la SNCB. Ceux-ci pourraient éventuellement être utilisés pour les Billets FIP 50. Toutefois, une confirmation officielle n'a pas encore été donnée. Pour les employés bénéficiant de la Réduction FIP de 75 % (p. ex. National Rail), il ne semble pas y avoir de solution à l'heure actuelle.
+Il est prévu de rendre disponibles des billets avec une réduction de 50 % aux distributeurs de billets SNCB pour le personnel de la SNCB. Ceux-ci pourraient éventuellement être utilisés pour les Billets FIP 50. Toutefois, une confirmation officielle n’a pas encore été donnée. Pour les employés bénéficiant de la Réduction FIP de 75 % (p. ex. National Rail), il ne semble pas y avoir de solution à l’heure actuelle.
 
-Nous vous tiendrons informés dès que de plus amples détails seront disponibles. En attendant, consultez la page [SNCB](/operator/sncb) pour les dernières informations sur les options d'achat de billets.
+Nous vous tiendrons informés dès que de plus amples détails seront disponibles. En attendant, consultez la page [SNCB](/operator/sncb) pour les dernières informations sur les options d’achat de billets.
 
 **Mise à jour 02.05.2026 :** \
 Il a été confirmé que ni les Billets FIP 50 ni les Billets FIP 75 ne seront disponibles aux distributeurs automatiques de la SNCB.

--- a/content/news/9/index.fr.md
+++ b/content/news/9/index.fr.md
@@ -1,7 +1,7 @@
 ---
 date: "2026-04-01"
 draft: false
-title: "L'opérateur polonais Koleje Małopolskie est le plus récent membre FIP"
+title: "L’opérateur polonais Koleje Małopolskie est le plus récent membre FIP"
 description: "Les Koleje Małopolskie (KMŁ) sont le plus récent membre FIP depuis le 1er avril 2026, élargissant ainsi la validité de la FIP en Pologne. Tous les détails ne sont pas encore connus."
 country:
   - poland
@@ -11,8 +11,8 @@ operator:
 
 Les Koleje Małopolskie (KMŁ) sont le plus récent membre FIP depuis le 1er avril 2026, élargissant ainsi la validité de la FIP en Pologne. Toutes les compagnies ferroviaires appartenant aux voïvodies peuvent désormais être utilisées avec les avantages FIP.
 
-La KMŁ propose des liaisons ferroviaires régionales dans la région de Cracovie. Avec ses trains, on peut par exemple rejoindre le célèbre parc d'attractions Energylandia (gare de Zator Park Rozrywki) ou la mine de sel de Wieliczka (gare de Wieliczka-Rynek-Kopalnia). Oświęcim est également directement accessible depuis Cracovie via la KMŁ.
+La KMŁ propose des liaisons ferroviaires régionales dans la région de Cracovie. Avec ses trains, on peut par exemple rejoindre le célèbre parc d’attractions Energylandia (gare de Zator Park Rozrywki) ou la mine de sel de Wieliczka (gare de Wieliczka-Rynek-Kopalnia). Oświęcim est également directement accessible depuis Cracovie via la KMŁ.
 
 Tout ce qui est déjà connu sur la validité FIP et les options de réservation est décrit sur la [page KMŁ](/operator/kml). Il est probable que les possibilités de réservation seront progressivement élargies avec les canaux supplémentaires connus des autres compagnies ferroviaires polonaises (par ex. Koleo). La page [Pologne](/country/poland) a également été mise à jour et indique quels opérateurs sont désormais tous intégrés dans la FIP.
 
-Concernant les Coupons FIP, veuillez noter qu'il n'est peut-être pas encore possible de les commander auprès de votre compagnie ferroviaire respective. Un rappel au service compétent pour les avantages de voyage est souvent utile, car l'intégration de la KMŁ dans la FIP a été annoncée à très court terme.
+Concernant les Coupons FIP, veuillez noter qu’il n’est peut-être pas encore possible de les commander auprès de votre compagnie ferroviaire respective. Un rappel au service compétent pour les avantages de voyage est souvent utile, car l’intégration de la KMŁ dans la FIP a été annoncée à très court terme.

--- a/content/operator/attica/index.fr.md
+++ b/content/operator/attica/index.fr.md
@@ -12,7 +12,7 @@ aliases:
   - /booking/attica-phone
 ---
 
-Le groupe Attica est un important opérateur grec de ferries exploitant plusieurs marques, dont Superfast Ferries, Blue Star Ferries, Hellenic Seaways et Anek Lines. L'entreprise exploite des liaisons maritimes nationales et internationales entre la Grèce continentale, l'Italie et les îles grecques.
+Le groupe Attica est un important opérateur grec de ferries exploitant plusieurs marques, dont Superfast Ferries, Blue Star Ferries, Hellenic Seaways et Anek Lines. L’entreprise exploite des liaisons maritimes nationales et internationales entre la Grèce continentale, l’Italie et les îles grecques.
 
 ## Résumé
 
@@ -36,7 +36,7 @@ Le groupe Attica est un important opérateur grec de ferries exploitant plusieur
     additional_information_url="https://www.superfast.com/de-de/hafen-und-destinationen"
 %}}
 
-Les bénéficiaires FIP obtiennent une réduction de 50 % sur les classes de cabines ou de sièges, quelle que soit la classe d'ayant droit.[^2]
+Les bénéficiaires FIP obtiennent une réduction de 50 % sur les classes de cabines ou de sièges, quelle que soit la classe d’ayant droit.[^2]
 
 #### Lignes régulières
 
@@ -61,19 +61,19 @@ Les bénéficiaires FIP obtiennent une réduction de 50 % sur les classes de cab
 
 Les bénéficiaires FIP obtiennent une réduction de 50 % sur les classes de cabines ou de sièges.
 
-- Les bénéficiaires FIP de 1ère classe peuvent voyager en Business Class ou sur des sièges de type avion. Sur les lignes Le Pirée – Héraklion et Le Pirée – La Canée, la réduction s'applique également à une cabine partagée AB4 (4 couchettes intérieures).
-- Les bénéficiaires FIP de 2ᵉ classe peuvent voyager en Economy Class sur le pont. Sur les lignes Le Pirée – Héraklion et Le Pirée – La Canée, la réduction s'applique également aux sièges de type avion.[^2]
+- Les bénéficiaires FIP de 1ère classe peuvent voyager en Business Class ou sur des sièges de type avion. Sur les lignes Le Pirée – Héraklion et Le Pirée – La Canée, la réduction s’applique également à une cabine partagée AB4 (4 couchettes intérieures).
+- Les bénéficiaires FIP de 2ᵉ classe peuvent voyager en Economy Class sur le pont. Sur les lignes Le Pirée – Héraklion et Le Pirée – La Canée, la réduction s’applique également aux sièges de type avion.[^2]
 
-La réduction ne s'applique qu'au personnel en activité et à leurs proches, pas aux retraités et à leurs proches.[^2]
+La réduction ne s’applique qu’au personnel en activité et à leurs proches, pas aux retraités et à leurs proches.[^2]
 
-Aucun avantage FIP n'est accordé en juillet et août.[^2]
+Aucun avantage FIP n’est accordé en juillet et août.[^2]
 
 #### Lignes régulières
 
 - Cyclades
 - Dodécanèse
 - Îles Saroniques
-- Îles de l'Égée du Nord
+- Îles de l’Égée du Nord
 - Crète
 
 {{% /train-category %}}
@@ -89,11 +89,11 @@ Les cabines LUX sont exclues de tous les avantages FIP.[^2]
 
 ## Achat de billets et réservations
 
-Les billets de ferry doivent impérativement être réservés avant le départ ; l'enregistrement au bureau du port est obligatoire.[^1]
+Les billets de ferry doivent impérativement être réservés avant le départ ; l’enregistrement au bureau du port est obligatoire.[^1]
 
-Sur les liaisons internationales, des suppléments carburant, des suppléments environnementaux, des frais EU ETS et des taxes portuaires s'appliquent.[^2]
-Pour les lignes intérieures, il n'est pas nécessaire de payer les taxes portuaires séparément, car elles sont incluses dans le tarif.
-Aucune réduction n'est accordée pour le transport de véhicules.[^1]
+Sur les liaisons internationales, des suppléments carburant, des suppléments environnementaux, des frais EU ETS et des taxes portuaires s’appliquent.[^2]
+Pour les lignes intérieures, il n’est pas nécessaire de payer les taxes portuaires séparément, car elles sont incluses dans le tarif.
+Aucune réduction n’est accordée pour le transport de véhicules.[^1]
 
 ### En ligne
 
@@ -107,11 +107,11 @@ Aucune réduction n'est accordée pour le transport de véhicules.[^1]
 
 {{% booking id="attica-agents" /%}}
 
-Le jour du voyage, des réservations peuvent être effectuées sur place sous réserve de disponibilité. L'achat à bord des navires n'est pas possible.[^1]
+Le jour du voyage, des réservations peuvent être effectuées sur place sous réserve de disponibilité. L’achat à bord des navires n’est pas possible.[^1]
 
 ## Réductions
 
-Les enfants de moins de 4 ans n'occupant pas de lit, de couchette ou de siège paient 5,50 € par traversée.
+Les enfants de moins de 4 ans n’occupant pas de lit, de couchette ou de siège paient 5,50 € par traversée.
 Sur les liaisons vers et depuis Ancône et Venise, les enfants de 4 à 16 ans paient 50 % du tarif adulte. Les personnes de 16 ans et plus paient le plein tarif adulte.
 Sur les liaisons vers et depuis Bari, les enfants de 4 à 12 ans paient 50 % du tarif adulte. Les personnes de 12 ans et plus paient le plein tarif adulte.[^1]
 
@@ -119,7 +119,7 @@ Sur les liaisons vers et depuis Bari, les enfants de 4 à 12 ans paient 50 % du 
 
 ### Surclassements
 
-Un surclassement de siège vers toute cabine (sauf LUX) est possible avec une réduction de 25 % sur la différence de prix entre l'arrangement initial et celui demandé. Les surclassements sont disponibles sous réserve de disponibilité dans les agences portuaires de Blue Star Ferries/Hellenic Seaways/Superfast Ferries/Anek Lines ou au bureau du commissaire de bord.[^2]
+Un surclassement de siège vers toute cabine (sauf LUX) est possible avec une réduction de 25 % sur la différence de prix entre l’arrangement initial et celui demandé. Les surclassements sont disponibles sous réserve de disponibilité dans les agences portuaires de Blue Star Ferries/Hellenic Seaways/Superfast Ferries/Anek Lines ou au bureau du commissaire de bord.[^2]
 
 ## Sources
 

--- a/content/operator/bdz/index.fr.md
+++ b/content/operator/bdz/index.fr.md
@@ -27,7 +27,7 @@ Les Coupons FIP et les Billets FIP 50 sont valables sur les services BDŽ. Pour 
 ## Catégories de trains et réservations
 
 {{% highlight important %}}
-Les catégories de trains sont affichées dans les horaires BDŽ comme décrit ci-dessous. Dans d'autres horaires, les trains sont souvent simplement indiqués comme `R` ou `IR`.
+Les catégories de trains sont affichées dans les horaires BDŽ comme décrit ci-dessous. Dans d’autres horaires, les trains sont souvent simplement indiqués comme `R` ou `IR`.
 {{% /highlight %}}
 
 {{% train-category
@@ -37,7 +37,7 @@ Les catégories de trains sont affichées dans les horaires BDŽ comme décrit c
     fip_accepted=true
     reservation_required=true
 %}}
-Trains internationaux reliant Bucarest (Roumanie) à Sofia ou Varna. Ces trains ne circulent directement qu'en été ; sinon, une correspondance à Ruse est nécessaire. Dans d'autres horaires, ils peuvent aussi être indiqués comme `IR`.
+Trains internationaux reliant Bucarest (Roumanie) à Sofia ou Varna. Ces trains ne circulent directement qu’en été ; sinon, une correspondance à Ruse est nécessaire. Dans d’autres horaires, ils peuvent aussi être indiqués comme `IR`.
 
 Certains trains de nuit comprennent également des voitures-couchettes ou des voitures-lits, qui peuvent être utilisées avec une réservation appropriée.
 
@@ -53,7 +53,7 @@ La réservation de siège est obligatoire en 1ère et 2ᵉ classe.
     fip_accepted=true
     reservation_required=partially
 %}}
-Trains relativement rapides reliant les grandes villes avec peu d'arrêts. Ils utilisent souvent du matériel plus moderne, par exemple d'anciennes voitures IC de la DB. Les trains de nuit peuvent inclure des voitures-couchettes ou lits, nécessitant une réservation.
+Trains relativement rapides reliant les grandes villes avec peu d’arrêts. Ils utilisent souvent du matériel plus moderne, par exemple d’anciennes voitures IC de la DB. Les trains de nuit peuvent inclure des voitures-couchettes ou lits, nécessitant une réservation.
 
 #### Réservations
 
@@ -67,7 +67,7 @@ Une réservation est obligatoire pour certains trains (indiqué par _R_).
     fip_accepted=true
     reservation_required=partially
 %}}
-Trains nationaux reliant des villes avec peu d'arrêts.
+Trains nationaux reliant des villes avec peu d’arrêts.
 
 #### Réservations
 
@@ -129,7 +129,7 @@ Pour les billets ordinaires, les enfants de moins de 7 ans voyagent gratuitement
 
 Si vous souhaitez voyager au-delà de la destination réservée, un supplément doit être payé en plus du billet pour la distance supplémentaire. [^1]
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 L’interruption de voyage n’est pas autorisée avec un billet continu.
 

--- a/content/operator/bls/index.fr.md
+++ b/content/operator/bls/index.fr.md
@@ -15,8 +15,8 @@ Sur son site web, la BLS propose une [carte schématique des lignes](https://www
 ## Résumé
 
 - La BLS accepte les Coupons FIP et les Billets FIP 50.
-- L'utilisation de tous les trains (sauf les trains motorail), bus et bateaux avec FIP est possible.
-- Il n'y a pas d'obligation de réservation.
+- L’utilisation de tous les trains (sauf les trains motorail), bus et bateaux avec FIP est possible.
+- Il n’y a pas d’obligation de réservation.
 
 ## Validité des Billets FIP
 
@@ -25,7 +25,7 @@ Sur son site web, la BLS propose une [carte schématique des lignes](https://www
 
 ## Catégories de trains et réservations
 
-Il n'y a pas d'obligation de réservation dans aucun train de la BLS.
+Il n’y a pas d’obligation de réservation dans aucun train de la BLS.
 
 {{% train-category
         id="ir"
@@ -46,7 +46,7 @@ Trains nationaux avec arrêts dans les grandes villes.
         reservation_required=false
         reservation_possible=false
 %}}
-Trains s'arrêtant à toutes les stations. Dans les zones urbaines, également appelés S-Bahn.
+Trains s’arrêtant à toutes les stations. Dans les zones urbaines, également appelés S-Bahn.
 {{% /train-category %}}
 
 {{% train-category
@@ -59,11 +59,11 @@ Trains s'arrêtant à toutes les stations. Dans les zones urbaines, également a
 %}}
 Le GoldenPassExpress est une liaison ferroviaire continue de Montreux à Interlaken Ost, exploitée par la BLS en coopération avec la [MOB](/operator/sp#mob). La MOB exploite le train sur le tronçon à voie métrique entre Montreux et Zweisimmen, et la BLS sur le tronçon à voie normale entre Zweisimmen et Interlaken Ost. Dans les informations de connexion, ces trains sont marqués comme `PE`.
 
-Cela signifie que des Coupons FIP des deux, SP et BLS, doivent être présents pour parcourir l'ensemble du trajet. Les Billets FIP 50 peuvent être réservés en continu.
+Cela signifie que des Coupons FIP des deux, SP et BLS, doivent être présents pour parcourir l’ensemble du trajet. Les Billets FIP 50 peuvent être réservés en continu.
 
 #### Réservations
 
-Un voyage sans réservation de siège n'est possible que s'il reste des places disponibles. Sinon, une réservation payante peut être effectuée via le site Web de la MOB.
+Un voyage sans réservation de siège n’est possible que s’il reste des places disponibles. Sinon, une réservation payante peut être effectuée via le site Web de la MOB.
 {{% /train-category %}}
 
 {{% train-category
@@ -74,7 +74,7 @@ Un voyage sans réservation de siège n'est possible que s'il reste des places d
 %}}
 Trains motorail sur les lignes Kandersteg – Göppenstein, Brig – Iselle et Kandersteg – Iselle.
 
-Le FIP n'est pas valable dans ces trains, mais les trains circulant parallèlement du `RE 1` peuvent être utilisés.
+Le FIP n’est pas valable dans ces trains, mais les trains circulant parallèlement du `RE 1` peuvent être utilisés.
 {{% /train-category %}}
 
 ### Autres moyens de transport
@@ -108,13 +108,13 @@ Le FIP est valable sur les bateaux de la BLS sur le lac de Thoune et le lac de B
 {{% booking id="db-website"/%}}
 
 {{% booking id="db-website-fip-db"
-    subtitle="Billets FIP 50 transfrontaliers entre l'Allemagne et la Suisse, avec part de billet uniquement pour la section suisse. Réservé aux collaborateurs de la Deutsche Bahn."
+    subtitle="Billets FIP 50 transfrontaliers entre l’Allemagne et la Suisse, avec part de billet uniquement pour la section suisse. Réservé aux collaborateurs de la Deutsche Bahn."
 %}}
 Pour la BLS, des billets FIP 50 continus ne peuvent être réservés que pour certaines connexions sélectionnées.
 {{% /booking %}}
 
 {{% booking id="db-website-fip-international"
-    subtitle="Billets FIP 50 transfrontaliers entre l'Allemagne et la Suisse pour l'ensemble du trajet (non valable dans le pays d'émission de la Carte FIP)"
+    subtitle="Billets FIP 50 transfrontaliers entre l’Allemagne et la Suisse pour l’ensemble du trajet (non valable dans le pays d’émission de la Carte FIP)"
 %}}
 Pour la BLS, des billets FIP 50 continus ne peuvent être réservés que pour certaines connexions sélectionnées.
 {{% /booking %}}
@@ -127,26 +127,26 @@ Pour la BLS, des billets FIP 50 continus ne peuvent être réservés que pour ce
 
 ### Dans le train
 
-L'achat de billets FIP dans le train n'est pas possible. Des frais de pénalité sont appliqués aux passagers sans billets.
+L’achat de billets FIP dans le train n’est pas possible. Des frais de pénalité sont appliqués aux passagers sans billets.
 
 ## Réductions
 
-Pour les trajets réguliers, les enfants jusqu'à 5 ans inclus voyagent gratuitement. Les enfants jusqu'à 15 ans inclus bénéficient d'une réduction de 50 % sur le tarif adulte. Les personnes de 16 ans et plus paient le tarif adulte normal.[^1]
+Pour les trajets réguliers, les enfants jusqu’à 5 ans inclus voyagent gratuitement. Les enfants jusqu’à 15 ans inclus bénéficient d’une réduction de 50 % sur le tarif adulte. Les personnes de 16 ans et plus paient le tarif adulte normal.[^1]
 
 ## Conditions tarifaires particulières
 
 ### Téléphériques
 
-Le FIP n'est pas valable dans les téléphériques et funiculaires exploités par la BLS. [^1]
+Le FIP n’est pas valable dans les téléphériques et funiculaires exploités par la BLS. [^1]
 
 ### Reconnaissance mutuelle des Coupons FIP de la SBB et de la BLS
 
 Les entreprises ferroviaires suisses SBB et BLS acceptent partiellement les Coupons FIP: [^2]
 
 - Les Coupons FIP de la SBB sont acceptés dans tous les trains de la BLS.
-- Les Coupons FIP de la BLS sont acceptés dans les trains de la SBB sur les lignes où circulent également des trains de la BLS, c'est-à-dire entre deux gares où circulent à la fois des trains de la SBB et de la BLS. Le réseau de la BLS est [consultable en ligne](https://www.bls.ch/-/media/bls/pdf/fahrplaene/bahn/netzplaene/netzplan-bls-bahn.pdf).
+- Les Coupons FIP de la BLS sont acceptés dans les trains de la SBB sur les lignes où circulent également des trains de la BLS, c’est-à-dire entre deux gares où circulent à la fois des trains de la SBB et de la BLS. Le réseau de la BLS est [consultable en ligne](https://www.bls.ch/-/media/bls/pdf/fahrplaene/bahn/netzplaene/netzplan-bls-bahn.pdf).
 
-Cependant, les Coupons FIP de la SBB ne sont pas valables sur les bateaux de la BLS sur le lac de Thoune et le lac de Brienz, ni dans les bus de la BLS, qui circulent principalement dans l'Emmental.
+Cependant, les Coupons FIP de la SBB ne sont pas valables sur les bateaux de la BLS sur le lac de Thoune et le lac de Brienz, ni dans les bus de la BLS, qui circulent principalement dans l’Emmental.
 
 ### Services de remplacement ferroviaire
 

--- a/content/operator/bsb/index.fr.md
+++ b/content/operator/bsb/index.fr.md
@@ -80,7 +80,7 @@ Le billet anniversaire doit être retiré avant le départ aux points de vente.[
 
 ## Conditions tarifaires spéciales
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 Une interruption de voyage est autorisée sans formalités.[^1]
 
@@ -91,7 +91,7 @@ Aucune réduction n’est accordée pour les véhicules entre Friedrichshafen et
 
 ### zellerSEEticket (zSEEt)
 
-Titulaires de la carte FIP bénéficient d'une réduction de 50 % sur le zellerSEEticket (zSEEt). Aucune autre réduction n'est acceptée.[^3]
+Titulaires de la carte FIP bénéficient d’une réduction de 50 % sur le zellerSEEticket (zSEEt). Aucune autre réduction n’est acceptée.[^3]
 
 ## Sources
 

--- a/content/operator/cd/index.fr.md
+++ b/content/operator/cd/index.fr.md
@@ -511,7 +511,7 @@ La signification des numéros d’itinéraire est disponible sur le [réseau fer
 
 Pour les trains à réservation obligatoire figurant dans la liste, des règles particulières s’appliquent, voir [Trains avec réservation obligatoire](#trains-avec-réservation-obligatoire).
 
-Le supplément coûte 250 CZK (à partir de février 2026) et peut être acheté avant le départ au Guichet ČD, à bord du train (veuillez contacter directement le personnel du train) ou sur Internet. La validité du supplément correspond à la même durée que la case actuelle du Coupon FIP (2 jours) et il est valable sur toutes les liaisons commerciales. [^3] L'achat en ligne est uniquement possible sur la site de la [ČD en tchèque ici](https://www.cd.cz/e-shop/in-karta/drzitel-zeleznicni-prukazky/default.htm) (_Jednorázový příplatek na komerční vlaky a vybrané linky_, choisir la date et sur la prochaine page après avoir cliqué sur _Koupit_ on peut rechanger la langue en anglais).
+Le supplément coûte 250 CZK (à partir de février 2026) et peut être acheté avant le départ au Guichet ČD, à bord du train (veuillez contacter directement le personnel du train) ou sur Internet. La validité du supplément correspond à la même durée que la case actuelle du Coupon FIP (2 jours) et il est valable sur toutes les liaisons commerciales. [^3] L’achat en ligne est uniquement possible sur la site de la [ČD en tchèque ici](https://www.cd.cz/e-shop/in-karta/drzitel-zeleznicni-prukazky/default.htm) (_Jednorázový příplatek na komerční vlaky a vybrané linky_, choisir la date et sur la prochaine page après avoir cliqué sur _Koupit_ on peut rechanger la langue en anglais).
 
 Les remboursements de suppléments sont possibles jusqu’à 23h59 la veille du premier jour de validité (sans retenue) ou dans les 15 minutes suivant l’achat (sans retenue). Si un supplément inutilisé est restitué avant 8h00 le premier jour de validité, des frais de traitement de 100 CZK sont appliqués. Dans tous les autres cas, aucun remboursement n’est possible. [^1]
 
@@ -680,7 +680,7 @@ Les Réductions FIP ne sont pas valables sur les trains spéciaux et historiques
 
 Les Billets FIP sont valables sur les lignes directes 083 et 098 (Děčín – Rumburk via Dolní Žleb et Dolní Poustevna et retour), même pour des trajets quittant puis revenant en Tchéquie. Toutefois, la montée/descente dans une gare internationale n’est pas autorisée.
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 L’interruption de voyage n’est pas autorisée pour les trajets intérieurs jusqu’à 100 km. Pour les trajets de 101 km ou plus, l’interruption est possible (mais pas en gare internationale).
 

--- a/content/operator/cfr/index.fr.md
+++ b/content/operator/cfr/index.fr.md
@@ -26,7 +26,7 @@ Les Coupons FIP et les Billets FIP 50 sont valables sur les services de CFR Căl
 
 ## Catégories de trains et réservations
 
-Les catégories de trains sont en partie également utilisées par d'autres opérateurs en Roumanie. Pour l'utilisation de la FIP, il est important de vérifier que l'opérateur est CFR Călători.
+Les catégories de trains sont en partie également utilisées par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
 
 {{% train-category
     id="ic"
@@ -35,10 +35,10 @@ Les catégories de trains sont en partie également utilisées par d'autres opé
     fip_accepted=true
     reservation_required=true
 %}}
-Trains nationaux longue distance avec peu d'arrêts intermédiaires et un confort comparativement plus élevé. Ils circulent principalement au départ de Bucarest dans les différentes directions du pays.
+Trains nationaux longue distance avec peu d’arrêts intermédiaires et un confort comparativement plus élevé. Ils circulent principalement au départ de Bucarest dans les différentes directions du pays.
 
 {{% highlight confusion %}}
-Les trains `IC` sont en partie également exploités par d'autres opérateurs en Roumanie. Pour l'utilisation de la FIP, il est important de vérifier que l'opérateur est CFR Călători.
+Les trains `IC` sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
 {{% /highlight %}}
 
 #### Réservations
@@ -55,10 +55,10 @@ Une réservation de place assise est obligatoire. Si le train est complet, une r
     fip_accepted=true
     reservation_required=true
 %}}
-Trains relativement rapides reliant les grandes villes du pays avec peu d'arrêts intermédiaires. Certains circulent également en transfrontalier, notamment vers la Hongrie.
+Trains relativement rapides reliant les grandes villes du pays avec peu d’arrêts intermédiaires. Certains circulent également en transfrontalier, notamment vers la Hongrie.
 
 {{% highlight confusion %}}
-Les trains `IR` sont en partie également exploités par d'autres opérateurs en Roumanie. Pour l'utilisation de la FIP, il est important de vérifier que l'opérateur est CFR Călători.
+Les trains `IR` sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
 {{% /highlight %}}
 
 #### Réservations
@@ -75,12 +75,12 @@ Une réservation de place assise est obligatoire. Si le train est complet, une r
     fip_accepted=true
     reservation_required=true
 %}}
-Trains principalement internationaux circulant de nuit. Ils sont aussi parfois référencés comme `D` dans les recherches de correspondances d'autres fournisseurs.
+Trains principalement internationaux circulant de nuit. Ils sont aussi parfois référencés comme `D` dans les recherches de correspondances d’autres fournisseurs.
 
 Ces trains comprennent généralement des voitures-couchettes ou voitures-lits, qui peuvent être utilisées avec une réservation correspondante.
 
 {{% highlight confusion %}}
-Les trains `IRN` sont en partie également exploités par d'autres opérateurs en Roumanie. Pour l'utilisation de la FIP, il est important de vérifier que l'opérateur est CFR Călători.
+Les trains `IRN` sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
 {{% /highlight %}}
 
 #### Réservations
@@ -89,7 +89,7 @@ Une réservation est obligatoire, soit pour une place assise, en couchette ou en
 
 **Coût de la réservation :** 5 RON pour les places assises et debout sur les relations nationales
 
-Pour les voitures-couchettes et voitures-lits, les tarifs suivants s'appliquent sur les relations nationales : [Grille tarifaire pour les voitures-couchettes et voitures-lits](https://www.cfrcalatori.ro/en/supplements-sleeping-car-berth-car/)
+Pour les voitures-couchettes et voitures-lits, les tarifs suivants s’appliquent sur les relations nationales : [Grille tarifaire pour les voitures-couchettes et voitures-lits](https://www.cfrcalatori.ro/en/supplements-sleeping-car-berth-car/)
 {{% /train-category %}}
 
 {{% train-category
@@ -99,12 +99,12 @@ Pour les voitures-couchettes et voitures-lits, les tarifs suivants s'appliquent 
     fip_accepted=true
     reservation_required=partially
 %}}
-Les trains internationaux vers la Bulgarie, la Moldavie et l'Ukraine circulent sans catégorie de train spécifique et n'ont qu'un numéro de train.
+Les trains internationaux vers la Bulgarie, la Moldavie et l’Ukraine circulent sans catégorie de train spécifique et n’ont qu’un numéro de train.
 
 Ces trains comprennent souvent des voitures-couchettes ou voitures-lits, qui peuvent être utilisées avec une réservation correspondante.
 
 {{% highlight confusion %}}
-Ces trains sont en partie également exploités par d'autres opérateurs en Roumanie. Pour l'utilisation de la FIP, il est important de vérifier que l'opérateur est CFR Călători.
+Ces trains sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
 {{% /highlight %}}
 
 #### Réservations
@@ -113,7 +113,7 @@ Une réservation est souvent obligatoire (reconnaissable par un _R_ dans la rech
 
 **Coût de la réservation :** 5 RON pour les places assises et debout sur les relations nationales
 
-Pour les voitures-couchettes et voitures-lits, les tarifs suivants s'appliquent sur les relations nationales : [Grille tarifaire pour les voitures-couchettes et voitures-lits](https://www.cfrcalatori.ro/en/supplements-sleeping-car-berth-car/)
+Pour les voitures-couchettes et voitures-lits, les tarifs suivants s’appliquent sur les relations nationales : [Grille tarifaire pour les voitures-couchettes et voitures-lits](https://www.cfrcalatori.ro/en/supplements-sleeping-car-berth-car/)
 {{% /train-category %}}
 
 {{% train-category
@@ -123,10 +123,10 @@ Pour les voitures-couchettes et voitures-lits, les tarifs suivants s'appliquent 
     fip_accepted=true
     reservation_required=partially
 %}}
-Trains régionaux desservant également les petites localités. Les différents trains sur une même ligne n'ont souvent pas de schéma d'arrêt fixe, ce qui signifie que les petits arrêts ne sont desservis que par certains trains `R`.
+Trains régionaux desservant également les petites localités. Les différents trains sur une même ligne n’ont souvent pas de schéma d’arrêt fixe, ce qui signifie que les petits arrêts ne sont desservis que par certains trains `R`.
 
 {{% highlight confusion %}}
-Les trains `R` sont en partie également exploités par d'autres opérateurs en Roumanie. Pour l'utilisation de la FIP, il est important de vérifier que l'opérateur est CFR Călători.
+Les trains `R` sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
 {{% /highlight %}}
 
 #### Réservations
@@ -149,27 +149,27 @@ Une réservation est nécessaire pour certains trains, indiqués par un _R_.
 {{% booking id="cfr-ticket-office" /%}}
 
 {{% booking id="db-ticket-office" subtitle="Pour le train de nuit Vienne – Bucarest et les InterCity" %}}
-Au guichet DB, des Billets FIP 50 et des réservations pour le train de nuit Vienne – Bucarest peuvent être achetés. Les réservations peuvent être effectuées 90 jours à l'avance. Des réservations sont disponibles pour les InterCity.
+Au guichet DB, des Billets FIP 50 et des réservations pour le train de nuit Vienne – Bucarest peuvent être achetés. Les réservations peuvent être effectuées 90 jours à l’avance. Des réservations sont disponibles pour les InterCity.
 {{% /booking %}}
 
 ### À bord du train
 
-Il n'est pas possible d'acheter des billets à tarif réduit FIP à bord du train. Les réservations doivent également être obtenues avant le départ.
+Il n’est pas possible d’acheter des billets à tarif réduit FIP à bord du train. Les réservations doivent également être obtenues avant le départ.
 
 ## Réductions
 
-Pour les billets réguliers, les enfants de moins de 5 ans voyagent gratuitement. Les enfants de moins de 10 ans bénéficient d'une réduction de 50 % sur le tarif adulte. Les enfants plus âgés paient le plein tarif adulte.[^1]
+Pour les billets réguliers, les enfants de moins de 5 ans voyagent gratuitement. Les enfants de moins de 10 ans bénéficient d’une réduction de 50 % sur le tarif adulte. Les enfants plus âgés paient le plein tarif adulte.[^1]
 
 ## Conditions tarifaires spéciales
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
-Avec les billets FIP 50, une interruption de voyage n'est autorisée qu'une seule fois et pour une durée maximale de 24 heures à compter de l'arrivée à la gare où le voyage est interrompu. Pour cela, le billet doit être composté dans l'heure qui suit l'arrivée.[^1]
+Avec les billets FIP 50, une interruption de voyage n’est autorisée qu’une seule fois et pour une durée maximale de 24 heures à compter de l’arrivée à la gare où le voyage est interrompu. Pour cela, le billet doit être composté dans l’heure qui suit l’arrivée.[^1]
 
 ## Recommandations
 
 {{% highlight tip %}}
-CFR Călători assure une offre de base solide sur le réseau ferroviaire roumain, en grande partie vieillissant, en particulier sur les axes principaux. Hormis l'obligation de réservation sur la plupart des liaisons, il est relativement simple de parcourir le pays avec la FIP. Les trains internationaux vers l'Europe de l'Ouest constituent un point fort particulier, tout comme les trains bien connus vers la Moldavie et la Turquie, même si ces derniers ne peuvent pas être utilisés avec la FIP sur l'intégralité du trajet.
+CFR Călători assure une offre de base solide sur le réseau ferroviaire roumain, en grande partie vieillissant, en particulier sur les axes principaux. Hormis l’obligation de réservation sur la plupart des liaisons, il est relativement simple de parcourir le pays avec la FIP. Les trains internationaux vers l’Europe de l’Ouest constituent un point fort particulier, tout comme les trains bien connus vers la Moldavie et la Turquie, même si ces derniers ne peuvent pas être utilisés avec la FIP sur l’intégralité du trajet.
 {{% /highlight %}}
 
 ## Sources

--- a/content/operator/cie/index.fr.md
+++ b/content/operator/cie/index.fr.md
@@ -10,15 +10,15 @@ aliases:
   - /booking/irish-rail-website
 ---
 
-Córas Iompair Éireann (CIE) est la compagnie ferroviaire nationale d'[Irlande](/country/ireland) et la société mère d'Irish Rail (Iarnród Éireann). La filiale exploite la majorité du trafic ferroviaire en République d'Irlande, notamment les lignes principales entre Dublin, Cork, Galway et Limerick, ainsi que des liaisons régionales dans les environs de Dublin et Cork.
+Córas Iompair Éireann (CIE) est la compagnie ferroviaire nationale d’[Irlande](/country/ireland) et la société mère d’Irish Rail (Iarnród Éireann). La filiale exploite la majorité du trafic ferroviaire en République d’Irlande, notamment les lignes principales entre Dublin, Cork, Galway et Limerick, ainsi que des liaisons régionales dans les environs de Dublin et Cork.
 
-Sur son site web, Irish Rail propose une [carte d'ensemble des lignes](https://www.irishrail.ie/en-ie/travel-information/station-and-route-maps/ireland-rail-map).
+Sur son site web, Irish Rail propose une [carte d’ensemble des lignes](https://www.irishrail.ie/en-ie/travel-information/station-and-route-maps/ireland-rail-map).
 
 ## Résumé
 
-- Le FIP est accepté sur toutes les liaisons ferroviaires d'Irish Rail.
+- Le FIP est accepté sur toutes les liaisons ferroviaires d’Irish Rail.
 - La First Class ne peut pas être utilisée avec le FIP.
-- Les Billets FIP 50 / FIP 75 sont désormais difficiles à réserver et souvent plus chers que les « Low Fare Tickets » disponibles publiquement, qui doivent toutefois être réservés à l'avance.
+- Les Billets FIP 50 / FIP 75 sont désormais difficiles à réserver et souvent plus chers que les « Low Fare Tickets » disponibles publiquement, qui doivent toutefois être réservés à l’avance.
 
 ## Validité des Billets FIP
 
@@ -37,10 +37,10 @@ Sur son site web, Irish Rail propose une [carte d'ensemble des lignes](https://w
     route_overview_url="https://www.irishrail.ie/en-ie/travel-information/station-and-route-maps/ireland-rail-map"
 %}}
 
-Les trains InterCity relient les principales villes d'Irlande, notamment Dublin, Cork, Galway et Limerick. Le FIP est accepté sur toutes les liaisons InterCity. Le service Enterprise entre Dublin et Belfast est également assuré par des trains InterCity. Plus d'informations sur l'Enterprise sont disponibles sur la [page Irlande](/country/ireland#royaume-uni).
+Les trains InterCity relient les principales villes d’Irlande, notamment Dublin, Cork, Galway et Limerick. Le FIP est accepté sur toutes les liaisons InterCity. Le service Enterprise entre Dublin et Belfast est également assuré par des trains InterCity. Plus d’informations sur l’Enterprise sont disponibles sur la [page Irlande](/country/ireland#royaume-uni).
 
 {{% highlight important %}}
-La First Class entre Dublin et Cork ne peut pas être utilisée avec le FIP. Plus d'informations sur les catégories de classes sont disponibles [ci-dessous](#catégories-de-classes).
+La First Class entre Dublin et Cork ne peut pas être utilisée avec le FIP. Plus d’informations sur les catégories de classes sont disponibles [ci-dessous](#catégories-de-classes).
 {{% /highlight %}}
 
 #### Réservations
@@ -85,7 +85,7 @@ Le DART (Dublin Area Rapid Transit) est un réseau ferroviaire de banlieue relia
     reservation_possible=false
 %}}
 
-Le FIP n'est pas valable sur les liaisons en bus de Bus Éireann.
+Le FIP n’est pas valable sur les liaisons en bus de Bus Éireann.
 
 {{% /train-category %}}
 
@@ -97,7 +97,7 @@ Le FIP n'est pas valable sur les liaisons en bus de Bus Éireann.
     reservation_possible=false
 %}}
 
-Le FIP n'est pas valable sur les liaisons en bus de Dublin Bus.
+Le FIP n’est pas valable sur les liaisons en bus de Dublin Bus.
 
 {{% /train-category %}}
 
@@ -105,7 +105,7 @@ Le FIP n'est pas valable sur les liaisons en bus de Dublin Bus.
 
 - **Second Class** : Classe standard, utilisable avec les Billets FIP 50 / FIP 75 et les Coupons FIP de première et deuxième classe.
 - **Premier Class** : Disponible sur le trajet Dublin – Tralee et la liaison Dublin – Cork. Elle peut être utilisée avec les Coupons FIP de 1re classe, et moyennant un supplément aussi avec les Coupons FIP de 2e classe. **Important** : Aux heures de pointe, la « First Class » remplace la Premier Class et ne peut pas être utilisée avec le FIP.
-- **First Class** : Uniquement disponible entre Dublin et Cork aux heures de pointe, également appelée City Gold. La First Class offre un service à bord et des sièges à réglage électronique. Elle ne peut pas être utilisée avec le FIP.[^2] À partir de mars 2026, toutes les liaisons entre Dublin et Cork _à l'exception_ des suivantes sont assurées avec la First Class[^1] :
+- **First Class** : Uniquement disponible entre Dublin et Cork aux heures de pointe, également appelée City Gold. La First Class offre un service à bord et des sièges à réglage électronique. Elle ne peut pas être utilisée avec le FIP.[^2] À partir de mars 2026, toutes les liaisons entre Dublin et Cork _à l’exception_ des suivantes sont assurées avec la First Class[^1] :
   - Liaisons Premier Class Dublin – Cork : 10h00 (lundi – samedi), 12h00 (lundi – vendredi) et 14h00 (lundi – vendredi)
   - Liaisons Premier Class Cork – Dublin : 13h25 (lundi – samedi), 14h25 (dimanche uniquement), 15h25 (lundi – vendredi) et 17h25 (lundi – jeudi et samedi)
 
@@ -128,15 +128,15 @@ Les Billets FIP 50 / FIP 75 ne peuvent pas être réservés en ligne.
 ### À bord du train
 
 Les Billets FIP 50 / FIP 75 doivent être achetés avant le départ.
-Les suppléments pour passer de la 2e classe à la Premier Class peuvent être achetés à bord du train si aucun guichet n'est disponible à la gare.[^2]
+Les suppléments pour passer de la 2e classe à la Premier Class peuvent être achetés à bord du train si aucun guichet n’est disponible à la gare.[^2]
 
 ## Réductions
 
-Les enfants jusqu'à 5 ans voyagent gratuitement. Les jeunes jusqu'à 16 ans bénéficient d'une réduction de 50 % sur le tarif adulte. Les personnes de 16 ans et plus paient le plein tarif FIP adulte.[^2]
+Les enfants jusqu’à 5 ans voyagent gratuitement. Les jeunes jusqu’à 16 ans bénéficient d’une réduction de 50 % sur le tarif adulte. Les personnes de 16 ans et plus paient le plein tarif FIP adulte.[^2]
 
 ## Conditions tarifaires spéciales
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 Les interruptions de voyage sont autorisées avec les billets FIP, mais doivent être documentées par une annotation à la gare où le voyage a été interrompu.
 

--- a/content/operator/cp/index.fr.md
+++ b/content/operator/cp/index.fr.md
@@ -161,7 +161,7 @@ Les enfants de moins de 4 ans voyagent gratuitement sans siège propre. Les enfa
 
 ## Conditions tarifaires spéciales
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 Les passagers titulaires d’un billet de réduction FIP acheté au Portugal ne sont pas autorisés à interrompre leur voyage. Pour les billets achetés en dehors du Portugal, une interruption de voyage est autorisée (éventuellement sous réserve de réservation). [^1]
 

--- a/content/operator/db/index.fr.md
+++ b/content/operator/db/index.fr.md
@@ -108,7 +108,7 @@ Pour les Railjets à destination de l’Italie, un supplément est requis à par
 
 Les trains Intercity complètent le réseau ICE. Ils circulent à une vitesse inférieure à celle des ICE, relient de nombreuses villes et desservent aussi de nombreuses régions de vacances.
 
-Certains [services Nightjet](#nj) utilisent des voitures Intercity (IC). Ces voitures peuvent être utilisées sans réservation. Le service IC est affiché dans les systèmes d'information en plus du service Nightjet.
+Certains [services Nightjet](#nj) utilisent des voitures Intercity (IC). Ces voitures peuvent être utilisées sans réservation. Le service IC est affiché dans les systèmes d’information en plus du service Nightjet.
 {{% /train-category %}}
 
 {{% train-category
@@ -178,7 +178,7 @@ _Astuce :_ Pour les trajets Allemagne - Italie, utiliser les trajets nationaux g
 
 Pour les Nightjet, des réservations/suppléments pour les voitures-lits et couchettes peuvent être réservés. Un FIP Coupon pour les pays/compagnies traversés est nécessaire. Sans FIP Coupon, un billet au Tarif Global FIP pour tout le trajet peut être acheté.
 
-Certains services Nightjet sont assurés par des voitures [Intercity](#ic). Ces voitures peuvent être utilisées sans réservation. Le service IC est affiché dans les systèmes d'information, en plus du service Nightjet.
+Certains services Nightjet sont assurés par des voitures [Intercity](#ic). Ces voitures peuvent être utilisées sans réservation. Le service IC est affiché dans les systèmes d’information, en plus du service Nightjet.
 
 **Coût :** Selon le trajet, la fréquentation et la catégorie de voiture.
 
@@ -324,7 +324,7 @@ Une [carte d’aperçu](https://www.nvv.de/fileadmin/nvv/data/2._Fahrtinfo/4._Li
 
 ### DB Regio Stuttgart
 
-DB Regio Stuttgart (anciennement SWEG Bahn Stuttgart) n'accepte pas les réductions FIP. Cela concerne les lignes suivantes : [^2]
+DB Regio Stuttgart (anciennement SWEG Bahn Stuttgart) n’accepte pas les réductions FIP. Cela concerne les lignes suivantes : [^2]
 
 - RE 6 : Tübingen - Stuttgart
 - RE 10a : Heilbronn - Mosbach-Neckarelz - Heidelberg - Mannheim
@@ -337,7 +337,7 @@ DB Regio Stuttgart (anciennement SWEG Bahn Stuttgart) n'accepte pas les réducti
 
 ### DB Regio Bayern
 
-Les trains de DB Regio Bayern entre Nürnberg Hbf et Regensburg Hbf sont exploités au nom de l'opérateur ferroviaire agilis. Aucune réduction FIP n'est donc reconnue sur cette section. [^2]
+Les trains de DB Regio Bayern entre Nürnberg Hbf et Regensburg Hbf sont exploités au nom de l’opérateur ferroviaire agilis. Aucune réduction FIP n’est donc reconnue sur cette section. [^2]
 
 ### Trajets dans les réseaux de transport
 

--- a/content/operator/eurostar/index.fr.md
+++ b/content/operator/eurostar/index.fr.md
@@ -109,7 +109,7 @@ Les billets sont émis exclusivement sous forme numérique (email requis).
 
 ### En ligne
 
-Mais la gestion du billet (annulation, échange, rebooking) est possible via le site Eurostar, plus d'informations sous [Modifications & Annulations](#modifications--annulations). Si vous indiquez un e-mail lié à un compte Eurostar existant, le billet s’affichera automatiquement dans votre espace personnel.
+Mais la gestion du billet (annulation, échange, rebooking) est possible via le site Eurostar, plus d’informations sous [Modifications & Annulations](#modifications--annulations). Si vous indiquez un e-mail lié à un compte Eurostar existant, le billet s’affichera automatiquement dans votre espace personnel.
 
 {{% booking id="railtourguide-website"
     fip_50=nil
@@ -187,13 +187,13 @@ Enfants jusqu’à 3 ans inclus: gratuit, mais sans place attribuée. Pas d’au
 
 ### Modifications & Annulations
 
-Les Billets FIP peuvent être modifiés ou annulés gratuitement jusqu'à une heure avant le départ. Passé ce délai, toute modification ou annulation est impossible.
+Les Billets FIP peuvent être modifiés ou annulés gratuitement jusqu’à une heure avant le départ. Passé ce délai, toute modification ou annulation est impossible.
 
-En principe, il n'est possible de rebooker que sur d'autres trains disponibles disposant encore de contingents suffisants, voir aussi [Quotas de billets](#quotas-de-billets). Lors d'une modification, il est également possible de passer d'Eurostar Standard à Eurostar Plus en payant la différence. En revanche, un déclassement d'Eurostar Plus à Eurostar Standard ne donnera pas lieu à un remboursement de la différence.
+En principe, il n’est possible de rebooker que sur d’autres trains disponibles disposant encore de contingents suffisants, voir aussi [Quotas de billets](#quotas-de-billets). Lors d’une modification, il est également possible de passer d’Eurostar Standard à Eurostar Plus en payant la différence. En revanche, un déclassement d’Eurostar Plus à Eurostar Standard ne donnera pas lieu à un remboursement de la différence.
 
-En cas d'annulation, le prix total des Billets FIP est remboursé. Les éventuels frais de réservation facturés par des prestataires externes ne sont pas remboursés.
+En cas d’annulation, le prix total des Billets FIP est remboursé. Les éventuels frais de réservation facturés par des prestataires externes ne sont pas remboursés.
 
-La modification, l'annulation et le passage à une classe supérieure sont possibles avec le numéro de réservation via le [site Eurostar](https://www.eurostar.com/customer-dashboard/en/get-booking).
+La modification, l’annulation et le passage à une classe supérieure sont possibles avec le numéro de réservation via le [site Eurostar](https://www.eurostar.com/customer-dashboard/en/get-booking).
 
 ### Quotas de billets
 
@@ -212,11 +212,11 @@ La vérification des contingents de billets disponibles est possible via les sit
 
 #### HOTNAT (Correspondance à Bruxelles, Cologne, Paris)
 
-Pour Eurostar, l'achat de billets directs n'est pas possible. Cependant, pour garantir la correspondance lors d'un changement, il est possible d'utiliser [HOTNAT (Hop on the next available train)](https://www.railteam.eu/fr/am-i-eligible-for-hotnat/).
+Pour Eurostar, l’achat de billets directs n’est pas possible. Cependant, pour garantir la correspondance lors d’un changement, il est possible d’utiliser [HOTNAT (Hop on the next available train)](https://www.railteam.eu/fr/am-i-eligible-for-hotnat/).
 
-Si la correspondance entre deux trains à grande vitesse est manquée en raison d'un retard ou d'une suppression, il est possible d'emprunter le prochain train disponible du même opérateur ou d'un autre membre Railteam. Pour cela, il faut demander le changement de réservation au guichet sur place.
+Si la correspondance entre deux trains à grande vitesse est manquée en raison d’un retard ou d’une suppression, il est possible d’emprunter le prochain train disponible du même opérateur ou d’un autre membre Railteam. Pour cela, il faut demander le changement de réservation au guichet sur place.
 
-HOTNAT s'applique uniquement lors d'une correspondance entre trains à grande vitesse de membres Railteam (DB, Eurostar, NS, SBB, SNCB, SNCF, ÖBB) et dans les gares de Paris, Bruxelles, Cologne, Munich, Bâle et Zurich. L'utilisation dépend du taux d'occupation des trains.
+HOTNAT s’applique uniquement lors d’une correspondance entre trains à grande vitesse de membres Railteam (DB, Eurostar, NS, SBB, SNCB, SNCF, ÖBB) et dans les gares de Paris, Bruxelles, Cologne, Munich, Bâle et Zurich. L’utilisation dépend du taux d’occupation des trains.
 
 #### London International CIV (Correspondance à Londres)
 

--- a/content/operator/euskotren/index.fr.md
+++ b/content/operator/euskotren/index.fr.md
@@ -21,7 +21,7 @@ Dans le nord de l’[Espagne](/country/spain "Espagne"), Euskotren exploite un r
 
 {{< fip-validity type="fip-coupon" status="invalid" disable_dialog=true >}}
 {{< fip-validity type="fip-reduced-ticket" status="invalid" subtitle="FIP 50" disable_dialog=true >}}
-{{< fip-validity type="additional" status="valid" text="'Euskotren FIP Ticket' spécial (pour titulaires et accompagnants)" disable_dialog=true >}}
+{{< fip-validity type="additional" status="valid" text="’Euskotren FIP Ticket’ spécial (pour titulaires et accompagnants)" disable_dialog=true >}}
 
 {{% float-image
   src="euskotren_fip_ticket.webp"
@@ -108,7 +108,7 @@ Si vous n’avez pas d’"Euskotren FIP Ticket", le personnel des stations déli
   type="bus"
   fip_accepted=false
 %}}
-Les Billets FIP ne sont pas valables sur les lignes de bus régionales d'Euskotren. Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lorsqu'ils remplacent un train dans lequel le FIP aurait été valable.
+Les Billets FIP ne sont pas valables sur les lignes de bus régionales d’Euskotren. Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lorsqu’ils remplacent un train dans lequel le FIP aurait été valable.
 {{% /train-category %}}
 
 ## Catégories de classes

--- a/content/operator/fs/index.fr.md
+++ b/content/operator/fs/index.fr.md
@@ -279,7 +279,7 @@ Les trains Le Frecce longue distance ont des catégories de classes particulièr
 
 {{% booking id="fs-website" %}}
 {{% highlight inofficial %}}
-Nous recevons actuellement de nombreux retours indiquant que la réservation de billets FIP et de places sur le site Web FS n'est pas possible. Nous ne savons pas si ces restrictions sont temporaires ou permanentes. En cas de problèmes lors de la réservation, nous recommandons d'acheter les Billets FIP 50 et les réservations directement aux guichets Trenitalia.
+Nous recevons actuellement de nombreux retours indiquant que la réservation de billets FIP et de places sur le site Web FS n’est pas possible. Nous ne savons pas si ces restrictions sont temporaires ou permanentes. En cas de problèmes lors de la réservation, nous recommandons d’acheter les Billets FIP 50 et les réservations directement aux guichets Trenitalia.
 {{% /highlight %}}
 {{% /booking %}}
 
@@ -378,7 +378,7 @@ La mention "prenotabile" dans les informations du train :
   width="60%"
   position="right"
 %}}
-L'intitulé du billet "Prenotazione – Ordinaria" :
+L’intitulé du billet "Prenotazione – Ordinaria" :
 {{% /float-image %}}
 
 **Non lié à un train :** \
@@ -399,7 +399,7 @@ La mention "non prenotabile" dans les informations du train :
   width="60%"
   position="right"
 %}}
-L'intitulé du billet "Ordinaria" :
+L’intitulé du billet "Ordinaria" :
 {{% /float-image %}}
 
 {{% /expander %}}
@@ -408,7 +408,7 @@ L'intitulé du billet "Ordinaria" :
 
 Les billets pour les trains régionaux non liés à un train (_non prenotabile_) doivent être validés sur le quai (obliteratrici).
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 L’interruption de voyage n’est pas autorisée dans les trains longue distance. Dans les trains régionaux, elle est possible sans formalités, sauf pour les Billets FIP 50 liés à un train spécifique avec numéro de train imprimé (voir [Billets liés à un train dans les trains régionaux](#billets-liés-à-un-train-dans-les-trains-régionaux)).
 

--- a/content/operator/gb/index.fr.md
+++ b/content/operator/gb/index.fr.md
@@ -43,7 +43,7 @@ Il n’existe pas de catégories de trains classiques au Royaume-Uni. Les servic
 
 Avanti West Coast propose des liaisons rapides sur la côte ouest de la Grande-Bretagne, notamment entre Londres, Manchester et Glasgow.
 
-En première classe, des snacks, repas et boissons (alcoolisées) sont servis. [Plus d'informations sur l'offre sont disponibles ici.](https://www.avantiwestcoast.co.uk/travel-information/onboard/food-and-drinks/first-class-service). Sur les trajets plus courts, le service peut être limité : les boissons sont disponibles, mais la carte complète peut ne pas être proposée par manque de temps.
+En première classe, des snacks, repas et boissons (alcoolisées) sont servis. [Plus d’informations sur l’offre sont disponibles ici.](https://www.avantiwestcoast.co.uk/travel-information/onboard/food-and-drinks/first-class-service). Sur les trajets plus courts, le service peut être limité : les boissons sont disponibles, mais la carte complète peut ne pas être proposée par manque de temps.
 
 {{% /train-category %}}
 
@@ -95,7 +95,7 @@ Chiltern Railways propose des liaisons régionales entre London Marylebone, Birm
 
 CrossCountry propose des liaisons longue distance entre le nord-est, le centre et le sud-ouest de l’Angleterre, ainsi que l’Écosse et le Pays de Galles. Les trains relient notamment Aberdeen, Birmingham, Bristol, Cardiff, Manchester et Penzance, desservant de nombreuses régions en dehors des lignes principales.
 
-En première classe, des snacks, repas et boissons (alcoolisées) sont parfois servis. [Plus d'informations sur l'offre sont disponibles ici.](https://www.crosscountrytrains.co.uk/travel-information/on-board/first-class-food-and-drink)
+En première classe, des snacks, repas et boissons (alcoolisées) sont parfois servis. [Plus d’informations sur l’offre sont disponibles ici.](https://www.crosscountrytrains.co.uk/travel-information/on-board/first-class-food-and-drink)
 
 {{% /train-category %}}
 
@@ -122,7 +122,7 @@ East Midlands Railway relie Londres aux East Midlands et au Yorkshire en trafic 
 
 La Elizabeth Line propose des liaisons suburbaines continues d’est en ouest à Londres et complète le réseau urbain. La Elizabeth Line fait partie de National Rail et peut être utilisée avec les réductions FIP. Elle offre une bonne possibilité de traverser la ville avec FIP. [^1]
 
-Il n'y a pas de guichets entre Abbey Wood et Canary Wharf où les Billets FIP 50 peuvent être achetés.
+Il n’y a pas de guichets entre Abbey Wood et Canary Wharf où les Billets FIP 50 peuvent être achetés.
 
 {{% highlight tip %}}
 Certaines stations de la Elizabeth Line sont aussi desservies par le métro londonien. Les portiques de ces stations sont souvent surveillés par du personnel TfL. Pour éviter toute confusion, il convient de préciser l’utilisation de la Elizabeth Line lors de la présentation du Coupon FIP.
@@ -153,7 +153,7 @@ Gatwick Express est une liaison rapide et directe entre London Victoria et l’a
 
 Grand Central propose des liaisons directes entre London King’s Cross, le Yorkshire et le nord-est de l’Angleterre, notamment Sunderland, Bradford et York.
 
-En première classe, des snacks et boissons sont servis. [Plus d'informations sur l'offre sont disponibles ici.](https://www.grandcentralrail.com/tickets/ticket-types/first-class-and-business-travel)
+En première classe, des snacks et boissons sont servis. [Plus d’informations sur l’offre sont disponibles ici.](https://www.grandcentralrail.com/tickets/ticket-types/first-class-and-business-travel)
 
 {{% /train-category %}}
 
@@ -179,7 +179,7 @@ Great Northern propose des liaisons pour navetteurs de Londres vers le Hertfords
 
 Greater Anglia relie London Liverpool Street aux comtés de l’est de l’Angleterre et à Norwich.
 
-Sur la ligne principale entre Norwich et Londres, les passagers de première classe peuvent récupérer gratuitement des en-cas et des boissons au café-bar en semaine (du lundi au vendredi, jours fériés inclus).[^6] Vérifiez au préalable la [disponibilité et les horaires d'ouverture du café-bar](https://www.greateranglia.co.uk/travel-information/your-journey/catering).
+Sur la ligne principale entre Norwich et Londres, les passagers de première classe peuvent récupérer gratuitement des en-cas et des boissons au café-bar en semaine (du lundi au vendredi, jours fériés inclus).[^6] Vérifiez au préalable la [disponibilité et les horaires d’ouverture du café-bar](https://www.greateranglia.co.uk/travel-information/your-journey/catering).
 
 {{% /train-category %}}
 
@@ -194,7 +194,7 @@ Sur la ligne principale entre Norwich et Londres, les passagers de première cla
 
 Great Western Railway relie London Paddington au sud-ouest de l’Angleterre, au South Wales et à Bristol en trafic longue distance et régional.
 
-En première classe, snacks et boissons sont servis. [Plus d'informations sur l'offre sont disponibles ici.](https://www.gwr.com/travelling-with-us/first-class/food-and-drink)
+En première classe, snacks et boissons sont servis. [Plus d’informations sur l’offre sont disponibles ici.](https://www.gwr.com/travelling-with-us/first-class/food-and-drink)
 
 GWR exploite aussi un train de nuit de Londres à Penzance – le Night Riviera Sleeper, avec réservation obligatoire. Les Coupons FIP doivent seulement être valables le jour d’arrivée.[^1]
 
@@ -244,7 +244,7 @@ Hull Trains propose des liaisons directes entre London King’s Cross et les pri
 
 LNER exploite des trains longue distance sur la côte est entre Londres, Édimbourg et York.
 
-En première classe, snacks, repas et boissons (alcoolisées) sont servis. [Plus d'informations sur l'offre sont disponibles ici.](https://www.lner.co.uk/first-class-travel/menu/)
+En première classe, snacks, repas et boissons (alcoolisées) sont servis. [Plus d’informations sur l’offre sont disponibles ici.](https://www.lner.co.uk/first-class-travel/menu/)
 
 {{% /train-category %}}
 
@@ -270,9 +270,9 @@ London Overground complète le réseau du métro comme un réseau suburbain et p
 %}}
 Lumo circule sur deux lignes en Grande-Bretagne :
 
-- Sur l'East Coast Main Line entre London King's Cross, Newcastle et Édimbourg. Le FIP est accepté sur ces liaisons East Coast.
+- Sur l’East Coast Main Line entre London King’s Cross, Newcastle et Édimbourg. Le FIP est accepté sur ces liaisons East Coast.
 
-- Sur la West Coast Main Line, First Lumo Stirling lance des liaisons Lumo West Coast au printemps 2026 au départ de London Euston via Milton Keynes, Crewe, Preston et Carlisle jusqu'à Stirling. Le FIP est accepté sur ces liaisons West Coast. [^7]
+- Sur la West Coast Main Line, First Lumo Stirling lance des liaisons Lumo West Coast au printemps 2026 au départ de London Euston via Milton Keynes, Crewe, Preston et Carlisle jusqu’à Stirling. Le FIP est accepté sur ces liaisons West Coast. [^7]
 
 {{% /train-category %}}
 
@@ -396,7 +396,7 @@ Thameslink propose des liaisons nord-sud continues à travers Londres et relie d
 
 TransPennine Express relie le nord-ouest et le nord-est de l’Angleterre ainsi que l’Écosse via les Pennines.
 
-En première classe, snacks, repas et boissons (alcoolisées) sont parfois servis. [Plus d'informations sur l'offre sont disponibles ici.](https://www.tpexpress.co.uk/travelling-with-us/first-class)
+En première classe, snacks, repas et boissons (alcoolisées) sont parfois servis. [Plus d’informations sur l’offre sont disponibles ici.](https://www.tpexpress.co.uk/travelling-with-us/first-class)
 
 {{% /train-category %}}
 
@@ -435,9 +435,9 @@ Au Royaume-Uni, il existe différentes catégories de billets. La Réduction FIP
 - **Billets Advance :** \
   Ces billets sont fortement réduits mais ne sont valables que pour le train sélectionné. Ils peuvent être achetés jusqu’à 10 minutes avant le départ. La Réduction FIP 50 / FIP 75 ne s’applique pas à ces billets.
 - **Rovers :** \
-  Les Rovers sont des billets valables un ou plusieurs jours pour des trajets illimités dans une zone spécifique. La Réduction FIP 50 / FIP 75 s'applique à certains Rovers. Le [site National Rail](https://www.nationalrail.co.uk/ticket-types/promotions/?promotionType=ranger-rover) donne un aperçu des Rovers disponibles. La Réduction FIP 50 / FIP 75 n'est accordée que sur demande.
+  Les Rovers sont des billets valables un ou plusieurs jours pour des trajets illimités dans une zone spécifique. La Réduction FIP 50 / FIP 75 s’applique à certains Rovers. Le [site National Rail](https://www.nationalrail.co.uk/ticket-types/promotions/?promotionType=ranger-rover) donne un aperçu des Rovers disponibles. La Réduction FIP 50 / FIP 75 n’est accordée que sur demande.
 
-  [BR Fares](https://www.brfares.com/!roverhome) propose une page où vous pouvez saisir le nom du Rover et sélectionner "FIP Discount 50%" ou "FIP Discount 75%" comme option de réduction. Si un résultat s'affiche, le Rover est valable avec FIP, sinon il ne l'est pas.
+  [BR Fares](https://www.brfares.com/!roverhome) propose une page où vous pouvez saisir le nom du Rover et sélectionner "FIP Discount 50%" ou "FIP Discount 75%" comme option de réduction. Si un résultat s’affiche, le Rover est valable avec FIP, sinon il ne l’est pas.
 
   {{% expander "Liste des Rovers disponibles avec réduction FIP" info "rover" %}}
   Il s’agit d’une liste non officielle des Rovers disponibles fournie par la communauté (état au 24 janvier 2026). [^3]
@@ -516,7 +516,7 @@ De nombreuses gares au Royaume-Uni sont équipées de portiques de contrôle qui
 
 ### Transports à Londres
 
-La plupart des services de transport à Londres sont exploités par Transport for London (TfL). Ceux-ci n'offrent généralement pas de réductions FIP, sauf dans des conditions particulières. La [Elizabeth Line](#elizabeth-line) et la [London Overground](#london-overground) peuvent être utilisées sans restriction avec FIP. Certains trains régionaux comme [Thameslink](#thameslink), qui traversent Londres, peuvent également être utilisés avec les Coupons FIP. Le [Gatwick Express](#gatwick-express) et le [Heathrow Express](#heathrow-express) peuvent également être utilisés.
+La plupart des services de transport à Londres sont exploités par Transport for London (TfL). Ceux-ci n’offrent généralement pas de réductions FIP, sauf dans des conditions particulières. La [Elizabeth Line](#elizabeth-line) et la [London Overground](#london-overground) peuvent être utilisées sans restriction avec FIP. Certains trains régionaux comme [Thameslink](#thameslink), qui traversent Londres, peuvent également être utilisés avec les Coupons FIP. Le [Gatwick Express](#gatwick-express) et le [Heathrow Express](#heathrow-express) peuvent également être utilisés.
 
 {{% train-category
   id="london-buses-dlr-tram"
@@ -526,7 +526,7 @@ La plupart des services de transport à Londres sont exploités par Transport fo
   reservation_required=false
 %}}
 
-Les services suivants n'acceptent pas le FIP : [^1]
+Les services suivants n’acceptent pas le FIP : [^1]
 
 - Bus de Londres
 - Docklands Light Railway (DLR)
@@ -544,10 +544,10 @@ Les services suivants n'acceptent pas le FIP : [^1]
   reservation_required=false
 %}}
 
-Le métro londonien est exploité par TfL et n'accepte pas les réductions FIP.
+Le métro londonien est exploité par TfL et n’accepte pas les réductions FIP.
 
 {{< highlight important >}}
-Avec les Billets FIP 50 / FIP 75 National Rail nécessitant un transfert entre gares londoniennes, le métro peut être utilisé exclusivement pour la liaison entre ces gares. L'interruption du trajet dans le métro n'est pas autorisée. Les billets valables pour ce transfert sont marqués ✠ (croix de Malte) ou † (poignard). [^1]
+Avec les Billets FIP 50 / FIP 75 National Rail nécessitant un transfert entre gares londoniennes, le métro peut être utilisé exclusivement pour la liaison entre ces gares. L’interruption du trajet dans le métro n’est pas autorisée. Les billets valables pour ce transfert sont marqués ✠ (croix de Malte) ou † (poignard). [^1]
 {{< /highlight >}}
 
 {{% /train-category %}}
@@ -584,7 +584,7 @@ La réduction est de 75 % sur le tarif adulte régulier.
   additional_information_url="https://festrail.co.uk"
 %}}
 
-La Ffestiniog and Welsh Highland Railway est l'une des plus anciennes lignes à voie étroite du monde, reliant Porthmadog, Caernarfon, Blaenau Ffestiniog et Minffordd. Elle traverse les montagnes spectaculaires du Snowdonia. Depuis la gare National Rail de Bangor, prendre le bus 5C (environ 30 minutes) jusqu'à Caernarfon Bus Station, puis marcher (4 minutes, 500 m) jusqu'à la gare. Des correspondances directes existent aussi à Blaenau Ffestiniog (National Rail, quai 1), Minffordd (50 m à pied) et Porthmadog (environ 13 minutes à pied, 1 km).
+La Ffestiniog and Welsh Highland Railway est l’une des plus anciennes lignes à voie étroite du monde, reliant Porthmadog, Caernarfon, Blaenau Ffestiniog et Minffordd. Elle traverse les montagnes spectaculaires du Snowdonia. Depuis la gare National Rail de Bangor, prendre le bus 5C (environ 30 minutes) jusqu’à Caernarfon Bus Station, puis marcher (4 minutes, 500 m) jusqu’à la gare. Des correspondances directes existent aussi à Blaenau Ffestiniog (National Rail, quai 1), Minffordd (50 m à pied) et Porthmadog (environ 13 minutes à pied, 1 km).
 
 La réduction est de 75 % sur le tarif adulte régulier.
 
@@ -599,7 +599,7 @@ La réduction est de 75 % sur le tarif adulte régulier.
   additional_information_url="https://iwsteamrailway.co.uk"
 %}}
 
-La Isle of Wight Steam Railway circule sur l'île de Wight entre Smallbrook Junction et Wootton. Elle est connue pour ses locomotives et voitures victoriennes restaurées avec soin. L'accès le plus simple se fait via Smallbrook Junction, avec une correspondance directe depuis National Rail (1 minute à pied).
+La Isle of Wight Steam Railway circule sur l’île de Wight entre Smallbrook Junction et Wootton. Elle est connue pour ses locomotives et voitures victoriennes restaurées avec soin. L’accès le plus simple se fait via Smallbrook Junction, avec une correspondance directe depuis National Rail (1 minute à pied).
 
 La réduction est de 50 % sur le tarif adulte régulier.
 
@@ -614,7 +614,7 @@ La réduction est de 50 % sur le tarif adulte régulier.
   additional_information_url="https://kesr.org.uk"
 %}}
 
-La Kent and East Sussex Railway relie Tenterden à Bodiam à travers les collines du sud-est de l'Angleterre. La ligne propose des trains à vapeur et diesel. Depuis Ashford International, prendre le bus 2 ou 2A (45–55 minutes, 20 km) jusqu'à Tenterden Town Centre (The Vine), puis marcher (3 minutes, 250 m) jusqu'à la gare. Depuis Headcorn, prendre le bus 12 ou 12RL (25 minutes).
+La Kent and East Sussex Railway relie Tenterden à Bodiam à travers les collines du sud-est de l’Angleterre. La ligne propose des trains à vapeur et diesel. Depuis Ashford International, prendre le bus 2 ou 2A (45–55 minutes, 20 km) jusqu’à Tenterden Town Centre (The Vine), puis marcher (3 minutes, 250 m) jusqu’à la gare. Depuis Headcorn, prendre le bus 12 ou 12RL (25 minutes).
 
 La réduction est de 50 % sur le tarif adulte régulier.
 
@@ -629,7 +629,7 @@ La réduction est de 50 % sur le tarif adulte régulier.
   additional_information_url="https://lake-railway.co.uk"
 %}}
 
-La Llanberis Lake Railway longe le Llyn Padarn au cœur du parc national de Snowdonia. La ligne historique à voie étroite offre de magnifiques vues sur les montagnes autour de Llanberis. Depuis la gare de Bangor, prendre le bus 85 ou 86 (environ 50 minutes) jusqu'à Llanberis Interchange ; de là, 1 minute à pied jusqu'à la gare de la ligne historique.
+La Llanberis Lake Railway longe le Llyn Padarn au cœur du parc national de Snowdonia. La ligne historique à voie étroite offre de magnifiques vues sur les montagnes autour de Llanberis. Depuis la gare de Bangor, prendre le bus 85 ou 86 (environ 50 minutes) jusqu’à Llanberis Interchange ; de là, 1 minute à pied jusqu’à la gare de la ligne historique.
 
 La réduction est de 50 % sur le tarif adulte régulier.
 
@@ -644,9 +644,9 @@ La réduction est de 50 % sur le tarif adulte régulier.
   additional_information_url="https://tramway.co.uk"
 %}}
 
-Le National Tramway Museum à Crich abrite l'une des plus grandes collections de tramways historiques au monde. Les visiteurs peuvent voyager à bord de trams restaurés sur une ligne traversant le village reconstitué « Crich Tramway Village ». Depuis la gare de Matlock, prendre le bus 140 ou 141 (environ 32 minutes, 11 km), ou marcher depuis Whatstandwell (environ 35 minutes, 2,2 km).
+Le National Tramway Museum à Crich abrite l’une des plus grandes collections de tramways historiques au monde. Les visiteurs peuvent voyager à bord de trams restaurés sur une ligne traversant le village reconstitué « Crich Tramway Village ». Depuis la gare de Matlock, prendre le bus 140 ou 141 (environ 32 minutes, 11 km), ou marcher depuis Whatstandwell (environ 35 minutes, 2,2 km).
 
-La réduction est de 2 personnes pour le prix d'1.
+La réduction est de 2 personnes pour le prix d’1.
 
 {{% /train-category %}}
 
@@ -659,7 +659,7 @@ La réduction est de 2 personnes pour le prix d'1.
   additional_information_url="https://talyllyn.co.uk"
 %}}
 
-La Talyllyn Railway est la plus ancienne ligne à voie étroite préservée au monde circulant encore sur son tracé d'origine. Elle relie Tywyn Wharf à Nant Gwernol au centre du Pays de Galles. La gare National Rail de Tywyn est à seulement 350 m (4 minutes à pied) de la gare Wharf Station.
+La Talyllyn Railway est la plus ancienne ligne à voie étroite préservée au monde circulant encore sur son tracé d’origine. Elle relie Tywyn Wharf à Nant Gwernol au centre du Pays de Galles. La gare National Rail de Tywyn est à seulement 350 m (4 minutes à pied) de la gare Wharf Station.
 
 La réduction est de 50 % sur le tarif adulte régulier.
 

--- a/content/operator/gysev/index.fr.md
+++ b/content/operator/gysev/index.fr.md
@@ -113,7 +113,7 @@ Certains trains Személyvonat sont également exploités par MÁV où les Billet
     type="bus"
     fip_accepted=false
 %}}
-Les réductions FIP ne sont pas valables sur les liaisons d'autobus GySEV. Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lorsqu'ils remplacent un train dans lequel le FIP aurait été valable.
+Les réductions FIP ne sont pas valables sur les liaisons d’autobus GySEV. Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lorsqu’ils remplacent un train dans lequel le FIP aurait été valable.
 {{% /train-category %}}
 
 ## Achat de billets et réservations
@@ -152,13 +152,13 @@ Avec les tarifs publics, les enfants de moins de 6 ans voyagent gratuitement. Le
 
 ## Conditions tarifaires spéciales
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
-Pour un arrêt intermédiaire, le billet doit être composté à la gare où l'arrêt doit avoir lieu.
+Pour un arrêt intermédiaire, le billet doit être composté à la gare où l’arrêt doit avoir lieu.
 
 ### Services de remplacement ferroviaire
 
-Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lorsqu'ils remplacent un train dans lequel le FIP aurait été valable.
+Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lorsqu’ils remplacent un train dans lequel le FIP aurait été valable.
 
 ## Sources
 

--- a/content/operator/ht/index.fr.md
+++ b/content/operator/ht/index.fr.md
@@ -10,7 +10,7 @@ aliases:
   - /booking/ht-website
 ---
 
-Hellenic Train S.A. (Ελληνικοί Σιδηρόδρομοι Α.Ε.) exploite l'ensemble du transport de voyageurs de l'État sur le réseau grec à voie normale. L'entreprise exploite des services grandes lignes, régionaux et de banlieue (« Proastiakos »). Depuis 2017, elle est une filiale à 100 % des chemins de fer italiens Ferrovie dello Stato Italiane (FS).
+Hellenic Train S.A. (Ελληνικοί Σιδηρόδρομοι Α.Ε.) exploite l’ensemble du transport de voyageurs de l’État sur le réseau grec à voie normale. L’entreprise exploite des services grandes lignes, régionaux et de banlieue (« Proastiakos »). Depuis 2017, elle est une filiale à 100 % des chemins de fer italiens Ferrovie dello Stato Italiane (FS).
 
 ## Résumé
 
@@ -33,17 +33,17 @@ Hellenic Train S.A. (Ελληνικοί Σιδηρόδρομοι Α.Ε.) exploit
     reservation_possible=true
 %}}
 
-Ces trains relient Athènes (Αθήνα) et Thessalonique (Θεσσαλονίκη) ainsi que Larisa (Λάρισα) et d'autres grandes villes. La ligne est électrifiée et offre les temps de trajet les plus courts du pays. Le FIP est pleinement accepté, mais une réservation de siège gratuite est obligatoire.
+Ces trains relient Athènes (Αθήνα) et Thessalonique (Θεσσαλονίκη) ainsi que Larisa (Λάρισα) et d’autres grandes villes. La ligne est électrifiée et offre les temps de trajet les plus courts du pays. Le FIP est pleinement accepté, mais une réservation de siège gratuite est obligatoire.
 
 #### Réservations
 
-Les réservations doivent être obtenues à l'avance. Elles peuvent être achetées en ligne ou en gare.
+Les réservations doivent être obtenues à l’avance. Elles peuvent être achetées en ligne ou en gare.
 
 {{% highlight tip %}}
-Les trains IC sont souvent complets quelques jours à l'avance. Il est conseillé de s'occuper de la réservation suffisamment tôt.
+Les trains IC sont souvent complets quelques jours à l’avance. Il est conseillé de s’occuper de la réservation suffisamment tôt.
 
 Astuce pour les voyageurs avec un Coupon FIP :
-Comme les réservations individuelles ne sont pas disponibles en ligne, réservez d'abord un Billet FIP 50. Celui-ci peut être annulé gratuitement. Sur place, vous pouvez vérifier si des réservations sont encore disponibles. Si oui, annulez le Billet FIP 50 ; sinon, voyagez avec le Billet FIP 50.
+Comme les réservations individuelles ne sont pas disponibles en ligne, réservez d’abord un Billet FIP 50. Celui-ci peut être annulé gratuitement. Sur place, vous pouvez vérifier si des réservations sont encore disponibles. Si oui, annulez le Billet FIP 50 ; sinon, voyagez avec le Billet FIP 50.
 {{% /highlight %}}
 
 {{% /train-category %}}
@@ -56,12 +56,12 @@ Comme les réservations individuelles ne sont pas disponibles en ligne, réserve
     reservation_required=false
 %}}
 
-Les trains régionaux relient les villes et régions en dehors de l'axe principal.
+Les trains régionaux relient les villes et régions en dehors de l’axe principal.
 
 Certains trains sont désignés sous le nom de Proastiakos ou Suburban Railway, ce qui est comparable à un S-Bahn. Dans le planificateur de voyage, ces services apparaissent également comme trains régionaux `REG`.
 
 {{% highlight confusion %}}
-Les services touristiques comme le Pelion Train sont également indiqués comme `REG` dans le planificateur de voyage, mais le FIP n'y est pas valable.
+Les services touristiques comme le Pelion Train sont également indiqués comme `REG` dans le planificateur de voyage, mais le FIP n’y est pas valable.
 {{% /highlight %}}
 
 {{% /train-category %}}
@@ -85,14 +85,14 @@ Les bus exploités par Hellenic Train acceptent les avantages FIP.[^1]
     fip_accepted=false
 %}}
 
-Hellenic Train exploite trois liaisons ferroviaires touristiques ou historiques sur lesquelles le FIP n'est pas accepté.[^1]
+Hellenic Train exploite trois liaisons ferroviaires touristiques ou historiques sur lesquelles le FIP n’est pas accepté.[^1]
 
-- Pelion Train d'Ano Lechonia (Άνω Λεχώνια) à Milies (Μηλιές) (https://www.hellenictrain.gr/en/mythical-route)
+- Pelion Train d’Ano Lechonia (Άνω Λεχώνια) à Milies (Μηλιές) (https://www.hellenictrain.gr/en/mythical-route)
 - Chemin de fer à crémaillère « Odontotos » de Diakopto (Διακοπτό) à Kalavryta (Καλάβρυτα) (https://www.hellenictrain.gr/en/attraction-rails)
 - Katakolo (Κατάκολο) – Olympie (Αρχαία Ολυμπία) (https://www.hellenictrain.gr/en/katakolo-olympia)
 
 {{< highlight info >}}
-Selon des retours d'expérience, le chemin de fer à crémaillère entre Diakopto et Kalavryta peut être utilisé avec un Coupon FIP et une réservation gratuite disponible sur place. Nous ne sommes actuellement pas en mesure de vérifier l'utilisation avec le FIP 50, car l'exploitation a été temporairement suspendue.[^3]
+Selon des retours d’expérience, le chemin de fer à crémaillère entre Diakopto et Kalavryta peut être utilisé avec un Coupon FIP et une réservation gratuite disponible sur place. Nous ne sommes actuellement pas en mesure de vérifier l’utilisation avec le FIP 50, car l’exploitation a été temporairement suspendue.[^3]
 {{< /highlight >}}
 
 {{% /train-category %}}
@@ -121,28 +121,28 @@ Selon des retours d'expérience, le chemin de fer à crémaillère entre Diakopt
 ### À bord du train
 
 Les réservations ne sont pas disponibles à bord du train.
-Si le voyage commence dans une gare où le guichet n'est pas occupé, les billets peuvent être achetés à bord du train.[^2]
+Si le voyage commence dans une gare où le guichet n’est pas occupé, les billets peuvent être achetés à bord du train.[^2]
 
 ## Réductions
 
-Aux tarifs publics, les enfants jusqu'à 4 ans voyagent gratuitement, les enfants jusqu'à 12 ans bénéficient d'une réduction de 50 % sur le tarif adulte. À partir de 12 ans, le tarif adulte régulier s'applique.[^1]
+Aux tarifs publics, les enfants jusqu’à 4 ans voyagent gratuitement, les enfants jusqu’à 12 ans bénéficient d’une réduction de 50 % sur le tarif adulte. À partir de 12 ans, le tarif adulte régulier s’applique.[^1]
 
 ## Conditions tarifaires spéciales
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
-L'interruption de voyage n'est pas autorisée.[^1]
+L’interruption de voyage n’est pas autorisée.[^1]
 
 ### Modifications et annulations de Billets FIP 50
 
-Avant le début du voyage, les billets peuvent être annulés jusqu'à 10 minutes avant le départ prévu.[^5]
+Avant le début du voyage, les billets peuvent être annulés jusqu’à 10 minutes avant le départ prévu.[^5]
 
-- Pour une annulation jusqu'à 48 heures avant l'heure de départ prévue de la gare de départ, 100 % de la valeur nominale du billet original est remboursé.
-- Pour une annulation entre 48 et 2 heures avant l'heure de départ prévue de la gare de départ, 80 % de la valeur nominale du billet original est remboursé.
-- Pour une annulation moins de 2 heures avant l'heure de départ prévue de la gare de départ et jusqu'à la fermeture du système de vente, 50 % de la valeur nominale du billet original est remboursé.
+- Pour une annulation jusqu’à 48 heures avant l’heure de départ prévue de la gare de départ, 100 % de la valeur nominale du billet original est remboursé.
+- Pour une annulation entre 48 et 2 heures avant l’heure de départ prévue de la gare de départ, 80 % de la valeur nominale du billet original est remboursé.
+- Pour une annulation moins de 2 heures avant l’heure de départ prévue de la gare de départ et jusqu’à la fermeture du système de vente, 50 % de la valeur nominale du billet original est remboursé.
 
-Pour annuler un billet acheté au guichet, le billet doit être présenté. Le remboursement du prix du billet s'effectue via le moyen de paiement initialement choisi.
-Un billet acheté en ligne peut être annulé au guichet ou via la [ligne téléphonique](https://www.hellenictrain.gr/en/contact-us) en indiquant le numéro du billet. Le remboursement du prix du billet s'effectue via le moyen de paiement choisi. Les utilisateurs enregistrés peuvent annuler le billet eux-mêmes via la gestion des billets dans le menu « My Trips ».
+Pour annuler un billet acheté au guichet, le billet doit être présenté. Le remboursement du prix du billet s’effectue via le moyen de paiement initialement choisi.
+Un billet acheté en ligne peut être annulé au guichet ou via la [ligne téléphonique](https://www.hellenictrain.gr/en/contact-us) en indiquant le numéro du billet. Le remboursement du prix du billet s’effectue via le moyen de paiement choisi. Les utilisateurs enregistrés peuvent annuler le billet eux-mêmes via la gestion des billets dans le menu « My Trips ».
 
 ## Sources
 

--- a/content/operator/kd/index.fr.md
+++ b/content/operator/kd/index.fr.md
@@ -80,7 +80,7 @@ Les Billets FIP 50 peuvent être vendus uniquement pour les trajets nationaux.
 
 ### À bord du train
 
-Les Billets FIP 50 peuvent également être achetés directement à bord du train. Pour cela, le personnel de bord doit être contacté immédiatement après l'embarquement. En cas d'embarquement aux gares disposant également d'un guichet ou d'un distributeur de billets, des frais de délivrance à bord peuvent s'ajouter au prix du billet. Paiement en espèces ou par carte bancaire sans contact (Visa, Visa Electron, V Pay, Mastercard, Maestro) accepté. Paiement uniquement possible en zloty polonais.[^1]
+Les Billets FIP 50 peuvent également être achetés directement à bord du train. Pour cela, le personnel de bord doit être contacté immédiatement après l’embarquement. En cas d’embarquement aux gares disposant également d’un guichet ou d’un distributeur de billets, des frais de délivrance à bord peuvent s’ajouter au prix du billet. Paiement en espèces ou par carte bancaire sans contact (Visa, Visa Electron, V Pay, Mastercard, Maestro) accepté. Paiement uniquement possible en zloty polonais.[^1]
 
 ## Réductions
 

--- a/content/operator/kml/index.fr.md
+++ b/content/operator/kml/index.fr.md
@@ -9,14 +9,14 @@ aliases:
   - /booking/kml-ticket-office
 ---
 
-Les Koleje Małopolskie, abrégées KMŁ, sont une compagnie ferroviaire polonaise qui assure principalement des services régionaux dans la voïvodie de Petite-Pologne. C'est l'une des cinq compagnies différentes proposant la FIP en [Pologne](/country/poland).
+Les Koleje Małopolskie, abrégées KMŁ, sont une compagnie ferroviaire polonaise qui assure principalement des services régionaux dans la voïvodie de Petite-Pologne. C’est l’une des cinq compagnies différentes proposant la FIP en [Pologne](/country/poland).
 
-Sur son site Web, la KMŁ propose un [aperçu des lignes exploitées](https://kolejemalopolskie.com.pl/pl/rozklad-jazdy/rozklady-kolejowe). Il convient de noter que certaines lignes sont également desservies en parallèle par d'autres opérateurs.
+Sur son site Web, la KMŁ propose un [aperçu des lignes exploitées](https://kolejemalopolskie.com.pl/pl/rozklad-jazdy/rozklady-kolejowe). Il convient de noter que certaines lignes sont également desservies en parallèle par d’autres opérateurs.
 
 ## Résumé
 
 - La KMŁ accepte les Coupons FIP et les Billets FIP 50.
-- Seule la 2ᵉ classe est disponible dans les trains et aucune réservation n'est possible.
+- Seule la 2ᵉ classe est disponible dans les trains et aucune réservation n’est possible.
 
 ## Validité des Billets FIP
 
@@ -25,18 +25,18 @@ Sur son site Web, la KMŁ propose un [aperçu des lignes exploitées](https://ko
 
 Les Coupons FIP et les Billets FIP 50 sont valables chez la KMŁ.
 
-Pour les trajets avec différents opérateurs en Pologne, il faut disposer soit d'un Billet FIP 50 valable pour l'ensemble du trajet, soit de Coupons FIP des deux opérateurs.
+Pour les trajets avec différents opérateurs en Pologne, il faut disposer soit d’un Billet FIP 50 valable pour l’ensemble du trajet, soit de Coupons FIP des deux opérateurs.
 
 ## Catégories de trains et réservations
 
-La KMŁ ne distingue pas de catégories de trains différentes. Les trains sont indiqués dans les horaires avec l'abréviation « KMŁ » au début, suivie d'un numéro de train spécifique. Des numéros de lignes existent mais ne sont généralement pas affichés dans les horaires. Seuls des billets de 2ᵉ classe sont proposés, car il n'y a pas de 1ʳᵉ classe dans les trains KMŁ. De plus, aucune réservation n'est possible.
+La KMŁ ne distingue pas de catégories de trains différentes. Les trains sont indiqués dans les horaires avec l’abréviation « KMŁ » au début, suivie d’un numéro de train spécifique. Des numéros de lignes existent mais ne sont généralement pas affichés dans les horaires. Seuls des billets de 2ᵉ classe sont proposés, car il n’y a pas de 1ʳᵉ classe dans les trains KMŁ. De plus, aucune réservation n’est possible.
 
 Il ne nous est pas actuellement possible de confirmer si les Billets FIP sont également valables dans les bus de la KMŁ. Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lorsqu’ils remplacent un train dans lequel le FIP aurait été valable.
 
 ## Achat de billets et réservations
 
 {{% highlight important %}}
-La KMŁ n'étant membre FIP que depuis le 01.04.2026, les possibilités de réservation sont actuellement encore très limitées et devraient être progressivement élargies.
+La KMŁ n’étant membre FIP que depuis le 01.04.2026, les possibilités de réservation sont actuellement encore très limitées et devraient être progressivement élargies.
 {{% /highlight %}}
 
 ### En gare
@@ -45,11 +45,11 @@ La KMŁ n'étant membre FIP que depuis le 01.04.2026, les possibilités de rése
 
 ### À bord du train
 
-Les Billets FIP 50 doivent être achetés avant le départ dans les gares où le guichet est ouvert.[^1] S'il n'y a pas de guichet ouvert, les billets peuvent également être achetés directement à bord du train. Pour cela, il faut se présenter au personnel de bord après l'embarquement. Les billets peuvent être payés en espèces ou par carte bancaire sans contact. Le paiement n'est possible qu'en monnaie locale, le Złoty.
+Les Billets FIP 50 doivent être achetés avant le départ dans les gares où le guichet est ouvert.[^1] S’il n’y a pas de guichet ouvert, les billets peuvent également être achetés directement à bord du train. Pour cela, il faut se présenter au personnel de bord après l’embarquement. Les billets peuvent être payés en espèces ou par carte bancaire sans contact. Le paiement n’est possible qu’en monnaie locale, le Złoty.
 
 ## Réductions
 
-Nous ne disposons actuellement d'aucune information concernant les réductions.
+Nous ne disposons actuellement d’aucune information concernant les réductions.
 
 ## Conditions tarifaires spéciales
 
@@ -60,9 +60,9 @@ Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lors
 ## Recommandations
 
 {{% highlight tip %}}
-Le nouveau membre FIP KMŁ est un excellent complément pour les trajets sur le réseau ferroviaire polonais. Même si peu d'informations sont encore disponibles sur l'utilisation de la FIP, celle-ci devrait être aussi simple et pratique que chez les autres compagnies ferroviaires régionales du pays. Sur certaines lignes, des trains de PKP InterCity et Polregio circulent également en parallèle, de sorte qu'en utilisant un Coupon FIP, un Coupon FIP supplémentaire de la PKP est très utile pour ne pas être trop limité dans le choix des trains.
+Le nouveau membre FIP KMŁ est un excellent complément pour les trajets sur le réseau ferroviaire polonais. Même si peu d’informations sont encore disponibles sur l’utilisation de la FIP, celle-ci devrait être aussi simple et pratique que chez les autres compagnies ferroviaires régionales du pays. Sur certaines lignes, des trains de PKP InterCity et Polregio circulent également en parallèle, de sorte qu’en utilisant un Coupon FIP, un Coupon FIP supplémentaire de la PKP est très utile pour ne pas être trop limité dans le choix des trains.
 
-Parmi les destinations phares avec la KMŁ, on trouve notamment le célèbre parc d'attractions Energylandia (gare de Zator Park Rozrywki) et la mine de sel de Wieliczka (gare de Wieliczka-Rynek-Kopalnia).
+Parmi les destinations phares avec la KMŁ, on trouve notamment le célèbre parc d’attractions Energylandia (gare de Zator Park Rozrywki) et la mine de sel de Wieliczka (gare de Wieliczka-Rynek-Kopalnia).
 {{% /highlight %}}
 
 ## Sources

--- a/content/operator/ks/index.fr.md
+++ b/content/operator/ks/index.fr.md
@@ -11,14 +11,14 @@ aliases:
   - /booking/ks-website
 ---
 
-Koleje Śląskie, abrégées KŚ, est une entreprise de transport ferroviaire polonaise qui propose principalement des services régionaux dans la voïvodie de Silésie. C'est l'une des cinq entreprises différentes qui proposent le FIP en [Pologne](/country/poland).
+Koleje Śląskie, abrégées KŚ, est une entreprise de transport ferroviaire polonaise qui propose principalement des services régionaux dans la voïvodie de Silésie. C’est l’une des cinq entreprises différentes qui proposent le FIP en [Pologne](/country/poland).
 
-Sur son site Web KŚ propose une [carte d'aperçu des lignes](https://www.kolejeslaskie.pl/rozklad_jazdy/schemat-linii-komunikacyjnych/).
+Sur son site Web KŚ propose une [carte d’aperçu des lignes](https://www.kolejeslaskie.pl/rozklad_jazdy/schemat-linii-komunikacyjnych/).
 
 ## Résumé
 
 - KŚ accepte les Coupons FIP et les Billets FIP 50.
-- Seule la 2ème classe est disponible dans les trains et aucune réservation n'est possible.
+- Seule la 2ème classe est disponible dans les trains et aucune réservation n’est possible.
 - Certains trajets spéciaux sont exclus du FIP.
 - Certains itinéraires peuvent également être utilisés avec les Coupons FIP de PKP.
 
@@ -33,7 +33,7 @@ Pour les trajets transfrontaliers, un Billet FIP 50 ininterrompu ou les Coupons 
 
 ## Catégories de trains et réservations
 
-KŚ ne distingue pas différentes catégories de trains. Les trains ont généralement un numéro de ligne commençant par « S », qui n'est cependant souvent pas indiqué dans les médias d'information (il y a souvent simplement « KŚ » puis un numéro de train). Seuls les billets de 2ème classe sont proposés, car il n'y a pas de 1ère classe dans les trains KŚ. De plus, aucune réservation n'est possible.
+KŚ ne distingue pas différentes catégories de trains. Les trains ont généralement un numéro de ligne commençant par « S », qui n’est cependant souvent pas indiqué dans les médias d’information (il y a souvent simplement « KŚ » puis un numéro de train). Seuls les billets de 2ème classe sont proposés, car il n’y a pas de 1ère classe dans les trains KŚ. De plus, aucune réservation n’est possible.
 
 Les Billets FIP ne sont généralement pas valables dans les bus KŚ. Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lorsqu’ils remplacent un train dans lequel le FIP aurait été valable.
 
@@ -55,12 +55,12 @@ Les Billets FIP 50 ne peuvent être vendus que pour les connexions nationales.
 
 {{% booking id="db-website-fip-db"
         reservations=nil
-        subtitle="Billets FIP 50 transfrontaliers entre l'Allemagne et la Pologne, avec portion de billet uniquement pour la section polonaise. Réservé aux employés de la Deutsche Bahn."
+        subtitle="Billets FIP 50 transfrontaliers entre l’Allemagne et la Pologne, avec portion de billet uniquement pour la section polonaise. Réservé aux employés de la Deutsche Bahn."
 /%}}
 
 {{% booking id="db-website-fip-international"
         reservations=nil
-        subtitle="Billets FIP 50 transfrontaliers entre l'Allemagne et la Pologne pour l'ensemble du trajet (non valide dans le pays d'émission de la Carte FIP)"
+        subtitle="Billets FIP 50 transfrontaliers entre l’Allemagne et la Pologne pour l’ensemble du trajet (non valide dans le pays d’émission de la Carte FIP)"
 /%}}
 
 ### En gare
@@ -73,11 +73,11 @@ Les Billets FIP 50 ne peuvent être vendus que pour les connexions nationales.
 
 ### À bord du train
 
-Les Billets FIP 50 peuvent également être achetés directement dans le train. Pour cela, le personnel de bord doit être contacté immédiatement après l'embarquement. En cas d'embarquement aux gares disposant également d'un guichet ou d'un distributeur de billets, des frais de délivrance en train peuvent s'ajouter au prix du billet. Les billets peuvent être payés en espèces ou par carte de crédit sans contact. Le paiement n'est possible que dans la devise locale, le Złoty.
+Les Billets FIP 50 peuvent également être achetés directement dans le train. Pour cela, le personnel de bord doit être contacté immédiatement après l’embarquement. En cas d’embarquement aux gares disposant également d’un guichet ou d’un distributeur de billets, des frais de délivrance en train peuvent s’ajouter au prix du billet. Les billets peuvent être payés en espèces ou par carte de crédit sans contact. Le paiement n’est possible que dans la devise locale, le Złoty.
 
 ## Réductions
 
-Pour les billets réguliers, les enfants de moins de 4 ans voyagent gratuitement. Les enfants de moins de 26 ans bénéficient d'une réduction de 20 % sur le tarif adulte. Les personnes à partir de 26 ans paient le tarif adulte complet.[^1]
+Pour les billets réguliers, les enfants de moins de 4 ans voyagent gratuitement. Les enfants de moins de 26 ans bénéficient d’une réduction de 20 % sur le tarif adulte. Les personnes à partir de 26 ans paient le tarif adulte complet.[^1]
 
 ## Conditions tarifaires spéciales
 
@@ -97,9 +97,9 @@ Sur les lignes suivantes de KŚ, tant les Billets FIP de KŚ que ceux de PKP son
 - Pszczyna – Wisła Głębce
 - Kluczbork – Katowice
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
-Les interruptions de voyage sont possibles à tout moment et aucune preuve n'est requise pour cela.
+Les interruptions de voyage sont possibles à tout moment et aucune preuve n’est requise pour cela.
 
 ### Services de remplacement ferroviaire
 
@@ -108,7 +108,7 @@ Dans les bus de remplacement ferroviaire, les réductions FIP sont valables lors
 ## Recommandations
 
 {{% highlight tip %}}
-Similaire aux autres sociétés ferroviaires régionales en Pologne qui acceptent le FIP, l'utilisation du FIP chez KŚ est simple et pratique avec peu d'exceptions. La région métropolitaine polonaise autour de Katowice peut ainsi être facilement utilisée pour les transports régionaux. Les fans de la compagnie ferroviaire peuvent également se procurer des articles de fan au centre de voyages de KŚ à la gare de Katowice.
+Similaire aux autres sociétés ferroviaires régionales en Pologne qui acceptent le FIP, l’utilisation du FIP chez KŚ est simple et pratique avec peu d’exceptions. La région métropolitaine polonaise autour de Katowice peut ainsi être facilement utilisée pour les transports régionaux. Les fans de la compagnie ferroviaire peuvent également se procurer des articles de fan au centre de voyages de KŚ à la gare de Katowice.
 {{% /highlight %}}
 
 ## Sources

--- a/content/operator/kw/index.fr.md
+++ b/content/operator/kw/index.fr.md
@@ -86,7 +86,7 @@ Indépendamment du FIP, Polregio propose un billet week-end avantageux qui, sous
 
 Les Billets FIP ne sont pas valides dans les trains spéciaux exploités par KW.
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 Les interruptions de voyage sont possibles à tout moment et aucune preuve n’est requise pour cela.
 

--- a/content/operator/lka/index.fr.md
+++ b/content/operator/lka/index.fr.md
@@ -109,7 +109,7 @@ Indépendamment du FIP, Polregio propose un billet week-end avantageux qui, sous
 
 Les Billets FIP ne sont pas valides dans les trains spéciaux exploités par ŁKA.
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 Les interruptions de voyage sont possibles à tout moment et aucune preuve n’est requise pour cela.
 

--- a/content/operator/ltg/index.fr.md
+++ b/content/operator/ltg/index.fr.md
@@ -79,7 +79,7 @@ Avec des billets ordinaires, jusqu’à 2 enfants jusqu’à 7 ans inclus voyage
 
 En été, LTG-Link exploite des trains directs entre Vilnius et la mer Baltique (« seaside express ») les vendredis, samedis et dimanches, avec arrêt uniquement à Kretinga et Klaipeda. À Kretinga, correspondance en bus pour Palanga, à Klaipeda pour la presqu’île de Courlande. FIP est valable dans ces trains et les bus de correspondance.[^3]
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 Une interruption de voyage n’est pas prévue, car un billet distinct doit être obtenu pour chaque trajet.
 

--- a/content/operator/nir/index.fr.md
+++ b/content/operator/nir/index.fr.md
@@ -10,7 +10,7 @@ aliases:
   - /booking/translink-whatsapp
 ---
 
-Northern Ireland Railways (NIR) est la compagnie ferroviaire nationale d'Irlande du Nord et fait partie de Translink, une entreprise de transport public. Le réseau ferroviaire est compact et comprend principalement des liaisons à destination et en provenance de Belfast.
+Northern Ireland Railways (NIR) est la compagnie ferroviaire nationale d’Irlande du Nord et fait partie de Translink, une entreprise de transport public. Le réseau ferroviaire est compact et comprend principalement des liaisons à destination et en provenance de Belfast.
 
 ## Résumé
 
@@ -78,15 +78,15 @@ Les Billets FIP 50 / FIP 75 ne peuvent pas être achetés en ligne.
 
 ### À bord du train
 
-Les Billets FIP 50 / FIP 75 doivent être achetés avant le départ. Sur le service Enterprise, il est possible d'acheter le supplément entre la 1re et la 2e classe à bord du train.
+Les Billets FIP 50 / FIP 75 doivent être achetés avant le départ. Sur le service Enterprise, il est possible d’acheter le supplément entre la 1re et la 2e classe à bord du train.
 
 ## Réductions
 
-Les enfants jusqu'à 5 ans voyagent gratuitement. Les jeunes jusqu'à 16 ans bénéficient d'une réduction de 50 % sur le tarif adulte. Les personnes de 16 ans et plus paient le plein tarif FIP adulte.[^1]
+Les enfants jusqu’à 5 ans voyagent gratuitement. Les jeunes jusqu’à 16 ans bénéficient d’une réduction de 50 % sur le tarif adulte. Les personnes de 16 ans et plus paient le plein tarif FIP adulte.[^1]
 
 ## Conditions tarifaires spéciales
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 Les interruptions de voyage ne sont autorisées que pour prendre des trains de correspondance.[^1]
 

--- a/content/operator/ns/index.fr.md
+++ b/content/operator/ns/index.fr.md
@@ -31,7 +31,7 @@ Les agents de [SNCB / NMBS](/operator/sncb) peuvent obtenir un _Unlimited Pass_ 
 
 ## Catégories de trains et réservations
 
-Aucune réservation n'est requise pour les trains NS aux Pays-Bas, et elle n'est généralement pas possible. Pour les trains internationaux `ICE` vers l'Allemagne, la réservation est possible et sera obligatoire en été 2025 (uniquement pour les trajets transfrontaliers).
+Aucune réservation n’est requise pour les trains NS aux Pays-Bas, et elle n’est généralement pas possible. Pour les trains internationaux `ICE` vers l’Allemagne, la réservation est possible et sera obligatoire en été 2025 (uniquement pour les trajets transfrontaliers).
 
 Un supplément est partiellement nécessaire pour les trains Eurocity Direct et Intercity Direct.
 
@@ -44,12 +44,12 @@ Un supplément est partiellement nécessaire pour les trains Eurocity Direct et 
     reservation_possible=true
     additional_information_url="https://www.nsinternational.com/en/trains/ice"
 %}}
-Trains à grande vitesse de la Deutsche Bahn, exploités aux Pays-Bas par NS. Ils circulent entre Amsterdam et l'Allemagne (Cologne / Francfort-sur-le-Main ou Hanovre / Berlin), mais peuvent également être utilisés à l'intérieur des Pays-Bas entre Amsterdam et Arnhem ou Hengelo avec un Coupon FIP sans supplément. Avec un Billet FIP 50, un supplément est toutefois requis.
+Trains à grande vitesse de la Deutsche Bahn, exploités aux Pays-Bas par NS. Ils circulent entre Amsterdam et l’Allemagne (Cologne / Francfort-sur-le-Main ou Hanovre / Berlin), mais peuvent également être utilisés à l’intérieur des Pays-Bas entre Amsterdam et Arnhem ou Hengelo avec un Coupon FIP sans supplément. Avec un Billet FIP 50, un supplément est toutefois requis.
 
 {{% highlight important %}}
-Lors de l'utilisation de Billets FIP 50 pour des trajets nationaux aux Pays-Bas, un [supplément ICE](https://www.ns.nl/en/tickets/ice-supplement) de 3 € par trajet doit être payé. Aucun supplément n'est requis avec un Coupon FIP.
+Lors de l’utilisation de Billets FIP 50 pour des trajets nationaux aux Pays-Bas, un [supplément ICE](https://www.ns.nl/en/tickets/ice-supplement) de 3 € par trajet doit être payé. Aucun supplément n’est requis avec un Coupon FIP.
 
-Le supplément peut être acheté [en ligne](https://www.ns.nl/en/tickets/ice-supplement), via l'application NS ou sur place au guichet ou au distributeur. Sur place, il peut être chargé sur une carte OV-chipkaart. Sans carte OV-chipkaart, des frais supplémentaires de 1,50 € s'appliquent pour un billet unique.
+Le supplément peut être acheté [en ligne](https://www.ns.nl/en/tickets/ice-supplement), via l’application NS ou sur place au guichet ou au distributeur. Sur place, il peut être chargé sur une carte OV-chipkaart. Sans carte OV-chipkaart, des frais supplémentaires de 1,50 € s’appliquent pour un billet unique.
 {{% /highlight %}}
 
 #### Réservations
@@ -72,7 +72,7 @@ Train international avec supplément entre Lelystad, Amsterdam et Bruxelles, ave
 {{< highlight important >}}
 Pour un trajet exclusivement national sur le tronçon entre Rotterdam et Schiphol, un [supplément](https://www.ns.nl/en/season-tickets/other/intercity-direct-supplement.html) de 3,20 € est requis pour les Billets FIP 50.
 
-Si le Billet FIP 50 comprend également un tronçon international (embarquement ou débarquement de l'`ECD` en dehors des Pays-Bas), aucun supplément n'est requis pour les Billets FIP 50, même si le tronçon Rotterdam - Schiphol est emprunté avec l'`ECD`.
+Si le Billet FIP 50 comprend également un tronçon international (embarquement ou débarquement de l’`ECD` en dehors des Pays-Bas), aucun supplément n’est requis pour les Billets FIP 50, même si le tronçon Rotterdam - Schiphol est emprunté avec l’`ECD`.
 
 Exemples de billets avec supplément requis :
 
@@ -85,9 +85,9 @@ Exemples de billets sans supplément requis :
 - Bruxelles - Rotterdam
 - Breda - Rotterdam
 
-Le supplément peut être acheté [en ligne](https://www.ns.nl/en/tickets/icd-supplement), via l'application NS ou sur place au guichet ou au distributeur. Il peut être chargé sur une carte OV-chipkaart. Sans carte OV-chipkaart, des frais supplémentaires de 1,50 € s'appliquent pour un billet unique.
+Le supplément peut être acheté [en ligne](https://www.ns.nl/en/tickets/icd-supplement), via l’application NS ou sur place au guichet ou au distributeur. Il peut être chargé sur une carte OV-chipkaart. Sans carte OV-chipkaart, des frais supplémentaires de 1,50 € s’appliquent pour un billet unique.
 
-Les détenteurs d'une carte OV-chipkaart peuvent acheter un supplément à tarif réduit de 1,92 € (40 % de réduction) au guichet pendant les [heures creuses](https://www.ns.nl/en/travel-information/off-peak-hours.html). [^1] [^2] [^3] [^4]
+Les détenteurs d’une carte OV-chipkaart peuvent acheter un supplément à tarif réduit de 1,92 € (40 % de réduction) au guichet pendant les [heures creuses](https://www.ns.nl/en/travel-information/off-peak-hours.html). [^1] [^2] [^3] [^4]
 {{< /highlight >}}
 
 ![Réseau Eurocity (Direct)](eurocity-map.fr.svg)
@@ -120,9 +120,9 @@ Train rapide, partiellement avec supplément, entre Lelystad ou Amersfoort, Amst
 {{< highlight important >}}
 Pour les trajets sur le tronçon entre Rotterdam et Schiphol, un [supplément](https://www.ns.nl/en/season-tickets/other/intercity-direct-supplement.html) de 3,20 € est requis pour les Billets FIP 50.
 
-Ce supplément peut être acheté [en ligne](https://www.ns.nl/en/tickets/icd-supplement), via l'application NS ou sur place au guichet ou au distributeur. Il peut être chargé sur une carte OV-chipkaart. Sans carte OV-chipkaart, des frais supplémentaires de 1,50 € s'appliquent pour un billet unique.
+Ce supplément peut être acheté [en ligne](https://www.ns.nl/en/tickets/icd-supplement), via l’application NS ou sur place au guichet ou au distributeur. Il peut être chargé sur une carte OV-chipkaart. Sans carte OV-chipkaart, des frais supplémentaires de 1,50 € s’appliquent pour un billet unique.
 
-Les détenteurs d'une carte OV-chipkaart peuvent acheter un supplément à tarif réduit de 1,92 € (40 % de réduction) au guichet pendant les [heures creuses](https://www.ns.nl/en/travel-information/off-peak-hours.html). [^1] [^2] [^3] [^4]
+Les détenteurs d’une carte OV-chipkaart peuvent acheter un supplément à tarif réduit de 1,92 € (40 % de réduction) au guichet pendant les [heures creuses](https://www.ns.nl/en/travel-information/off-peak-hours.html). [^1] [^2] [^3] [^4]
 {{< /highlight >}}
 
 ![Réseau Intercity Direct, Spag85, [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0), via [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Intercity_direct_network.jpg)](intercity-direct-map.webp)
@@ -136,7 +136,7 @@ Les détenteurs d'une carte OV-chipkaart peuvent acheter un supplément à tarif
     fip_accepted=true
     reservation_required=false
 %}}
-Contrairement à d'autres pays, il ne s'agit pas de véritables trains longue distance, mais plutôt de trains régionaux rapides avec peu d'arrêts.
+Contrairement à d’autres pays, il ne s’agit pas de véritables trains longue distance, mais plutôt de trains régionaux rapides avec peu d’arrêts.
 {{% /train-category %}}
 
 {{% train-category
@@ -146,10 +146,10 @@ Contrairement à d'autres pays, il ne s'agit pas de véritables trains longue di
     fip_accepted=true
     reservation_required=false
 %}}
-Trains régionaux avec plus d'arrêts que les Intercity, mais uniquement dans les gares principales.
+Trains régionaux avec plus d’arrêts que les Intercity, mais uniquement dans les gares principales.
 
 {{% highlight confusion %}}
-Les trains de la catégorie Sneltrein / Regional-Express `RE`, notamment les liaisons Venlo – Hamm (Allemagne), Maastricht – Aix-la-Chapelle (Allemagne) et Arnhem – Düsseldorf (Allemagne), ainsi que d'autres liaisons RE, ne sont pas exploités par NS et ne sont pas accessibles avec FIP.
+Les trains de la catégorie Sneltrein / Regional-Express `RE`, notamment les liaisons Venlo – Hamm (Allemagne), Maastricht – Aix-la-Chapelle (Allemagne) et Arnhem – Düsseldorf (Allemagne), ainsi que d’autres liaisons RE, ne sont pas exploités par NS et ne sont pas accessibles avec FIP.
 {{% /highlight %}}
 {{% /train-category %}}
 
@@ -201,7 +201,7 @@ Les Billets FIP 50 ne peuvent pas être achetés à bord. [^1]
 
 ## Réductions
 
-Les enfants de moins de 4 ans voyagent gratuitement. Les enfants entre 4 et 11 ans inclus ont besoin d'un [billet Railrunner](https://www.ns.nl/en/tickets/railrunner) à 2,50 €, valable toute une journée. Alternativement, pour les enfants entre 4 et 11 ans inclus voyageant accompagnés d'un adulte, l'abonnement saisonnier gratuit [« Kids Vrij »](https://www.ns.nl/en/season-tickets/kids-vrij.html) peut être obtenu. Une OV chipkaart est nécessaire à cet effet (frais uniques de 7,50 €). À partir de 12 ans, le tarif FIP adulte normal s'applique.
+Les enfants de moins de 4 ans voyagent gratuitement. Les enfants entre 4 et 11 ans inclus ont besoin d’un [billet Railrunner](https://www.ns.nl/en/tickets/railrunner) à 2,50 €, valable toute une journée. Alternativement, pour les enfants entre 4 et 11 ans inclus voyageant accompagnés d’un adulte, l’abonnement saisonnier gratuit [« Kids Vrij »](https://www.ns.nl/en/season-tickets/kids-vrij.html) peut être obtenu. Une OV chipkaart est nécessaire à cet effet (frais uniques de 7,50 €). À partir de 12 ans, le tarif FIP adulte normal s’applique.
 
 ## Conditions tarifaires spéciales
 

--- a/content/operator/oebb/index.fr.md
+++ b/content/operator/oebb/index.fr.md
@@ -342,7 +342,7 @@ Les trains grandes lignes ÖBB circulent entre Salzbourg et Kufstein sur le rés
 
 À part le supplément pour le Coupon FIP, il n’y a pas de distinction entre les trains locaux et grandes lignes. Tous les billets, y compris les Billets FIP 50, sont valables sur tous les trains ÖBB.
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 Arrêts intermédiaires sont possible uniquement pour les distances de 101 km ou plus et ne nécessite aucune formalité supplémentaire.
 

--- a/content/operator/pkp/index.fr.md
+++ b/content/operator/pkp/index.fr.md
@@ -306,7 +306,7 @@ La validité des billets dépend de la distance :
 - 51 km à 100 km : 6 heures à partir de la date et de l’heure d’émission ou au choix du voyageur,
 - à partir de 101 km : 1 jour (un jour est valable de 00h01 à 24h00).
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 #### PKP Intercity (EIP, EIC, IC, TLK)
 

--- a/content/operator/renfe/index.fr.md
+++ b/content/operator/renfe/index.fr.md
@@ -190,7 +190,7 @@ Les réservations sont obligatoires, sauf sur la ligne Barcelone(-Gérone-Figuer
 
 Trains de banlieue, comparables à un RER/S-Bahn. Les Coupons FIP gratuits sont valables sans restriction.
 
-À Barcelone, les Cercanías (y compris vers l'aéroport) ne sont accessibles que par des portiques. À un guichet avec du personnel, il est possible de demander un « Bono Gratuit » (pour le Coupon FIP) – un billet gratuit qui ouvre les portiques. Il n'est valable que pour un seul trajet.[^4]
+À Barcelone, les Cercanías (y compris vers l’aéroport) ne sont accessibles que par des portiques. À un guichet avec du personnel, il est possible de demander un « Bono Gratuit » (pour le Coupon FIP) – un billet gratuit qui ouvre les portiques. Il n’est valable que pour un seul trajet.[^4]
 
 - Cercanías Asturias
 - Cercanías Bilbao – Bilboko Aldiriak

--- a/content/operator/sbb/index.fr.md
+++ b/content/operator/sbb/index.fr.md
@@ -69,7 +69,7 @@ Trains internationaux vers l’Allemagne et l’Italie.
 1ère classe : 13 € \
 2ᵉ classe : 11 €
 
-Une réservation et un supplément sont requis pour la section italienne. Il est moins cher de voyager vers l'Italie en changeant de train à Chiasso ([Voir Voyage vers l'Italie](/country/switzerland#italie "Voyage vers l'Italie")). Le supplément peut être acheté au guichet CFF ou à bord du train.
+Une réservation et un supplément sont requis pour la section italienne. Il est moins cher de voyager vers l’Italie en changeant de train à Chiasso ([Voir Voyage vers l’Italie](/country/switzerland#italie "Voyage vers l’Italie")). Le supplément peut être acheté au guichet CFF ou à bord du train.
 {{% /train-category %}}
 
 {{% train-category
@@ -82,7 +82,7 @@ Une réservation et un supplément sont requis pour la section italienne. Il est
 %}}
 Trains rapides nationaux ne s’arrêtant que dans les grandes villes et les gares de correspondance.
 
-Certains services [Nightjet](#nj) sont exploités avec des voitures à sièges `IC`. Ces voitures peuvent être utilisées sans réservation. Le service IC est affiché dans les systèmes d'information en plus du service Nightjet.
+Certains services [Nightjet](#nj) sont exploités avec des voitures à sièges `IC`. Ces voitures peuvent être utilisées sans réservation. Le service IC est affiché dans les systèmes d’information en plus du service Nightjet.
 {{% /train-category %}}
 
 {{% train-category
@@ -95,7 +95,7 @@ Certains services [Nightjet](#nj) sont exploités avec des voitures à sièges `
 %}}
 Trains de nuit Nightjet de l’ÖBB et trains de nuit EuroNight de la ČD, MÁV et HŽ, exploités par les CFF en Suisse. Ils desservent notamment Berlin, Dresde, Leipzig, Prague, Budapest, Ljubljana et Zagreb.
 
-Certains services Nightjet sont assurés par des voitures [Intercity](#ic). Ces voitures peuvent être utilisées sans réservation. Le service IC est affiché dans les systèmes d'information, en plus du service Nightjet.
+Certains services Nightjet sont assurés par des voitures [Intercity](#ic). Ces voitures peuvent être utilisées sans réservation. Le service IC est affiché dans les systèmes d’information, en plus du service Nightjet.
 
 #### Réservations
 

--- a/content/operator/sll/index.fr.md
+++ b/content/operator/sll/index.fr.md
@@ -11,7 +11,7 @@ aliases:
   - /booking/stena-line-limited-phone
 ---
 
-L’entreprise Stena Line exploite divers ferries pour passagers et véhicules. Les liaisons en mer d'Irlande sont assurées par Stena Line Limited (SLL) dans le cadre de l'accord FIP.
+L’entreprise Stena Line exploite divers ferries pour passagers et véhicules. Les liaisons en mer d’Irlande sont assurées par Stena Line Limited (SLL) dans le cadre de l’accord FIP.
 
 Les services de ferry entre Harwich ([Royaume-Uni](/country/united-kingdom)) et Hoek van Holland ([Pays-Bas](/country/netherlands)) sont assurés par [Stena Line BV (StL)](/operator/stl), un opérateur FIP distinct.
 
@@ -32,7 +32,7 @@ Les services de ferry entre Harwich ([Royaume-Uni](/country/united-kingdom)) et 
     width="40%"
     position="right"
 %}}
-Les ferries assurant la traversée de la mer d'Irlande ne font pas de distinction de catégories. Différents navires, offrant des prestations variées, sont utilisés selon la traversée.
+Les ferries assurant la traversée de la mer d’Irlande ne font pas de distinction de catégories. Différents navires, offrant des prestations variées, sont utilisés selon la traversée.
 
 La licence FIP (Ferrari International Passenger License) est acceptée sur plusieurs lignes :
 
@@ -47,7 +47,7 @@ Vous trouverez la liste des navires utilisés sur le [site web de Stena Line](ht
 ## Catégories de classes
 
 Il n’existe qu’une seule classe à bord des navires pour FIP.
-Selon l'itinéraire et le navire, différentes options de salons et de cabines sont disponibles.
+Selon l’itinéraire et le navire, différentes options de salons et de cabines sont disponibles.
 Aucune remise FIP n’est accordée sur les salons ou les cabines. [^1]
 
 ## Achat de billets et de réservations

--- a/content/operator/sncb/index.fr.md
+++ b/content/operator/sncb/index.fr.md
@@ -31,7 +31,7 @@ Les agents de [NS](/operator/ns) peuvent obtenir un _Unlimited Pass_ leur permet
 
 ## Catégories de trains et réservations
 
-En Belgique, aucune réservation n’est requise dans les trains de la SNCB, et elle n’est souvent pas possible. Pour les trains internationaux `ICE` vers l'Allemagne, la réservation est possible et sera obligatoire en été 2026 (uniquement pour les trajets transfrontaliers).
+En Belgique, aucune réservation n’est requise dans les trains de la SNCB, et elle n’est souvent pas possible. Pour les trains internationaux `ICE` vers l’Allemagne, la réservation est possible et sera obligatoire en été 2026 (uniquement pour les trajets transfrontaliers).
 
 {{% train-category
   id="ice"
@@ -76,7 +76,7 @@ Contrairement à d’autres pays, il ne s’agit pas de véritables trains longu
 Train international entre Lelystad, Amsterdam et Bruxelles avec arrêts à Almere, Schiphol, Rotterdam et Anvers.
 
 {{% highlight important %}}
-Pour les trajets aux Pays-Bas, des règles spéciales s'appliquent, voir [NS ECD](/operator/ns#ecd)
+Pour les trajets aux Pays-Bas, des règles spéciales s’appliquent, voir [NS ECD](/operator/ns#ecd)
 {{% /highlight %}}
 
 ![Réseau Eurocity (Direct)](eurocity-map.fr.svg)
@@ -193,10 +193,10 @@ Les trajets nationaux ne peuvent malheureusement pas être achetés en ligne.
 ### À bord du train
 
 {{% highlight important %}}
-À partir du 1er juillet 2026, la SNCB ne vendra plus de billets à bord de ses trains. Cela concerne également les billets FIP à tarif réduit. Tous les voyageurs devront être en possession d'un billet valable avant de monter à bord. [^5]<sup>, </sup>[^6]
+À partir du 1er juillet 2026, la SNCB ne vendra plus de billets à bord de ses trains. Cela concerne également les billets FIP à tarif réduit. Tous les voyageurs devront être en possession d’un billet valable avant de monter à bord. [^5]<sup>, </sup>[^6]
 {{% /highlight %}}
 
-Les billets FIP à tarif réduit peuvent en principe être achetés à bord des trains. Le supplément SNCB habituel pour les ventes à bord n'est pas facturé, car ces billets ne sont pas disponibles aux distributeurs automatiques. [^2]<sup>, </sup>[^4]
+Les billets FIP à tarif réduit peuvent en principe être achetés à bord des trains. Le supplément SNCB habituel pour les ventes à bord n’est pas facturé, car ces billets ne sont pas disponibles aux distributeurs automatiques. [^2]<sup>, </sup>[^4]
 
 ## Réductions
 

--- a/content/operator/sncf/index.fr.md
+++ b/content/operator/sncf/index.fr.md
@@ -109,7 +109,7 @@ Les prix de réservation diffèrent entre les trains en période de pointe (Peak
 | En France Peak     | 16 €       | 11 €      |
 | International      | 40 €       | 20 €      |
 
-Pour les trains directs entre Francfort (Main) et Bordeaux en juillet et août, la DB ne vend pas de Billets FIP 50 / FIP 75 pour le trajet à l'intérieur de la France. Cependant, l'utilisation avec un Coupon FIP et une réservation SNCF est possible. [^5]
+Pour les trains directs entre Francfort (Main) et Bordeaux en juillet et août, la DB ne vend pas de Billets FIP 50 / FIP 75 pour le trajet à l’intérieur de la France. Cependant, l’utilisation avec un Coupon FIP et une réservation SNCF est possible. [^5]
 
 {{% /train-category %}}
 
@@ -361,7 +361,7 @@ Certaines lignes RER sont exploitées par la SNCF. Les réductions FIP sont vala
 
 Attention : pour les trajets entre Gare du Nord et Châtelet – Les Halles, seule la ligne RER D exploitée par la SNCF est valable. Les réductions FIP ne sont pas valables sur la ligne RER B exploitée par la RATP sur le même tronçon.
 
-L'accès à certaines gares est limité par des portillons. Lors de l'utilisation de Coupons FIP, un pass d'accès temporaire est nécessaire, voir [Portillons](#portillons).
+L’accès à certaines gares est limité par des portillons. Lors de l’utilisation de Coupons FIP, un pass d’accès temporaire est nécessaire, voir [Portillons](#portillons).
 {{% /train-category %}}
 
 {{% train-category
@@ -373,7 +373,7 @@ L'accès à certaines gares est limité par des portillons. Lors de l'utilisatio
 %}}
 Les réductions FIP sont valables sur toutes les lignes Transilien H, J, K, L, N, P, R, U et V.
 
-L'accès à certaines gares est limité par des portillons. Lors de l'utilisation de Coupons FIP, un pass d'accès temporaire est nécessaire, voir [Portillons](#portillons).
+L’accès à certaines gares est limité par des portillons. Lors de l’utilisation de Coupons FIP, un pass d’accès temporaire est nécessaire, voir [Portillons](#portillons).
 {{% /train-category %}}
 
 {{% train-category
@@ -399,7 +399,7 @@ Les Billets FIP à tarif réduit pour `RER` et Transilien peuvent être achetés
 {{% /float-image %}}
 
 {{% highlight important %}}
-De nombreuses gares équipées de portillons ne sont pas surveillées par du personnel. Il existe des interphones d'assistance, mais ils fonctionnent de manière peu fiable. Sans la _Contremarque de Passage_ (carte d'accès temporaire), il n'est donc souvent pas possible d'accéder aux gares.
+De nombreuses gares équipées de portillons ne sont pas surveillées par du personnel. Il existe des interphones d’assistance, mais ils fonctionnent de manière peu fiable. Sans la _Contremarque de Passage_ (carte d’accès temporaire), il n’est donc souvent pas possible d’accéder aux gares.
 {{% /highlight %}}
 
 ### Services de remplacement ferroviaire

--- a/content/operator/sp/index.fr.md
+++ b/content/operator/sp/index.fr.md
@@ -134,15 +134,15 @@ Tous ces services sont accessibles avec le FIP.
     reservation_required=partially
     reservation_possible=true
 %}}
-Ferrovie Autolinee Regionali Ticinesi (FART) exploite, outre quelques lignes d'autobus, la section suisse de la Centovallibahn de Locarno à Domodossola en Italie, sur laquelle circule également le Treno Panoramico Vigezzo Vision.
+Ferrovie Autolinee Regionali Ticinesi (FART) exploite, outre quelques lignes d’autobus, la section suisse de la Centovallibahn de Locarno à Domodossola en Italie, sur laquelle circule également le Treno Panoramico Vigezzo Vision.
 
-Bien que la Centovallibahn mène en Italie, les billets FIP de SP sont valables sur l'ensemble de la ligne, car la section italienne est exploitée par la SSIF, également membre SP du FIP.
+Bien que la Centovallibahn mène en Italie, les billets FIP de SP sont valables sur l’ensemble de la ligne, car la section italienne est exploitée par la SSIF, également membre SP du FIP.
 
 {{% highlight important %}}
-Dans certains trains, un supplément de panorama de 1,50 € doit être payé. Les liaisons de train concernées ne sont visibles que [en ligne sur le site de Centovalli](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) et non via le service d'information sur les connexions. Le supplément peut être acheté [en ligne](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) ou sur place dans le train.
+Dans certains trains, un supplément de panorama de 1,50 € doit être payé. Les liaisons de train concernées ne sont visibles que [en ligne sur le site de Centovalli](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) et non via le service d’information sur les connexions. Le supplément peut être acheté [en ligne](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) ou sur place dans le train.
 {{% /highlight %}}
 
-FART exploite également deux petits téléphériques. Il n'est pas connu si le FIP est reconnu sur ceux-ci.
+FART exploite également deux petits téléphériques. Il n’est pas connu si le FIP est reconnu sur ceux-ci.
 
 Dans le transport par bus, le FIP est pleinement reconnu.
 
@@ -150,7 +150,7 @@ Dans le transport par bus, le FIP est pleinement reconnu.
 
 Les réservations ne sont nécessaires que pendant les marchés de Noël et le Raduno degli Spazzacamini (la rencontre internationale des ramoneurs) à Santa Maria Maggiore.
 
-Dans les trains panoramiques, il n'est pas permis de voyager debout pour des raisons de confort.
+Dans les trains panoramiques, il n’est pas permis de voyager debout pour des raisons de confort.
 
 Les réservations de sièges peuvent être achetées [en ligne sur le site de Centovalli](https://prenota.vigezzinacentovalli.com/) pour 4 € par personne et par trajet.
 
@@ -460,7 +460,7 @@ Pour le Glacier Express, des réservations payantes doivent être achetées à l
     reservation_required=false
     reservation_possible=true
 %}}
-La Schweizerische Südostbahn (SOB) exploite des services réguliers à la fois sur ses propres lignes et sur certaines lignes de la CFF. En coopération avec la CFF, les trains régionaux connus tels que le Voralpen-Express/Treno Gottardo, l'Alpenrhein-Express et l'Aare Linth sont également exploités par la SOB.
+La Schweizerische Südostbahn (SOB) exploite des services réguliers à la fois sur ses propres lignes et sur certaines lignes de la CFF. En coopération avec la CFF, les trains régionaux connus tels que le Voralpen-Express/Treno Gottardo, l’Alpenrhein-Express et l’Aare Linth sont également exploités par la SOB.
 
 {{% highlight important %}}
 Il est à noter que les Coupons FIP ne sont pas valables sur les lignes où la SOB opère en coopération avec la CFF, par exemple entre Bâle CFF et Arth-Goldau. Sur ces itinéraires, seuls les Coupons FIP de la CFF sont valables. En revanche, les billets FIP 50 sont possibles.
@@ -489,14 +489,14 @@ La Società Subalpina di Imprese Ferroviarie exploite la section italienne de la
 Les billets FIP SP sont valables sur l’ensemble de la ligne, y compris la section suisse, car celle-ci est exploitée par la FART, également membre de SP.
 
 {{% highlight important %}}
-Dans certains trains, un supplément de panorama de 1,50 € doit être payé. Les liaisons de train concernées ne sont visibles que [en ligne sur le site de Centovalli](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) et non via le service d'information sur les connexions. Le supplément peut être acheté [en ligne](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) ou sur place dans le train.
+Dans certains trains, un supplément de panorama de 1,50 € doit être payé. Les liaisons de train concernées ne sont visibles que [en ligne sur le site de Centovalli](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) et non via le service d’information sur les connexions. Le supplément peut être acheté [en ligne](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) ou sur place dans le train.
 {{% /highlight %}}
 
 #### Réservations
 
 Les réservations ne sont nécessaires que pendant les marchés de Noël et le Raduno degli Spazzacamini (la rencontre internationale des ramoneurs) à Santa Maria Maggiore.
 
-Dans les trains panoramiques, il n'est pas permis de voyager debout pour des raisons de confort.
+Dans les trains panoramiques, il n’est pas permis de voyager debout pour des raisons de confort.
 
 Les réservations de sièges peuvent être achetées [en ligne sur le site de Centovalli](https://prenota.vigezzinacentovalli.com/) pour 4 € par personne et par trajet.
 

--- a/content/operator/stl/index.fr.md
+++ b/content/operator/stl/index.fr.md
@@ -166,7 +166,7 @@ Stena Line propose des billets permettant un voyage combiné train et ferry à p
 ## Recommandations
 
 {{% highlight important %}}
-Veuillez noter que l'enregistrement n'est possible que jusqu'à 45 minutes avant le départ. Prévoyez donc suffisamment de temps pour votre arrivée.
+Veuillez noter que l’enregistrement n’est possible que jusqu’à 45 minutes avant le départ. Prévoyez donc suffisamment de temps pour votre arrivée.
 {{% /highlight %}}
 
 L’accès à la station _Hoek van Holland Haven_ se fait généralement par la ligne de métro B depuis Rotterdam et Schiedam.

--- a/content/operator/zssk/index.fr.md
+++ b/content/operator/zssk/index.fr.md
@@ -161,7 +161,7 @@ Les réservations sont obligatoires uniquement en 1ʳᵉ classe.
     type="bus"
     fip_accepted=false
 %}}
-Les bus sont exclus des réductions FIP. Dans les bus de remplacement ferroviaire, les réductions FIP s'appliquent lorsqu'ils remplacent un train sur lequel le FIP aurait été valable.[^1]
+Les bus sont exclus des réductions FIP. Dans les bus de remplacement ferroviaire, les réductions FIP s’appliquent lorsqu’ils remplacent un train sur lequel le FIP aurait été valable.[^1]
 {{% /train-category %}}
 
 ## Achat de billets et de réservations
@@ -206,7 +206,7 @@ Les étudiants de moins de 26 ans et les seniors de 62 ans et plus originaires d
 
 ## Conditions tarifaires spéciales
 
-### Possibilité d'interrompre le trajet
+### Possibilité d’interrompre le trajet
 
 Possible uniquement pour les trajets de 101 km ou plus.
 


### PR DESCRIPTION
## Summary
- replace ASCII apostrophes (`'`) with typographic apostrophes (`’`) across French content pages
- align French content with the project glossary requirement for apostrophe usage
- keep wording and structure unchanged while applying typographic normalization