### PR TITLE
fix: Remove free ferry from Dartmouth Steam Railway

### DIFF
--- a/content/news/11/index.de.md
+++ b/content/news/11/index.de.md
@@ -11,7 +11,7 @@ operator:
 
 Bei der Dartmouth Steam Railway and River Boat Company in Großbritannien wird keine FIP Vergünstigung mehr gewährt. Zuvor wurde auf den regulären Fahrpreis für Erwachsene ein Rabatt von 75% eingeräumt, wenn der FIP Ausweis vor Ort vorgezeigt wurde. [^1]
 
-Die Dartmouth Steam Railway and River Boat Company betreibt Museumszugfahrten zwischen Paignton und Kingswear an der englischen Riviera. Im Preis ist auch die Fähre von Kingswear nach Dartmouth enthalten.
+Die Dartmouth Steam Railway and River Boat Company betreibt Museumszugfahrten zwischen Paignton und Kingswear an der englischen Riviera.
 
 Die Informationen auf der [National Rail](/operator/gb) Seite wurden entsprechend angepasst.
 

--- a/content/news/11/index.en.md
+++ b/content/news/11/index.en.md
@@ -11,7 +11,7 @@ operator:
 
 The Dartmouth Steam Railway and River Boat Company in Great Britain no longer grants any FIP discount. Previously, a 75% discount on the regular adult fare was granted when the FIP Card was presented on site. [^1]
 
-The Dartmouth Steam Railway and River Boat Company operates heritage train journeys between Paignton and Kingswear on the English Riviera. The ferry from Kingswear to Dartmouth is also included in the price.
+The Dartmouth Steam Railway and River Boat Company operates heritage train journeys between Paignton and Kingswear on the English Riviera.
 
 The information on the [National Rail](/operator/gb) page has been updated accordingly.
 

--- a/content/news/11/index.fr.md
+++ b/content/news/11/index.fr.md
@@ -11,7 +11,7 @@ operator:
 
 La Dartmouth Steam Railway and River Boat Company en Grande-Bretagne n’accorde plus de réduction FIP. Auparavant, une réduction de 75 % sur le tarif adulte normal était accordée lorsque la Carte FIP était présentée sur place. [^1]
 
-La Dartmouth Steam Railway and River Boat Company propose des trajets en train historique entre Paignton et Kingswear sur la Riviera anglaise. Le ferry de Kingswear à Dartmouth est également inclus dans le prix.
+La Dartmouth Steam Railway and River Boat Company propose des trajets en train historique entre Paignton et Kingswear sur la Riviera anglaise.
 
 Les informations sur la page [National Rail](/operator/gb) ont été mises à jour en conséquence.
 

--- a/content/operator/gb/index.de.md
+++ b/content/operator/gb/index.de.md
@@ -568,7 +568,7 @@ Reguläre Tickets für Kinder können günstiger sein als Tickets mit FIP-Rabatt
   additional_information_url="https://dartmouthrailriver.co.uk"
 %}}
 
-Die Dartmouth Steam Railway and River Boat Company betreibt Fahrten mit Dampflokomotiven und historischen Wagen zwischen Paignton und Kingswear entlang der malerischen englischen Riviera. Die Strecke bietet beeindruckende Ausblicke auf die Küste von Devon und den River Dart. Neben dem Zug ist hier auch die Fähre von Kingswear nach Dartmouth mit im Preis inbegriffen. Der nächstgelegene National Rail Bahnhof ist Paignton – von dort sind es nur etwa 1 Minute Fußweg zum Bahnhof der Museumsbahn.
+Die Dartmouth Steam Railway and River Boat Company betreibt Fahrten mit Dampflokomotiven und historischen Wagen zwischen Paignton und Kingswear entlang der malerischen englischen Riviera. Die Strecke bietet beeindruckende Ausblicke auf die Küste von Devon und den River Dart. Der nächstgelegene National Rail Bahnhof ist Paignton – von dort sind es nur etwa 1 Minute Fußweg zum Bahnhof der Museumsbahn.
 
 {{% /train-category %}}
 

--- a/content/operator/gb/index.en.md
+++ b/content/operator/gb/index.en.md
@@ -566,7 +566,7 @@ Regular child tickets may be cheaper than tickets with FIP discount.
   additional_information_url="https://dartmouthrailriver.co.uk"
 %}}
 
-The Dartmouth Steam Railway and River Boat Company operates steam locomotive and historic carriage journeys between Paignton and Kingswear along the picturesque English Riviera. The route offers impressive views of the Devon coast and River Dart. The ferry from Kingswear to Dartmouth is included in the price. The nearest National Rail station is Paignton – only about 1 minute walk to the heritage railway station.
+The Dartmouth Steam Railway and River Boat Company operates steam locomotive and historic carriage journeys between Paignton and Kingswear along the picturesque English Riviera. The route offers impressive views of the Devon coast and River Dart. The nearest National Rail station is Paignton – only about 1 minute walk to the heritage railway station.
 
 {{% /train-category %}}
 

--- a/content/operator/gb/index.fr.md
+++ b/content/operator/gb/index.fr.md
@@ -569,7 +569,7 @@ Les billets enfants réguliers peuvent être moins chers que les billets avec r�
   additional_information_url="https://dartmouthrailriver.co.uk"
 %}}
 
-La Dartmouth Steam Railway and River Boat Company propose des trajets en locomotive à vapeur et voitures historiques entre Paignton et Kingswear le long de la pittoresque Riviera anglaise. La ligne offre de superbes vues sur la côte du Devon et la rivière Dart. Le ferry de Kingswear à Dartmouth est inclus dans le prix. La gare National Rail la plus proche est Paignton – à seulement 1 minute à pied de la gare de la ligne historique.
+La Dartmouth Steam Railway and River Boat Company propose des trajets en locomotive à vapeur et voitures historiques entre Paignton et Kingswear le long de la pittoresque Riviera anglaise. La ligne offre de superbes vues sur la côte du Devon et la rivière Dart. La gare National Rail la plus proche est Paignton – à seulement 1 minute à pied de la gare de la ligne historique.
 
 {{% /train-category %}}
 


### PR DESCRIPTION
The FIP tickets are not valid anymore, so the hint about the free ferry might be confusing. It still applies to full fare tickets, but since there is no discount, I wouldn't it mention anymore as it might be interpreted that the ferry can be used with FIP for free.