### PR TITLE
feat: replace hugo deprecations

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -5,12 +5,18 @@ defaultContentLanguage: "en"
 defaultContentLanguageInSubdir: true
 languages:
   en:
+    label: "English"
+    locale: "en"
     weight: 1
     title: "FIP Guide – Fast. Clear. Community-based."
   de:
+    label: "Deutsch"
+    locale: "de"
     weight: 2
     title: "FIP Guide – Schnell. Übersichtlich. Community-basiert."
   fr:
+    label: "Français"
+    locale: "fr"
     weight: 3
     title: "FIP Guide – Rapide. Clair. Basé sur le partage."
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -5,18 +5,12 @@ defaultContentLanguage: "en"
 defaultContentLanguageInSubdir: true
 languages:
   en:
-    languageName: "English"
-    languageCode: en
     weight: 1
     title: "FIP Guide – Fast. Clear. Community-based."
   de:
-    languageName: "Deutsch"
-    languageCode: de
     weight: 2
     title: "FIP Guide – Schnell. Übersichtlich. Community-basiert."
   fr:
-    languageName: "Français"
-    languageCode: fr
     weight: 3
     title: "FIP Guide – Rapide. Clair. Basé sur le partage."
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html
-  lang="{{ site.Language.LanguageCode }}"
-  dir="{{ or site.Language.LanguageDirection `ltr` }}"
+  lang="{{ site.Language.Locale }}"
+  dir="{{ or site.Language.Direction `ltr` }}"
 >
   <head>
     {{ partial "head" . }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -4,7 +4,7 @@
         <title>{{ .Site.Title }}</title>
         <link>{{ .Site.BaseURL }}</link>
         <description>{{ .Site.Params.description }}</description>
-        <language>{{ site.Language.LanguageCode }}</language>
+        <language>{{ site.Language.Locale }}</language>
         <image>{{ partial "header-logo" }}</image>
         {{ range where .Site.RegularPages "Section" "news" }}
         <item>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,7 +1,7 @@
 <div class="o-footer__line">
   <div
     aria-label="{{ T "footer-love.aria-label" }}"
-    {{ if and (ne site.Language.LanguageCode "fr") (ne site.Language.LanguageCode "en") }}
+    {{ if and (ne site.Language.Locale "fr") (ne site.Language.Locale "en") }}
       lang="en"
     {{ end }}
   >
@@ -57,7 +57,7 @@
       aria-label="{{ T "language-switcher.aria-label" }}"
     >
       {{ partial "icon" "translate" }}
-      <div>{{ $.Site.Language.LanguageName }}</div>
+      <div>{{ $.Site.Language.Label }}</div>
       <div class="o-dropdown__icon">
         {{ partial "icon" "keyboard_arrow_up" }}
       </div>
@@ -79,7 +79,7 @@
             href="{{ .Permalink }}"
             {{ if eq $.Site.Language .Language }}aria-current="page"{{ end }}
           >
-            {{ .Language.LanguageName }}
+            {{ .Language.Label }}
           </a>
         </li>
       {{ end }}

--- a/layouts/partials/structuredData.html
+++ b/layouts/partials/structuredData.html
@@ -90,7 +90,7 @@
         "name": "FIP Guide",
         "email": "nextstop@fipguide.org"
       },
-      "inLanguage": "{{ site.Language.LanguageCode }}",
+      "inLanguage": "{{ site.Language.Locale }}",
       "isAccessibleForFree": true
     }
   ]


### PR DESCRIPTION
Replaced `.Language.LanguageCode`, `.Language.LanguageDirection` and corresponding keys in `hugo.yaml`. Apparently, locale in hugo.yaml is not needed, but i added it anyway.