### PR TITLE
refactor: Add trailing slash to srbvoz URL

### DIFF
--- a/content/identify-operator/sv-website/index.de.md
+++ b/content/identify-operator/sv-website/index.de.md
@@ -1,7 +1,7 @@
 ---
 title: "SV Website"
 params:
-  url: "https://w3.srbvoz.rs/redvoznje"
+  url: "https://w3.srbvoz.rs/redvoznje/"
 ---
 
 Auf der Website der SV sind alle Züge aufgeführt.

--- a/content/identify-operator/sv-website/index.en.md
+++ b/content/identify-operator/sv-website/index.en.md
@@ -1,7 +1,7 @@
 ---
 title: "SV Website"
 params:
-  url: "https://w3.srbvoz.rs/redvoznje"
+  url: "https://w3.srbvoz.rs/redvoznje/"
 ---
 
 All trains are listed on the SV website.

--- a/content/identify-operator/sv-website/index.fr.md
+++ b/content/identify-operator/sv-website/index.fr.md
@@ -1,7 +1,7 @@
 ---
 title: "Site Web SV"
 params:
-  url: "https://w3.srbvoz.rs/redvoznje"
+  url: "https://w3.srbvoz.rs/redvoznje/"
 ---
 
 Tous les trains sont répertoriés sur le site web du SV.


### PR DESCRIPTION
Minor changes for consistency as we use the same URL with `/` in other places. The 404 detection treats them as two different URLs otherwise and runs the check twice.