### PR TITLE
Fix opening hours for NS international phone

### DIFF
--- a/content/booking/ns-phone/index.de.md
+++ b/content/booking/ns-phone/index.de.md
@@ -16,7 +16,7 @@ Die NS bietet eine Buchungshotline für Tickets und Reservierungen an:
 
 Für die Buchung ist eine Kreditkarte erforderlich, die Bezahlung erfolgt per Link, welcher per E-Mail zugesandt wird.
 
-Die Hotline ist täglich von 7 Uhr bis 23 Uhr erreichbar.
+Die Hotline ist montags bis freitags von 7 Uhr bis 19 Uhr und samstags und sonntags von 8:30 Uhr bis 17 Uhr erreichbar.
 
 {{% satellite /%}}
 

--- a/content/booking/ns-phone/index.en.md
+++ b/content/booking/ns-phone/index.en.md
@@ -16,7 +16,7 @@ NS offers a booking hotline for tickets and reservations:
 
 A credit card is required for booking. Payment is made via a link sent by email.
 
-The hotline is available daily from 7 a.m. to 11 p.m.
+The hotline is available on Monday through Friday from 7 a.m. to 7 p.m, and Saturday and Sunday from 8:30 a.m. to 5 p.m.
 
 {{% satellite /%}}
 

--- a/content/booking/ns-phone/index.fr.md
+++ b/content/booking/ns-phone/index.fr.md
@@ -16,7 +16,7 @@ La NS propose une hotline de réservation pour les billets et les réservations 
 
 Pour la réservation, une carte de crédit est requise, le paiement se fait par un lien envoyé par e-mail.
 
-La hotline est joignable tous les jours de 7h à 23h.
+La hotline est joignable du lundi au vendredi de 7 h à 19 h, et le samedi et le dimanche de 8 h 30 à 17 h.
 
 {{% satellite /%}}
 


### PR DESCRIPTION
According to the [Ordering tickets by telephone page](https://www.nsinternational.com/en/where-to-buy/telephone-nsinternational-service-center), the opening hours aren't accurate anymore:
> For telephone bookings, please contact NS International Customer Service. They are available for telephone bookings from Monday to Friday from 7.00 am to 7.00 pm and on Saturdays and Sundays from 8.30 am to 5.00 pm on 030 – 2300023.

This PR should fix that.