### PR TITLE
fix: Wrong link to DB FIP hotline

### DIFF
--- a/content/booking/db-phone-fip-db/index.de.md
+++ b/content/booking/db-phone-fip-db/index.de.md
@@ -9,7 +9,7 @@ params:
     second: "5,50 €"
   fip_50: true
   reservations: true
-  booking_link: "https://www.db-reisemarkt.de/reisemarkt/bahnangebote/ausland/FIP-Angebot-13034692"
+  booking_link: "https://www.db-reisemarkt.de/reisemarkt/bahnangebote/wissenswertes/ansprechpartner_db_ermaessigung-8140844"
   additional_info_link: "https://www.bahn.de/angebot/zusatzticket/sitzplatzreservierung"
   type: "phone"
 ---

--- a/content/booking/db-phone-fip-db/index.en.md
+++ b/content/booking/db-phone-fip-db/index.en.md
@@ -9,7 +9,7 @@ params:
     second: "5,50 €"
   fip_50: true
   reservations: true
-  booking_link: "https://www.db-reisemarkt.de/reisemarkt/bahnangebote/ausland/FIP-Angebot-13034692"
+  booking_link: "https://www.db-reisemarkt.de/reisemarkt/bahnangebote/wissenswertes/ansprechpartner_db_ermaessigung-8140844"
   additional_info_link: "https://int.bahn.de/en/offers/additional-services/seat-reservation"
   type: "phone"
 ---

--- a/content/booking/db-phone-fip-db/index.fr.md
+++ b/content/booking/db-phone-fip-db/index.fr.md
@@ -9,7 +9,7 @@ params:
     second: "5,50 €"
   fip_50: true
   reservations: true
-  booking_link: "https://www.db-reisemarkt.de/reisemarkt/bahnangebote/ausland/FIP-Angebot-13034692"
+  booking_link: "https://www.db-reisemarkt.de/reisemarkt/bahnangebote/wissenswertes/ansprechpartner_db_ermaessigung-8140844"
   additional_info_link: "https://int.bahn.de/fr/offres/reservation-de-places-assises"
   type: "phone"
 ---


### PR DESCRIPTION
The link to the DB FIP hotline leads to the wrong page, it should point to the hotline pages instead of the website booking page.