### PR TITLE
feat: Add additional context to SNCB ticket machine

### DIFF
--- a/content/booking/sncb-ticket-machine/index.de.md
+++ b/content/booking/sncb-ticket-machine/index.de.md
@@ -17,8 +17,14 @@ params:
 Auf dem Hauptbildschirm des Fahrkartenautomaten "SNCB Staff Ticket"[^2] auswählen. Dies gewährt eine Ermäßigung von 50%. FIP 75 Tickets und ICE Tickets sind nicht an Fahrkartenautomaten erhältlich. Die Option ist nur an nationalen Fahrkartenautomaten in Belgien verfügbar und nicht an internationalen Automaten wie z. B. am Aachener Hauptbahnhof.
 
 Zu beachten: Tickets zum Flughafen Brüssel Zaventem, die am Fahrkartenautomaten erworben werden, enthalten den Flughafenzuschlag nicht. Der Zuschlag muss als separates Zusatzprodukt erworben werden. [^1]
+
+{{< highlight important >}}
+Bei Ticketkauf am Automaten werden Tickets mit dem Tarifcode C01 ausgestellt. Diese richten sich eigentlich an SNCB Personal. Die richtigen Ticketcodes wären C99 für FIP50 und C00 für FIP75. Der Unterschied zwischen C01 und C99 ist der Flughafenzuschlag, der bei C01 nicht erhoben wird und deshalb separat gelöst werden muss.[^3] Nach unseren Informationen können die Automatentickets mit Tarifcode C01 auch für FIP50 verwendet werden, eine offizielle Garantie gibt es jedoch nicht.[^1]
+{{< /highlight >}}
 {{% /booking-section %}}
 
-[^1]: [FIP Guide Community: SNCB Fahrkartenautomat](https://discord.com/channels/1250522473188032512/1510952481532678176/1511320669118529708)
+[^1]: [FIP Guide Community: Confirmation that FIP tickets can be used](https://discord.com/channels/1250522473188032512/1510952481532678176/1511320669118529708)
 
-[^2]: [FIP Guide Community: SNCB Fahrkartenautomat](https://discord.com/channels/1250522473188032512/1510952481532678176/1512547393294303364)
+[^2]: [FIP Guide Community: Bild von SNCB Staff Ticket Option am Fahrkartenautomat](https://discord.com/channels/1250522473188032512/1510952481532678176/1512547393294303364)
+
+[^3]: [FIP Guide Community: Explanation of different staff travel tariff codes](https://discord.com/channels/1250522473188032512/1510952481532678176/1511307207713620059)

--- a/content/booking/sncb-ticket-machine/index.en.md
+++ b/content/booking/sncb-ticket-machine/index.en.md
@@ -17,8 +17,14 @@ params:
 Select "SNCB Staff Ticket"[^2] on the main screen of the ticket machine. This gives a 50% discount. FIP 75 Tickets and ICE Tickets are not available at ticket machines. This option is only available at domestic ticket machines in Belgium and not at international machines such as those at Aachen Main Station.
 
 Note that tickets to Brussels Zaventem Airport purchased at the ticket machine do not include the airport supplement. The supplement must be purchased separately as an add-on product. [^1]
+
+{{< highlight important >}}
+When purchasing tickets at the machine, tickets with tariff code C01 are issued. These are actually intended for SNCB staff. The correct ticket codes would be C99 for FIP50 and C00 for FIP75. The difference between C01 and C99 is the airport supplement, which is not charged for C01 and therefore must be purchased separately.[^3] According to our information, tickets from the machine with tariff code C01 can also be used for FIP50, however there is no official guarantee.[^1]
+{{< /highlight >}}
 {{% /booking-section %}}
 
-[^1]: [FIP Guide Community: SNCB Ticket Machine](https://discord.com/channels/1250522473188032512/1510952481532678176/1511320669118529708)
+[^1]: [FIP Guide Community: Confirmation that FIP tickets can be used](https://discord.com/channels/1250522473188032512/1510952481532678176/1511320669118529708)
 
-[^2]: [FIP Guide Community: SNCB Ticket Machine](https://discord.com/channels/1250522473188032512/1510952481532678176/1512547393294303364)
+[^2]: [FIP Guide Community: Bild von SNCB Staff Ticket Option am Fahrkartenautomat](https://discord.com/channels/1250522473188032512/1510952481532678176/1512547393294303364)
+
+[^3]: [FIP Guide Community: Explanation of different staff travel tariff codes](https://discord.com/channels/1250522473188032512/1510952481532678176/1511307207713620059)

--- a/content/booking/sncb-ticket-machine/index.fr.md
+++ b/content/booking/sncb-ticket-machine/index.fr.md
@@ -17,8 +17,14 @@ params:
 Sélectionner "SNCB Staff Ticket"[^2] sur l'écran principal du distributeur de billets. Cela donne une réduction de 50%. Les Billets FIP 75 et les Billets ICE ne sont pas disponibles aux distributeurs automatiques. Cette option n'est disponible qu'aux distributeurs automatiques nationaux en Belgique et non aux distributeurs internationaux comme ceux de la gare d'Aix-la-Chapelle.
 
 À noter : les billets à destination de l'aéroport de Bruxelles-Zaventem achetés au distributeur automatique n'incluent pas le supplément aéroport. Le supplément doit être acheté séparément en tant que produit additionnel. [^1]
+
+{{< highlight important >}}
+Lors de l'achat de billets au distributeur automatique, des billets avec le code tarif C01 sont délivrés. Ceux-ci sont en réalité destinés au personnel SNCB. Les codes de billet corrects seraient C99 pour FIP50 et C00 pour FIP75. La différence entre C01 et C99 est le supplément aéroport, qui n'est pas perçu pour C01 et doit donc être acheté séparément.[^3] Selon nos informations, les billets au distributeur automatique avec le code tarif C01 peuvent également être utilisés pour FIP50, cependant il n'existe pas de garantie officielle.[^1]
+{{< /highlight >}}
 {{% /booking-section %}}
 
-[^1]: [FIP Guide Community: Distributeurs de billets SNCB](https://discord.com/channels/1250522473188032512/1510952481532678176/1511320669118529708)
+[^1]: [FIP Guide Community: Confirmation that FIP tickets can be used](https://discord.com/channels/1250522473188032512/1510952481532678176/1511320669118529708)
 
-[^2]: [FIP Guide Community: Distributeurs de billets SNCB](https://discord.com/channels/1250522473188032512/1510952481532678176/1512547393294303364)
+[^2]: [FIP Guide Community: Bild von SNCB Staff Ticket Option am Fahrkartenautomat](https://discord.com/channels/1250522473188032512/1510952481532678176/1512547393294303364)
+
+[^3]: [FIP Guide Community: Explanation of different staff travel tariff codes](https://discord.com/channels/1250522473188032512/1510952481532678176/1511307207713620059)


### PR DESCRIPTION
In the current formulation it sounds like an official option, but this is not the case. This PR adds some additional context to let users know what the option is used for.