### PR TITLE
fix: add PKP ICN train category

### DIFF
--- a/content/operator/pkp/index.de.md
+++ b/content/operator/pkp/index.de.md
@@ -104,6 +104,25 @@ Einige Züge sind reservierungspflichtig. Die Reservierungspflicht kann in der [
 {{% /train-category %}}
 
 {{% train-category
+    id="icn"
+    title="IC Nieśpieszny (ICN)"
+    type="highspeed"
+    fip_accepted=false
+    reservation_required=true
+    reservation_possible=true
+%}}
+
+Der IC Nieśpieszny ist ein Erlebniszug im Retro-Stil von PKP Intercity mit einem Fokus auf bewusst entspanntes und langsames Reisen in historischen restaurierten Wagen.
+
+Sowohl FIP Freifahrtscheine als auch FIP 50 Tickets sind in diesem Zug nicht gültig.
+
+#### Reservierungen
+
+Eine Reservierung ist erforderlich.
+
+{{% /train-category %}}
+
+{{% train-category
     id="tlk"
     title="Twoje Linie Kolejowe (TLK)"
     type="regional"

--- a/content/operator/pkp/index.en.md
+++ b/content/operator/pkp/index.en.md
@@ -104,6 +104,25 @@ Some trains require reservations. The reservation requirement can be checked in 
 {{% /train-category %}}
 
 {{% train-category
+    id="icn"
+    title="IC Nieśpieszny (ICN)"
+    type="highspeed"
+    fip_accepted=false
+    reservation_required=true
+    reservation_possible=true
+%}}
+
+The IC Nieśpieszny is a retro-style experience train operated by PKP Intercity, with a focus on consciously relaxed and slow travel in historic restored coaches.
+
+Neither FIP Coupons nor FIP 50 Tickets are valid on this train.
+
+#### Reservations
+
+Reservation is required.
+
+{{% /train-category %}}
+
+{{% train-category
     id="tlk"
     title="Twoje Linie Kolejowe (TLK)"
     type="regional"

--- a/content/operator/pkp/index.fr.md
+++ b/content/operator/pkp/index.fr.md
@@ -104,6 +104,25 @@ Certains trains nécessitent une réservation. L’obligation de réservation pe
 {{% /train-category %}}
 
 {{% train-category
+    id="icn"
+    title="IC Nieśpieszny (ICN)"
+    type="highspeed"
+    fip_accepted=false
+    reservation_required=true
+    reservation_possible=true
+%}}
+
+L’IC Nieśpieszny est un train d’expérience de style rétro exploité par PKP Intercity, axé sur des voyages délibérément détendus et lents dans des voitures historiques restaurées.
+
+Ni les Coupons FIP ni les Billets FIP 50 ne sont valables dans ce train.
+
+#### Réservations
+
+Une réservation est obligatoire.
+
+{{% /train-category %}}
+
+{{% train-category
     id="tlk"
     title="Twoje Linie Kolejowe (TLK)"
     type="regional"


### PR DESCRIPTION
## Summary
- add the new PKP Intercity train category IC Nieśpieszny (ICN) to the PKP operator page
- note that neither FIP Coupons nor FIP 50 Tickets are valid on this train
- add the corresponding English and French translations

Closes #1002