### PR TITLE
feat: add direct rj kopenhagen   prague

### DIFF
--- a/content/country/denmark/index.de.md
+++ b/content/country/denmark/index.de.md
@@ -56,7 +56,7 @@ Aus Schweden kann angereist werden:
 
 ### Deutschland
 
-Von Deutschland aus kann der durchgängige `EC` Hamburg – Kopenhagen genutzt werden, der mehrfach täglich (in der Hauptsaison alle 2 Stunden) verkehrt. Diese Züge sind immer sehr stark ausgelastet, daher ist eine frühzeitige Buchung einer Reservierung dafür empfehlenswert.
+Von Deutschland aus kann der durchgängige `ECE` Hamburg – Kopenhagen genutzt werden, der mehrfach täglich (in der Hauptsaison alle 2 Stunden) verkehrt. Teilweise verkehrt dieser als `RJ` auf der Strecke Prag – Berlin – Hamburg – Kopenhagen. Diese Züge sind immer sehr stark ausgelastet, daher ist eine frühzeitige Buchung einer Reservierung dafür empfehlenswert.
 
 Alternativ gibt es mehrfach täglich `IC` Züge von Flensburg bis Fredericia, wo gute Umsteigemöglichkeiten in Richtung Aarhus/Aalborg und Kopenhagen bestehen.
 

--- a/content/country/denmark/index.en.md
+++ b/content/country/denmark/index.en.md
@@ -58,7 +58,7 @@ Since FIP discounts do not apply in Sweden and the Øresund route is operated by
 
 ### Germany
 
-From Germany, the direct `EC` Hamburg - Copenhagen can be used, operating multiple times daily (every 2 hours during the peak season). These trains are always very crowded, so early reservation booking is recommended.
+From Germany, the direct `ECE` Hamburg - Copenhagen can be used, operating multiple times daily (every 2 hours during the peak season). Some services operate as `RJ` on the Prague - Berlin - Hamburg - Copenhagen route. These trains are always very crowded, so early reservation booking is recommended.
 
 Alternatively, there are multiple daily `IC` trains from Flensburg to Fredericia, with good connections to Aarhus/Aalborg and Copenhagen.
 

--- a/content/country/denmark/index.fr.md
+++ b/content/country/denmark/index.fr.md
@@ -58,7 +58,7 @@ Cependant, les réductions FIP ne sont pas valables en Suède, et la liaison de 
 
 ### Allemagne
 
-Depuis l’Allemagne, l’ `EC` direct Hambourg – Copenhague est disponible plusieurs fois par jour (toutes les 2h en haute saison). Ces trains sont souvent très fréquentés, il est donc conseillé de réserver à l’avance.
+Depuis l’Allemagne, l’`ECE` direct Hambourg – Copenhague est disponible plusieurs fois par jour (toutes les 2h en haute saison). Certains trains circulent en tant que `RJ` sur l’itinéraire Prague – Berlin – Hambourg – Copenhague. Ces trains sont souvent très fréquentés, il est donc conseillé de réserver à l’avance.
 
 Alternativement, plusieurs trains `IC` relient Flensburg à Fredericia, avec bonnes correspondances vers Aarhus, Aalborg et Copenhague.
 

--- a/content/country/germany/index.de.md
+++ b/content/country/germany/index.de.md
@@ -161,7 +161,7 @@ MS = Mitte See
 
 ### Dänemark
 
-Von Dänemark aus kann der durchgängige `ECE` Kopenhagen – Hamburg genutzt werden, der mehrfach täglich (in der Hauptsaison alle 2 Stunden) verkehrt. Diese Züge sind immer sehr stark ausgelastet, daher ist eine frühzeitige Buchung einer Reservierung dafür empfehlenswert. Alternativ gibt es mehrfach täglich `IC` Züge von Fredericia bis Flensburg.
+Von Dänemark aus kann der durchgängige `ECE` Kopenhagen – Hamburg genutzt werden, der mehrfach täglich (in der Hauptsaison alle 2 Stunden) verkehrt. Teilweise verkehrt dieser als `RJ` auf der Strecke Kopenhagen – Hamburg – Berlin – Prag. Diese Züge sind immer sehr stark ausgelastet, daher ist eine frühzeitige Buchung einer Reservierung dafür empfehlenswert. Alternativ gibt es mehrfach täglich `IC` Züge von Fredericia bis Flensburg.
 
 Per Nahverkehr ist auch eine Einreise über Tønder möglich. Da hier jedoch weder die DSB auf dänischer Seite noch die DB auf deutscher Seite fährt, sind FIP-Ermäßigungen auf dieser Route nicht möglich. Alternativ gibt es die Möglichkeit, per Fähre nach Puttgarden oder Warnemünde einzureisen.
 

--- a/content/country/germany/index.en.md
+++ b/content/country/germany/index.en.md
@@ -157,7 +157,7 @@ MS = Middle of the lake
 
 ### Denmark
 
-From Denmark, the direct `ECE` Copenhagen – Hamburg can be used, which runs several times a day (every 2 hours in high season). These trains are always very busy, so it is advisable to book a reservation early. Alternatively, there are several `IC` trains daily from Fredericia to Flensburg.
+From Denmark, the direct `ECE` Copenhagen – Hamburg can be used, which runs several times a day (every 2 hours in high season). Some services operate as `RJ` on the Copenhagen – Hamburg – Berlin – Prague route. These trains are always very busy, so it is advisable to book a reservation early. Alternatively, there are several `IC` trains daily from Fredericia to Flensburg.
 
 It is also possible to enter via Tønder by regional train. However, since neither DSB on the Danish side nor DB on the German side operates here, FIP discounts are not available on this route. Alternatively, you can enter by ferry to Puttgarden or Warnemünde.
 

--- a/content/country/germany/index.fr.md
+++ b/content/country/germany/index.fr.md
@@ -157,7 +157,7 @@ MS = Mitte See
 
 ### Danemark
 
-Depuis le Danemark, l’`ECE` direct Copenhague – Hambourg circule plusieurs fois par jour (en haute saison toutes les 2 heures). Ces trains sont très fréquentés, il est donc conseillé de réserver tôt. Il existe aussi plusieurs `IC` de Fredericia à Flensburg chaque jour.
+Depuis le Danemark, l’`ECE` direct Copenhague – Hambourg circule plusieurs fois par jour (en haute saison toutes les 2 heures). Certains trains circulent en tant que `RJ` sur l’itinéraire Copenhague – Hambourg – Berlin – Prague. Ces trains sont très fréquentés, il est donc conseillé de réserver tôt. Il existe aussi plusieurs `IC` de Fredericia à Flensburg chaque jour.
 
 En trafic régional, il est aussi possible d’entrer par Tønder. Cependant, ni la DSB côté danois ni la DB côté allemand n’y circulent, donc aucune réduction FIP n’est possible sur cet itinéraire. Il est aussi possible de rejoindre l’Allemagne par ferry à Puttgarden ou Warnemünde.
 

--- a/content/operator/cd/index.de.md
+++ b/content/operator/cd/index.de.md
@@ -69,11 +69,13 @@ Die Preise für die Reservierung sind variabel (siehe [reservierungspflichtige Z
     reservation_possible=true
     additional_information_url="https://www.cd.cz/en/nase-vlaky/railjet/railjet/-27275/"
 %}}
-Die Railjet-Züge verbinden Brno und Prag schnell und komfortabel und bieten zudem eine Direktverbindung über Břeclav nach Wien und Graz. Sie halten nur an den wichtigsten Bahnhöfen. Auch die internationalen ComfortJet-Züge zwischen Prag und Deutschland bzw. Dänemark fallen ab Dezember 2025 unter diese Kategorie. Es gibt meist drei Wagenklassen:
+Die Railjet-Züge verbinden Brno und Prag schnell und komfortabel und bieten zudem eine Direktverbindung über Břeclav nach Wien und Graz. Sie halten nur an den wichtigsten Bahnhöfen. Auch die internationalen ComfortJet-Züge zwischen Prag und Deutschland bzw. Dänemark fallen unter diese Kategorie.
 
-**Economy**: Vergleichbar mit der 2. Klasse. \
-**First Class**: Vergleichbar mit der 1. Klasse. Ein FIP-Ausweis für die 1. Klasse wird benötigt. \
-**Business**: 1. Klasse mit Begrüßungsgetränk und eigenen Abteilen. Mit FIP Freifahrtschein nicht nutzbar (auch nicht mit dem dazugehörigen Zuschlag)
+Es gibt meist drei Wagenklassen:
+
+- **Economy**: Vergleichbar mit der 2. Klasse.
+- **First Class**: Vergleichbar mit der 1. Klasse. Ein FIP-Ausweis für die 1. Klasse wird benötigt.
+- **Business**: 1. Klasse mit Begrüßungsgetränk und eigenen Abteilen. Mit FIP Freifahrtschein nicht nutzbar (auch nicht mit dem dazugehörigen Zuschlag)
 
 Die Züge verfügen über modernes Wagenmaterial im Stil der ÖBB-Railjets, allerdings mit blauer Außengestaltung. Fahrräder, Kinderwagen und anderes Sperrgepäck können mitgenommen werden. Speisen und Getränke sind im Bordrestaurant oder per Am-Platz-Service erhältlich. In der 1. Klasse erhalten Fahrgäste kostenlos eine Flasche Wasser und eine Tageszeitung, in der Business Class zusätzlich ein Begrüßungsgetränk sowie einen Gutschein im Wert von 50 CZK für das Restaurantangebot (nur innerhalb Tschechiens). Für Kinder gibt es ein eigenes Kinderkino mit speziellen Programmen.
 

--- a/content/operator/cd/index.en.md
+++ b/content/operator/cd/index.en.md
@@ -69,11 +69,13 @@ Reservation prices are variable (see [trains with mandatory reservations](#train
     reservation_possible=true
     additional_information_url="https://www.cd.cz/en/nase-vlaky/railjet/railjet/-27275/"
 %}}
-Railjet trains connect Brno and Prague quickly and comfortably and also offer a direct connection via Břeclav to Vienna and Graz. They stop only at major stations. From December 2025, international ComfortJet trains between Prague and Germany/Denmark will also fall under this category. There are usually three classes:
+Railjet trains connect Brno and Prague quickly and comfortably and also offer a direct connection via Břeclav to Vienna and Graz. They stop only at major stations. International ComfortJet trains between Prague and Germany or Denmark also fall under this category.
 
-**Economy**: Comparable to 2nd class. \
-**First Class**: Comparable to 1st class. An FIP pass for 1st class is required. \
-**Business**: 1st class with welcome drink and private compartments. Not usable with FIP Coupon (even with surcharge).
+There are usually three classes:
+
+- **Economy**: Comparable to 2nd class.
+- **First Class**: Comparable to 1st class. An FIP pass for 1st class is required.
+- **Business**: 1st class with welcome drink and private compartments. Not usable with FIP Coupon (even with surcharge).
 
 The trains feature modern rolling stock in the ÖBB Railjet style, but with blue exterior. Bicycles, prams, and other bulky luggage can be taken on board. Food and drinks are available in the restaurant car or via at-seat service. In 1st class, passengers receive a free bottle of water and a newspaper; in Business Class, additionally a welcome drink and a 50 CZK voucher for the restaurant (within Czechia only). For children, there is a dedicated children's cinema.
 

--- a/content/operator/cd/index.fr.md
+++ b/content/operator/cd/index.fr.md
@@ -69,11 +69,13 @@ Le prix de la réservation est variable (voir [trains avec réservation obligato
     reservation_possible=true
     additional_information_url="https://www.cd.cz/en/nase-vlaky/railjet/railjet/-27275/"
 %}}
-Les trains Railjet relient Brno et Prague rapidement et confortablement, et offrent aussi une liaison directe via Břeclav vers Vienne et Graz. Ils ne s’arrêtent qu’aux principales gares. À partir de décembre 2025, les trains internationaux ComfortJet entre Prague et l’Allemagne/Danemark seront également inclus dans cette catégorie. Il existe généralement trois classes :
+Les trains Railjet relient Brno et Prague rapidement et confortablement, et offrent aussi une liaison directe via Břeclav vers Vienne et Graz. Ils ne s’arrêtent qu’aux principales gares. Les trains internationaux ComfortJet entre Prague et l’Allemagne ou le Danemark relèvent également de cette catégorie.
 
-**Economy** : Comparable à la 2ᵉ classe. \
-**First Class** : Comparable à la 1ère classe. Un Coupon FIP 1ère classe est nécessaire. \
-**Business** : 1ère classe avec boisson de bienvenue et compartiments privés. Non accessible avec un Coupon FIP (même avec supplément).
+Il existe généralement trois classes :
+
+- **Economy** : Comparable à la 2ᵉ classe.
+- **First Class** : Comparable à la 1ère classe. Un Coupon FIP 1ère classe est nécessaire.
+- **Business** : 1ère classe avec boisson de bienvenue et compartiments privés. Non accessible avec un Coupon FIP (même avec supplément).
 
 Les trains disposent de matériel moderne de type ÖBB Railjet, mais avec une livrée bleue. Les vélos, poussettes et bagages encombrants sont acceptés. Restauration disponible au wagon-restaurant ou service à la place. En 1ère classe, une bouteille d’eau et un journal sont offerts ; en Business, une boisson de bienvenue et un bon de 50 CZK pour le restaurant (valable uniquement en Tchéquie). Un cinéma pour enfants est disponible.
 

--- a/content/operator/db/index.de.md
+++ b/content/operator/db/index.de.md
@@ -83,7 +83,14 @@ Reservierungspflicht bei grenzüberschreitenden Fahrten nach Frankreich.
     reservation_possible=true
 %}}
 
-Internationale Schnellzüge der höchsten Kategorie der ÖBB/ČD in Kooperation mit der DB zwischen Hamburg, Berlin, Dresden und Prag sowie München, Österreich und Italien oder Ungarn. Railjets mit weniger Halten werden als Railjet Xpress vermarktet. Die Züge besitzen ein Bistro.
+Internationale Schnellzüge der höchsten Kategorie.
+
+Sie werden betrieben von
+
+- der ÖBB in Kooperation mit der DB auf der Strecke zwischen München, Österreich und Italien oder Ungarn.
+- der ČD in Kooperation mit der DB zwischen Hamburg, Berlin, Dresden sowie Prag. Teilweise werden die Züge bis Kopenhagen verlängert und verkehren zusätzlich in Kooperation mit der DSB.
+
+Railjets mit weniger Halten werden als Railjet Xpress vermarktet. Die Züge besitzen ein Bistro.
 
 Es gibt drei Wagenklassen:
 

--- a/content/operator/db/index.en.md
+++ b/content/operator/db/index.en.md
@@ -83,7 +83,14 @@ Reservation required for cross-border journeys to France.
     reservation_possible=true
 %}}
 
-International high-speed trains of the highest category of ÖBB/ČD in cooperation with DB between Hamburg, Berlin, Dresden, and Prague as well as Munich, Austria, and Italy or Hungary. Railjets with fewer stops are marketed as Railjet Xpress. The trains have a bistro.
+International high-speed trains of the highest category.
+
+They are operated by
+
+- ÖBB in cooperation with DB on the route between Munich, Austria, and Italy or Hungary.
+- ČD in cooperation with DB between Hamburg, Berlin, Dresden, and Prague. Some trains are extended to Copenhagen and additionally operate in cooperation with DSB.
+
+Railjets with fewer stops are marketed as Railjet Xpress. The trains have a bistro.
 
 There are three classes:
 

--- a/content/operator/db/index.fr.md
+++ b/content/operator/db/index.fr.md
@@ -83,7 +83,14 @@ Réservation obligatoire pour les trajets transfrontaliers vers la France.
     reservation_possible=true
 %}}
 
-Trains internationaux de la catégorie la plus élevée de l’ÖBB/ČD en coopération avec la DB entre Hambourg, Berlin, Dresde et Prague ainsi que Munich, l’Autriche et l’Italie ou la Hongrie. Les Railjets avec moins d’arrêts sont commercialisés comme Railjet Xpress. Les trains disposent d’un bistro.
+Trains internationaux de la catégorie la plus élevée.
+
+Ils sont exploités par
+
+- l’ÖBB en coopération avec la DB sur la liaison entre Munich, l’Autriche et l’Italie ou la Hongrie.
+- les ČD en coopération avec la DB entre Hambourg, Berlin, Dresde et Prague. Certains trains sont prolongés jusqu’à Copenhague et circulent en plus en coopération avec la DSB.
+
+Les Railjets avec moins d’arrêts sont commercialisés comme Railjet Xpress. Les trains disposent d’un bistro.
 
 Il existe trois classes de voitures :
 

--- a/content/operator/dsb/index.de.md
+++ b/content/operator/dsb/index.de.md
@@ -73,6 +73,25 @@ Eine Reservierung ist bei einer grenzüberschreitenden Fahrt empfehlenswert, in 
 {{% /train-category %}}
 
 {{% train-category
+    id="rj"
+    title="Railjet (RAIL JET)"
+    type="highspeed"
+    fip_accepted=true
+    reservation_required=partially
+    reservation_possible=true
+%}}
+
+Railjet-Züge verkehren grenzüberschreitend auf der Strecke zwischen Kopenhagen und Prag via Hamburg und Berlin.
+
+In der Verbindungsauskunft der DSB werden diese Züge als `RAIL JET` angezeigt, in anderen Auskunftssystemen wie z. B. der DB als `RJ`.
+
+#### Reservierungen
+
+Eine Reservierung ist bei einer grenzüberschreitenden Fahrt empfehlenswert, in der Hauptsaison (Sommer) meist auch verpflichtend.
+
+{{% /train-category %}}
+
+{{% train-category
     id="regional"
     title="Regionalzug (R / RE)"
     type="regional"

--- a/content/operator/dsb/index.en.md
+++ b/content/operator/dsb/index.en.md
@@ -73,6 +73,25 @@ A reservation is recommended for cross-border journeys and usually mandatory dur
 {{% /train-category %}}
 
 {{% train-category
+    id="rj"
+    title="Railjet (RAIL JET)"
+    type="highspeed"
+    fip_accepted=true
+    reservation_required=partially
+    reservation_possible=true
+%}}
+
+Railjet trains operate cross-border on the route between Copenhagen and Prague via Hamburg and Berlin.
+
+In the DSB journey planner, these trains are shown as `RAIL JET`; in other journey planners such as DB, they are shown as `RJ`.
+
+#### Reservations
+
+A reservation is recommended for cross-border journeys and usually mandatory in the peak season (summer).
+
+{{% /train-category %}}
+
+{{% train-category
     id="regional"
     title="Regional Train (R / RE)"
     type="regional"

--- a/content/operator/dsb/index.fr.md
+++ b/content/operator/dsb/index.fr.md
@@ -73,6 +73,25 @@ Réservation conseillée et généralement obligatoire en été.
 {{% /train-category %}}
 
 {{% train-category
+    id="rj"
+    title="Railjet (RAIL JET)"
+    type="highspeed"
+    fip_accepted=true
+    reservation_required=partially
+    reservation_possible=true
+%}}
+
+Les trains Railjet circulent en trafic transfrontalier sur la liaison entre Copenhague et Prague via Hambourg et Berlin.
+
+Dans la recherche d’itinéraire de la DSB, ces trains sont affichés comme `RAIL JET`, dans d’autres systèmes d’information comme celui de la DB ils sont affichés comme `RJ`.
+
+#### Réservations
+
+Une réservation est recommandée pour les trajets transfrontaliers et généralement obligatoire en haute saison (été).
+
+{{% /train-category %}}
+
+{{% train-category
     id="regional"
     title="Train régional (R / RE)"
     type="regional"


### PR DESCRIPTION
- EC → ECE + note regarding partial Railjet through-service to/from Prague (country pages)
- Revised Railjet description for DB (ÖBB/ČD operational split, including Copenhagen/DSB)
- New Railjet section for DSB