### PR TITLE
ci: Create comment instead of issue for broken links

### DIFF
--- a/.github/workflows/check-broken-links.md
+++ b/.github/workflows/check-broken-links.md
@@ -1,11 +1,3 @@
----
-title: Website Contains Broken Links
-labels:
-  - content
-assignees:
-  - lenderom
----
-
 ## Broken Links Detected
 
 Broken Link Checker found broken links on https://fipguide.org

--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -53,9 +53,10 @@ jobs:
             --exclude "www.trenitalia.fr"
       - uses: actions/checkout@v3
         if: failure()
-      - uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          filename: ${{ env.ISSUE_TEMPLATE }}
+      - name: Reopen issue and add comment
         if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue reopen 1001 || true
+          gh issue comment 1001 --body-file $ISSUE_TEMPLATE


### PR DESCRIPTION
To reduce the issue spam, just use one issue and reopen & add a new comment if we have new broken links.