### PR TITLE
fix: align SNCB recommendation meaning in French content

### DIFF
--- a/content/operator/sncb/index.de.md
+++ b/content/operator/sncb/index.de.md
@@ -205,7 +205,7 @@ Bis zu vier Kinder unter 12 Jahren reisen in Begleitung eines Erwachsenen (Perso
 
 ### Flughafen Brüssel Zaventem
 
-Auf Verbindungen von und zum Flughafen Brüssel Zaventem muss für den FIP Freifahrtschein ein Zuschlag gezahlt werden. Dieser beträgt aktuell 6,70 Euro (vgl. [Info der SNCB](https://www.belgiantrain.be/de/tickets-and-railcards/airports/brussels-airport)) und muss auch gezahlt werden, wenn der Hinweise _No Supplement Necessary_ angegeben ist. Bei FIP 50 / FIP 75 Tickets ist dieser bereits im Preis inbegriffen. [^1]
+Auf Verbindungen von und zum Flughafen Brüssel Zaventem muss für den FIP Freifahrtschein ein Zuschlag gezahlt werden. Dieser beträgt aktuell 7,10 Euro (vgl. [Info der SNCB](https://www.belgiantrain.be/de/tickets-and-railcards/airports/brussels-airport)) und muss auch gezahlt werden, wenn der Hinweise _No Supplement Necessary_ angegeben ist. Bei FIP 50 / FIP 75 Tickets ist dieser bereits im Preis inbegriffen. [^1]
 
 ## Quellen
 

--- a/content/operator/sncb/index.de.md
+++ b/content/operator/sncb/index.de.md
@@ -207,12 +207,6 @@ Bis zu vier Kinder unter 12 Jahren reisen in Begleitung eines Erwachsenen (Perso
 
 Auf Verbindungen von und zum Flughafen Brüssel Zaventem muss für den FIP Freifahrtschein ein Zuschlag gezahlt werden. Dieser beträgt aktuell 6,70 Euro (vgl. [Info der SNCB](https://www.belgiantrain.be/de/tickets-and-railcards/airports/brussels-airport)) und muss auch gezahlt werden, wenn der Hinweise _No Supplement Necessary_ angegeben ist. Bei FIP 50 / FIP 75 Tickets ist dieser bereits im Preis inbegriffen. [^1]
 
-## Empfehlungen
-
-{{% highlight tip %}}
-Die 1. Klasse in den Zügen der SNCB / NMBS wird oft auch mit 2. Klasse Tickets benutzt. Auch ist die 1. Klasse meist nicht viel komfortabler als die 2. Klasse. Anders als in anderen Ländern lohnt sich daher ein Kauf von 1. Klasse Tickets, um hier mehr Platz und Ruhe zu haben, nur bedingt.
-{{% /highlight %}}
-
 ## Quellen
 
 [^1]: [Rail Delivery Group](https://www.raildeliverygroup.com/rst/europe-and-fip.html)

--- a/content/operator/sncb/index.de.md
+++ b/content/operator/sncb/index.de.md
@@ -205,7 +205,7 @@ Bis zu vier Kinder unter 12 Jahren reisen in Begleitung eines Erwachsenen (Perso
 
 ### Flughafen Brüssel Zaventem
 
-Auf Verbindungen von und zum Flughafen Brüssel Zaventem muss für den FIP Freifahrtschein ein Zuschlag gezahlt werden. Dieser beträgt aktuell 6,90 Euro (vgl. [Info der SNCB](https://www.belgiantrain.be/de/tickets-and-railcards/airports/brussels-airport)) und muss auch gezahlt werden, wenn der Hinweise _No Supplement Necessary_ angegeben ist. Bei FIP 50 / FIP 75 Tickets ist dieser bereits im Preis inbegriffen. [^1]
+Auf Verbindungen von und zum Flughafen Brüssel Zaventem muss für den FIP Freifahrtschein ein Zuschlag gezahlt werden. Dieser beträgt aktuell 6,70 Euro (vgl. [Info der SNCB](https://www.belgiantrain.be/de/tickets-and-railcards/airports/brussels-airport)) und muss auch gezahlt werden, wenn der Hinweise _No Supplement Necessary_ angegeben ist. Bei FIP 50 / FIP 75 Tickets ist dieser bereits im Preis inbegriffen. [^1]
 
 ## Empfehlungen
 

--- a/content/operator/sncb/index.en.md
+++ b/content/operator/sncb/index.en.md
@@ -209,12 +209,6 @@ Up to four children under the age of 12 travel for free when accompanied by an a
 
 For connections to and from Brussels Zaventem Airport, a surcharge must be paid for the FIP Coupon. This currently amounts to € 6.70 (see [SNCB info](https://www.belgiantrain.be/en/tickets-and-railcards/airports/brussels-airport)) and must also be paid if the note _No Supplement Necessary_ is indicated. For FIP 50 / FIP 75 Tickets, this is already included in the price. [^1]
 
-## Recommendations
-
-{{% highlight tip %}}
-The first class in SNCB / NMBS trains is often used with second class tickets. Also, the 1st class is usually not much more comfortable than the second class. Unlike in other countries, buying first class tickets to have more space and quiet is only worthwhile to a limited extent.
-{{% /highlight %}}
-
 ## Sources
 
 [^1]: [Rail Delivery Group](https://www.raildeliverygroup.com/rst/europe-and-fip.html)

--- a/content/operator/sncb/index.fr.md
+++ b/content/operator/sncb/index.fr.md
@@ -211,7 +211,7 @@ Un supplément de 6,70 € est requis pour les trajets à destination ou en prov
 ## Recommandation
 
 {{% highlight tip %}}
-La 1ère classe dans les trains de la SNCB est souvent utilisée par des passagers sans billet valide, et son confort est rarement supérieur à la 2ᵉ classe. Il n’est donc pas toujours rentable d’y voyager avec un coupon de 1ʳᵉ classe.
+La 1ère classe dans les trains de la SNCB est souvent utilisée avec des billets de 2ᵉ classe, et son confort est rarement supérieur à la 2ᵉ classe. Il n’est donc pas toujours rentable d’y voyager avec un coupon de 1ʳᵉ classe.
 {{% /highlight %}}
 
 ## Sources

--- a/content/operator/sncb/index.fr.md
+++ b/content/operator/sncb/index.fr.md
@@ -208,12 +208,6 @@ Jusqu’à quatre enfants de moins de 12 ans voyagent gratuitement lorsqu’ils 
 
 Un supplément de 6,70 € est requis pour les trajets à destination ou en provenance de l’aéroport, même avec un Coupon FIP, même si le message _"Pas de supplément requis"_ figure sur le billet. Ce supplément est inclus dans le prix d’un Billet FIP 50 / FIP 75. [^1] [Plus d’infos sur le supplément SNCB](https://www.belgiantrain.be/fr/tickets-and-railcards/airports/brussels-airport)
 
-## Recommandation
-
-{{% highlight tip %}}
-La 1ère classe dans les trains de la SNCB est souvent utilisée avec des billets de 2ᵉ classe, et son confort est rarement supérieur à la 2ᵉ classe. Il n’est donc pas toujours rentable d’y voyager avec un coupon de 1ʳᵉ classe.
-{{% /highlight %}}
-
 ## Sources
 
 [^1]: [Rail Delivery Group](https://www.raildeliverygroup.com/rst/europe-and-fip.html)


### PR DESCRIPTION
## Summary
- adjust the French SNCB recommendation text to match the DE/EN meaning
- replace the phrasing about passengers without valid tickets with wording about second-class ticket usage in first class
- keep the recommendation intent and structure unchanged