### PR TITLE
style: Use `{{< highlight >}}` style in certain cases

### DIFF
--- a/content/booking/cd-ticket-office/index.de.md
+++ b/content/booking/cd-ticket-office/index.de.md
@@ -18,9 +18,9 @@ params:
 
 An ČD Ticketschaltern können FIP 50 Fahrkarten für Reisen innerhalb Tschechiens und in andere europäische Länder erworben werden.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Die ČD kann auch Tickets zu Grenzpunkten und nicht nur echten Bahnhöfen verkaufen. Das ist besonders hilfreich für Fahrten in andere Länder für die ein Freifahrtschein vorliegt.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/cd-ticket-office/index.en.md
+++ b/content/booking/cd-ticket-office/index.en.md
@@ -18,9 +18,9 @@ params:
 
 At ČD ticket offices, FIP 50 Tickets can be purchased for travel within Czechia and to other European countries.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 ČD can also sell tickets to Border Points and not only to actual stations. This is particularly helpful for journeys to other countries for which a FIP Coupon is available.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/cd-ticket-office/index.fr.md
+++ b/content/booking/cd-ticket-office/index.fr.md
@@ -18,9 +18,9 @@ params:
 
 Aux guichets ČD, il est possible d’acheter des Billets FIP 50 pour voyager en Tchéquie et vers d’autres pays européens.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 La ČD peut aussi vendre des billets vers des points frontières et pas seulement vers des gares réelles. Cela est particulièrement utile pour les trajets vers d’autres pays pour lesquels un Coupon FIP est disponible.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/db-website-fip-db/index.de.md
+++ b/content/booking/db-website-fip-db/index.de.md
@@ -52,6 +52,6 @@ Der Reservierungspreis wird pro Reise berechnet. So muss bei Verbindungen mit Um
 ![DB Reservierung buchen](db_reservation.webp)
 {{% /booking-section %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Bitte beachte entsprechende Vorverkaufsfristen und probiere es in diesem Fall zu einem späteren Zeitpunkt erneut, prüfe die Verbindung auf der entsprechenden Betreiberwebsite oder nutze andere Buchungswege.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/db-website-fip-db/index.en.md
+++ b/content/booking/db-website-fip-db/index.en.md
@@ -52,6 +52,6 @@ Seat reservations can be purchased via the Deutsche Bahn website. To do so, sele
 ![Book DB reservation](db_reservation.webp)
 {{% /booking-section %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 If an error occurs while booking trains requiring reservations, it may be that reservations are not yet available for that connection. Please observe the relevant advance booking deadlines and, in this case, try again later, check the connection on the operator's website, or use other booking methods.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/db-website-fip-db/index.fr.md
+++ b/content/booking/db-website-fip-db/index.fr.md
@@ -52,6 +52,6 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 ![Réserver une place DB](db_reservation.webp)
 {{% /booking-section %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l’opérateur ou utiliser d’autres méthodes de réservation.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/db-website-fip-international/index.de.md
+++ b/content/booking/db-website-fip-international/index.de.md
@@ -59,6 +59,6 @@ Der Reservierungspreis wird pro Reise berechnet. So muss bei Verbindungen mit Um
 ![DB Reservierung buchen](db_reservation.webp)
 {{% /booking-section %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Bitte beachte entsprechende Vorverkaufsfristen und probiere es in diesem Fall zu einem späteren Zeitpunkt erneut, prüfe die Verbindung auf der entsprechenden Betreiberwebsite oder nutze andere Buchungswege.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/db-website-fip-international/index.en.md
+++ b/content/booking/db-website-fip-international/index.en.md
@@ -59,6 +59,6 @@ Seat reservations can be purchased via the Deutsche Bahn website. To do so, sele
 ![Book DB reservation](db_reservation.webp)
 {{% /booking-section %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 If an error occurs while booking trains requiring reservations, it may be that reservations are not yet available for that connection. Please observe the relevant advance booking deadlines and, in this case, try again later, check the connection on the operator's website, or use other booking methods.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/db-website-fip-international/index.fr.md
+++ b/content/booking/db-website-fip-international/index.fr.md
@@ -60,6 +60,6 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 ![Réserver une place DB](db_reservation.webp)
 {{% /booking-section %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l’opérateur ou utiliser d’autres méthodes de réservation.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/db-website/index.de.md
+++ b/content/booking/db-website/index.de.md
@@ -26,6 +26,6 @@ Der Reservierungspreis wird pro Reise berechnet. So muss bei Verbindungen mit Um
 ![DB Reservierung buchen](db_reservation.webp)
 {{% /booking-section %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 Falls es während der Buchung von reservierungspflichtigen Zügen zu einem Fehler kommt, kann es sein, dass für die Verbindung noch keine Reservierungen verkauft werden. Bitte beachte entsprechende Vorverkaufsfristen und probiere es in diesem Fall zu einem späteren Zeitpunkt erneut, prüfe die Verbindung auf der entsprechenden Betreiberwebsite oder nutze andere Buchungswege.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/db-website/index.en.md
+++ b/content/booking/db-website/index.en.md
@@ -26,6 +26,6 @@ Seat reservations can be purchased via the Deutsche Bahn website. To do so, sele
 ![Book DB reservation](db_reservation.webp)
 {{% /booking-section %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 If an error occurs while booking trains requiring reservations, it may be that reservations are not yet available for that connection. Please observe the relevant advance booking deadlines and, in this case, try again later, check the connection on the operator's website, or use other booking methods.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/db-website/index.fr.md
+++ b/content/booking/db-website/index.fr.md
@@ -26,6 +26,6 @@ Les réservations de sièges peuvent être effectuées via le site web de la Deu
 ![Réserver une place DB](db_reservation.webp)
 {{% /booking-section %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 Si une erreur survient lors de la réservation de trains nécessitant une réservation, il se peut que les réservations ne soient pas encore disponibles pour cette liaison. Veuillez respecter les dates limites de réservation et, le cas échéant, réessayer plus tard, vérifier la liaison sur le site web de l’opérateur ou utiliser d’autres méthodes de réservation.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/dsb-ticket-office/index.de.md
+++ b/content/booking/dsb-ticket-office/index.de.md
@@ -18,9 +18,9 @@ aliases:
 
 ## FIP 50 Fahrkarten
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 Die DSB kann vermutlich nur an internationalen Ticketschaltern FIP 50 Tickets für Dänemark verkaufen. Diese sind in den Hauptbahnhöfen von Aarhus, Kopenhagen und Odense. Ob an diesen auch ausländische FIP 50 Tickets verkauft werden können, ist uns nicht bekannt.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/dsb-ticket-office/index.en.md
+++ b/content/booking/dsb-ticket-office/index.en.md
@@ -18,9 +18,9 @@ aliases:
 
 ## FIP 50 Tickets
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 DSB can probably only sell FIP 50 Tickets for Denmark at international ticket counters. These are located at the main stations in Aarhus, Copenhagen, and Odense. We do not know whether foreign FIP 50 Tickets can also be sold at these counters.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/dsb-ticket-office/index.fr.md
+++ b/content/booking/dsb-ticket-office/index.fr.md
@@ -18,9 +18,9 @@ aliases:
 
 ## Billets FIP 50
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 La DSB ne peut probablement vendre des Billets FIP 50 pour le Danemark seulement dans les guichets internationaux. Ceux-ci se trouvent dans les gares principales d’Aarhus, Copenhague et Odense. Nous ne savons pas si des Billets FIP 50 étrangers peuvent également y être vendus.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/fs-ticket-machine/index.de.md
+++ b/content/booking/fs-ticket-machine/index.de.md
@@ -33,8 +33,8 @@ Auf dem Startbildschirm des Automaten "Buy your tickets / Special Discounts" wä
 {.o-section--columns-flex}
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Bei Kurzstrecken im Le Frecce kann der Normaltarif güstiger als FIP reduzierte Tickets sein.
 
 Zusätzlich können Aufschläge für Le Frecce und sonstige Fernzüge teilweise teurer sein als ein FIP 50 Ticket.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/fs-ticket-machine/index.en.md
+++ b/content/booking/fs-ticket-machine/index.en.md
@@ -33,8 +33,8 @@ On the machine's start screen, select "Buy your tickets / Special Discounts". Th
 {.o-section--columns-flex}
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 For short distances on Le Frecce, the regular fare may be cheaper than FIP reduced tickets.
 
 Additionally, surcharges for Le Frecce and other long-distance trains can sometimes be more expensive than a FIP 50 Ticket.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/fs-ticket-machine/index.fr.md
+++ b/content/booking/fs-ticket-machine/index.fr.md
@@ -33,8 +33,8 @@ Sur l’écran d’accueil du distributeur, sélectionnez "Buy your tickets / Sp
 {.o-section--columns-flex}
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Pour les courtes distances sur Le Frecce, le tarif normal peut être moins cher que les Billets FIP réduits.
 
 De plus, les suppléments pour Le Frecce et autres trains longue distance peuvent parfois être plus chers qu’un Billet FIP 50.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/fs-ticket-office/index.de.md
+++ b/content/booking/fs-ticket-office/index.de.md
@@ -15,9 +15,9 @@ params:
 
 An Trenitalia Fahrkartenschaltern können FIP 50 Fahrkarten erworben werden.
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 Teilweise werden an Ticketschaltern Tickets zu unterschiedlichen Tarifen ausgestellt, daher können sich die Preise unterscheiden. Daraus resultierende Probleme bei der Ticketkontrolle im Zug sind uns bisher aber nicht bekannt.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}
@@ -40,8 +40,8 @@ Abweichende Preise für den Fernverkehr Richtung Schweiz/Österreich: z. B. 20�
 {{% /float-image %}}
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Bei Kurzstrecken im Le Frecce und sonstigen Fernzügen ist der Normaltarif güstiger als FIP reduzierte Tickets.
 
 Zusätzlich können Aufschläge für Le Frecce und sonstige Fernzüge teilweise teurer sein als ein FIP 50 Ticket.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/fs-ticket-office/index.en.md
+++ b/content/booking/fs-ticket-office/index.en.md
@@ -15,9 +15,9 @@ params:
 
 FIP 50 Tickets can be purchased at Trenitalia ticket offices.
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 Sometimes tickets at ticket offices are issued at different rates, so prices may vary. However, we are not aware of any resulting problems during ticket inspection on board.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}
@@ -40,8 +40,8 @@ Different prices for long-distance trains to Switzerland/Austria: e.g. €20 Chi
 {{% /float-image %}}
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 For short journeys on Le Frecce and other long-distance trains, the regular fare is cheaper than FIP reduced tickets.
 
 Additionally, supplements for Le Frecce and other long-distance trains can sometimes be more expensive than a FIP 50 Ticket.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/fs-ticket-office/index.fr.md
+++ b/content/booking/fs-ticket-office/index.fr.md
@@ -15,9 +15,9 @@ params:
 
 Les Billets FIP 50 peuvent être achetés aux guichets Trenitalia.
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 Parfois, les guichets délivrent des billets à des tarifs différents, ce qui peut entraîner des variations de prix. Cependant, aucun problème de contrôle des billets à bord n’a été signalé jusqu’à présent.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}
@@ -40,8 +40,8 @@ Tarifs différents pour les trains longue distance vers la Suisse/Autriche : par
 {{% /float-image %}}
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Pour les trajets courts en Le Frecce et autres trains longue distance, le tarif normal est parfois moins cher que les Billets FIP à tarif réduit.
 
 De plus, les suppléments pour Le Frecce et autres trains longue distance peuvent parfois être plus chers qu’un Billet FIP 50.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/fs-website/index.de.md
+++ b/content/booking/fs-website/index.de.md
@@ -34,8 +34,8 @@ Bei der Buchung muss über die Verbindungsauskunft erst eine Verbindung ausgewä
 {.o-section--columns-flex}
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Bei Kurzstrecken im Le Frecce kann der Normaltarif günstiger als FIP reduzierte Tickets sein.
 
 Zusätzlich können Aufschläge für Le Frecce und sonstige Fernzüge teilweise teurer sein als ein FIP 50 Ticket.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/fs-website/index.en.md
+++ b/content/booking/fs-website/index.en.md
@@ -34,8 +34,8 @@ When booking, you must first select a connection via the journey planner. Then, 
 {.o-section--columns-flex}
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 For short distances on Le Frecce, the standard fare may be cheaper than FIP reduced tickets.
 
 Additionally, supplements for Le Frecce and other long-distance trains can sometimes be more expensive than a FIP 50 Ticket.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/fs-website/index.fr.md
+++ b/content/booking/fs-website/index.fr.md
@@ -34,8 +34,8 @@ Lors de la réservation, il faut d’abord sélectionner une connexion via la re
 {.o-section--columns-flex}
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Pour les courtes distances sur Le Frecce, le tarif normal peut être moins cher que les Billets FIP réduits.
 
 De plus, les suppléments pour Le Frecce et autres trains longue distance peuvent parfois être plus chers qu’un Billet FIP 50.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/ht-website/index.de.md
+++ b/content/booking/ht-website/index.de.md
@@ -60,7 +60,7 @@ Der reguläre Ticketpreis wird dann um 50 % reduziert.
 Bei reservierungspflichtigen Angeboten wird eine Reservierung kostenfrei hinzugefügt. Optional kann der Sitzplatz ausgewählt werden, wenn die Option "Choose seat" ausgewählt wird.
 {{% /float-image %}}
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 Beim Kauf eines Tickets über die Hellenic Train-App kann folgende Meldung erscheinen:
 
 _„Der Kauf wurde erfolgreich abgeschlossen, jedoch ist beim Versand der E-Mail ein Fehler aufgetreten. Sie können Ihr Ticket abrufen, indem Sie Ihren Kundenbereich aufrufen oder – falls Sie den Kauf ohne Anmeldung getätigt haben – über die Funktion ‚Ticket abrufen‘ unter Verwendung von PNR/Ticketcode und E-Mail-Adresse bzw. PNR und CP.“_
@@ -70,7 +70,7 @@ Dieser Fehler tritt unabhängig davon auf, ob der Nutzer angemeldet ist oder nic
 Zur Lösung dieses Problems gibt es ein inoffizelles Tool, welches die Ticketinformationen anzeigt. Es ist auf GitHub verfügbar unter:
 
 https://github.com/MartinLangbecker/bookmarklets/tree/main/hellenic_train
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/ht-website/index.en.md
+++ b/content/booking/ht-website/index.en.md
@@ -60,7 +60,7 @@ The regular ticket price is then reduced by 50%.
 For services requiring a reservation, a reservation is added free of charge. Optionally, a seat can be selected by choosing the "Choose seat" option.
 {{% /float-image %}}
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 When purchasing a ticket via the Hellenic Train app, the following message may appear:
 
 _“The purchase was completed successfully; however, an error occurred while sending the email. You can retrieve your ticket by accessing your customer area, or—if you made the purchase without logging in—by ​​using the ‘Retrieve Ticket’ function with your PNR/ticket code and email address, or your PNR and CP.”_
@@ -70,7 +70,7 @@ This error occurs regardless of whether the user is logged in or not—in either
 To resolve this issue, an unofficial tool is available that displays the ticket information. It can be found on GitHub at:
 
 https://github.com/MartinLangbecker/bookmarklets/tree/main/hellenic_train
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/ht-website/index.fr.md
+++ b/content/booking/ht-website/index.fr.md
@@ -60,7 +60,7 @@ Le prix du billet régulier est alors réduit de 50 %.
 Pour les services nécessitant une réservation, une réservation est ajoutée gratuitement. Le siège peut optionnellement être choisi en sélectionnant l’option « Choose seat ».
 {{% /float-image %}}
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 Lors de l'achat d'un billet via l'application Hellenic Train, le message suivant peut s'afficher :
 
 _« L'achat a bien été effectué, mais une erreur s'est produite lors de l'envoi de l'e-mail. Vous pouvez récupérer votre billet en accédant à votre compte client ou, si vous avez effectué l'achat sans vous connecter, via la fonction « Récupérer le billet » en utilisant votre numéro de réservation (PNR)/code de billet et votre adresse e-mail, ou votre PNR et votre code de confirmation (CP). »_
@@ -70,7 +70,7 @@ Cette erreur se produit que l'utilisateur soit connecté ou non ; dans les deux
 Pour résoudre ce problème, un outil non officiel permet d'afficher les informations du billet. Il est disponible sur GitHub à l'adresse suivante :
 
 https://github.com/MartinLangbecker/bookmarklets/tree/main/hellenic_train
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/irish-rail-website/index.de.md
+++ b/content/booking/irish-rail-website/index.de.md
@@ -36,7 +36,7 @@ Die angezeigten Preise für die Premier Class enthalten die Preisdifferenz zwisc
 
 Reservierungen für FIP Freifahrtscheine der 1. Klasse können nicht online über Irish Rail gebucht werden.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 In Irland wird grundsätzlich der Name der Passagiere an den Reservierungsanzeigen in den Zügen angezeigt. Wenn das nicht gewünscht wird, kann bei der Buchung angegeben werden, dass stattdessen die Ticketnummer angezeigt wird.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/irish-rail-website/index.en.md
+++ b/content/booking/irish-rail-website/index.en.md
@@ -36,7 +36,7 @@ The prices displayed for Premier Class include the price difference between 1st 
 
 Reservations for 1st class FIP Coupons cannot be booked online via Irish Rail.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 In Ireland, the names of passengers are generally displayed on the reservation indicators in the trains. If this is not desired, the booking can indicate that the ticket number should be displayed instead.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/irish-rail-website/index.fr.md
+++ b/content/booking/irish-rail-website/index.fr.md
@@ -36,7 +36,7 @@ Les prix affichés pour la Premier Class incluent la différence de prix entre l
 
 Les réservations pour les Coupons FIP de 1re classe ne peuvent pas être effectuées en ligne via Irish Rail.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 En Irlande, le nom des passagers est en principe affiché sur les afficheurs de réservations dans les trains. Si cela n’est pas souhaité, il est possible d’indiquer lors de la réservation que le numéro de billet soit affiché à la place.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/koleo-website/index.de.md
+++ b/content/booking/koleo-website/index.de.md
@@ -25,7 +25,7 @@ Anschließend unter _Mein Konto / Moje konto_ bei _Rabatt / Zniżka_ die Vergün
 
 Anschließend wird der vergünstigte Preis direkt in der Verbindungssuche angezeigt.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Es ist empfehlenswert vor dem Kauf nochmal im nicht eingeloggten Zustand den Preis zu prüfen, um herauszufinden, ob tatsächlich der FIP 50 Preis berechnet wurde. Bei einzelnen Bahngesellschaften kam es hier in der Vergangenheit zu falschen Preisberechnungen ohne den FIP 50 Rabatt.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/koleo-website/index.en.md
+++ b/content/booking/koleo-website/index.en.md
@@ -25,7 +25,7 @@ Then under _My Account / Moje konto_ at _Discount / Zniżka_, add the discount _
 
 Subsequently, the discounted price is displayed directly in the connection search.
 
-{{% highlight important %}}
+{{< highlight important >}}
 It is recommended to check the price again in a non-logged-in state before purchasing to find out whether the FIP 50 price was actually calculated. With individual railway companies, there have been incorrect price calculations in the past without the FIP 50 discount.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/koleo-website/index.fr.md
+++ b/content/booking/koleo-website/index.fr.md
@@ -25,7 +25,7 @@ Ensuite, sous _Mon Compte / Moje konto_ à _Réduction / Zniżka_, ajouter la r�
 
 Par la suite, le prix réduit est affiché directement dans la recherche de connexion.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Il est recommandé de vérifier à nouveau le prix en état non connecté avant l’achat pour savoir si le prix FIP 50 a effectivement été calculé. Avec certaines compagnies ferroviaires, il y a eu des calculs de prix incorrects dans le passé sans la réduction FIP 50.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/lka-ticket-machine/index.de.md
+++ b/content/booking/lka-ticket-machine/index.de.md
@@ -17,9 +17,9 @@ An einigen Bahnhöfen in Polen gibt es Fahrkartenautomaten, die auch Fahrkarten 
 
 An den Fahrkartenautomaten können ermäßigte FIP 50 Fahrkarten erworben werden. Dafür muss, falls möglich, ein Rabatt “FIP (50%)” angegeben werden. Falls dies nicht möglich ist, sollte der Rabatt “UMOWA (ulga 50%)” angegeben werden.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In der Vergangenheit war “UMOWA” nicht immer korrekt für FIP-Fahrkarten. Im Zweifelsfall sollte vor Ort nachgefragt werden, ob dies auch wirklich der korrekte Tarif für FIP-Fahrkarten ist.
-{{% /highlight %}}
+{{< /highlight >}}
 
 ## Reservierungen
 

--- a/content/booking/lka-ticket-machine/index.en.md
+++ b/content/booking/lka-ticket-machine/index.en.md
@@ -17,9 +17,9 @@ At some stations in Poland, ticket machines are available that also sell tickets
 
 Discounted FIP 50 Tickets can be purchased at the ticket machines. If possible, the discount "FIP (50%)" should be selected. If this is not available, the discount "UMOWA (ulga 50%)" should be selected.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In the past, "UMOWA" was not always the correct option for FIP tickets. If in doubt, ask on-site whether this is indeed the correct fare for FIP tickets.
-{{% /highlight %}}
+{{< /highlight >}}
 
 ## Reservations
 

--- a/content/booking/lka-ticket-machine/index.fr.md
+++ b/content/booking/lka-ticket-machine/index.fr.md
@@ -17,9 +17,9 @@ Dans certaines gares en Pologne, des distributeurs de billets sont disponibles q
 
 Des Billets FIP 50 à tarif réduit peuvent être achetés aux distributeurs de billets. Si possible, la réduction « FIP (50%) » doit être sélectionnée. Si celle-ci n’est pas disponible, la réduction « UMOWA (ulga 50%) » doit être sélectionnée.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Par le passé, « UMOWA » n’était pas toujours l’option correcte pour les billets FIP. En cas de doute, demandez sur place si c’est bien le tarif correct pour les billets FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 ## Réservations
 

--- a/content/booking/renfe-ticket-office/index.de.md
+++ b/content/booking/renfe-ticket-office/index.de.md
@@ -26,6 +26,6 @@ Es fällt eine zusätzliche Gebühr von 0,55€ an.
 In den Verkaufsstellen der Renfe können alle Tickets ohne Reservierung (FIP 50) gebucht werden.
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Wie Erfahrung gezeigt hat, sind die Ticketschalter an großen Bahnhöfen oft sehr überlaufen. Es wird zwischen Schaltern für Regional- und Fernzüge unterschieden. Außerdem werden Kunden, die für den aktuellen Tag ein Ticket brauchen, bevorzugt behandelt. Das führt bei anderen Kunden zu längeren Wartezeiten. Wenn es geht, sollte man Tickets schon außerhalb von Spanien kaufen. Ist man auf den Ticketschalter in Spanien angewiesen, sollte man am besten morgens zum Bahnhof gehen, wenn ein Ticket für einen anderen Tag benötigt wird. Mittags kann es auch an Wochentagen zu sehr langen Wartezeiten kommen.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/renfe-ticket-office/index.en.md
+++ b/content/booking/renfe-ticket-office/index.en.md
@@ -26,6 +26,6 @@ An additional fee of €0.55 applies.
 At Renfe ticket offices, all non-reservation tickets (FIP 50) can be booked.
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Experience has shown that the ticket counters at large stations are often very crowded. There are different counters for regional and long-distance trains. In addition, customers who need a ticket for the current day are served firstly. This leads to longer waiting times for other customers. If possible, you should buy tickets outside of Spain. If you are reliant on the ticket counter in Spain, it is best to go to the station in the morning if you need a ticket for another day. At lunchtime, there can be very long waiting times, even on weekdays.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/renfe-ticket-office/index.fr.md
+++ b/content/booking/renfe-ticket-office/index.fr.md
@@ -26,7 +26,7 @@ Des frais supplémentaires de 0,55€ s’appliquent.
 Aux guichets de la Renfe, tous les billets sans réservation (FIP 50) peuvent y être achetés.
 {{% /booking-section %}}
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 L’expérience montre que les guichets des grandes gares sont souvent très fréquentés. \
 Il existe des guichets distincts pour les trains régionaux et les trains longue distance. \
 En outre, les clients qui souhaitent un billet pour le jour même sont prioritaires, ce qui entraîne des temps d’attente plus longs pour les autres voyageurs.
@@ -34,4 +34,4 @@ En outre, les clients qui souhaitent un billet pour le jour même sont prioritai
 Si possible, il est recommandé d’acheter les billets en dehors de l’Espagne. \
 Si vous devez absolument passer par un guichet en Espagne, il est conseillé de vous rendre à la gare le matin, surtout si le billet est pour un autre jour. \
 À l’heure du déjeuner, les files peuvent être très longues, même en semaine.
-{{% /highlight %}}
+{{< /highlight >}}

--- a/content/booking/rhb-website/index.de.md
+++ b/content/booking/rhb-website/index.de.md
@@ -18,9 +18,9 @@ params:
 
 Auf der Website der RhB dürfen für FIP 50 Tickets mit "50% Halbtax" Rabatt gekauft werden, sofern es sich nicht um ein Sparbillett, eine Spar-Tageskarte oder ein spezielles Billett handelt.[^1] Diese Option ist eigentlich für Fahrgäste mit Halbtax-Abo (Vergünstigungskarte der SBB) gedacht, wird aber auch als unkomplizierte Lösung für FIP 50 Fahrkarten akzeptiert. Der Halbtaxpreis muss bei der Angabe der Reisenden im Buchungsverlauf ausgewählt werden.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Unter anderem in städtischen Gebieten kann eine Fahrkarte mit Halbtax Rabatt auch Verkehrsmittel von Betreibern enthalten, die kein FIP akzeptieren (z. B. Straßenbahnen oder Busse). Diese Abschnitte können mit FIP nicht genutzt werden und das erworbene Ticket ist dort ohne Halbtax-Abo nicht gültig.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/rhb-website/index.en.md
+++ b/content/booking/rhb-website/index.en.md
@@ -18,9 +18,9 @@ params:
 
 On the RhB website, FIP 50 Tickets may be purchased using the "50% Half Fare" discount, provided they are not a Savings Ticket, Savings Day Ticket or special Ticket.[^1] This option is actually intended for passengers with a Half Fare subscription (SBB discount card), but it is also accepted as a straightforward solution for FIP 50 Tickets. The Half Fare price must be selected when entering the passengers during the booking process.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Particularly in urban areas, a Ticket with Half Fare discount may also include sections of transport operators that do not accept FIP (e.g. trams or buses). These sections cannot be used with FIP and the Ticket purchased is not valid there without a Half Fare subscription.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/rhb-website/index.fr.md
+++ b/content/booking/rhb-website/index.fr.md
@@ -18,9 +18,9 @@ params:
 
 Sur le site web de RhB, des Billets FIP 50 peuvent être achetés avec la réduction « 50% Demi-tarif », à condition qu'il ne s'agisse pas d'un Billet d'épargne, d'une Carte journalière d'épargne ou d'un Billet spécial.[^1] Cette option est en principe destinée aux voyageurs disposant d'un abonnement Demi-tarif (carte de réduction des CFF), mais elle est aussi acceptée comme solution simple pour les Billets FIP 50. Le tarif Demi-tarif doit être sélectionné lors de la saisie des voyageurs dans le processus de réservation.
 
-{{% highlight important %}}
+{{< highlight important >}}
 En particulier dans les zones urbaines, un Billet avec réduction Demi-tarif peut également comprendre des sections d'exploitants de transports qui n'acceptent pas les FIP (par exemple des tramways ou des bus). Ces sections ne peuvent pas être utilisées avec les FIP et le Billet acheté n'y est pas valable sans un abonnement Demi-tarif.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/sbb-ticket-machine/index.de.md
+++ b/content/booking/sbb-ticket-machine/index.de.md
@@ -16,9 +16,9 @@ aliases:
 
 An Fahrkartenautomaten der SBB dürfen FIP 50 Tickets mit "50% Halbtax" Rabatt gekauft werden, sofern es sich nicht um ein Sparbillett, eine Spar-Tageskarte oder ein spezielles Billett handelt.[^1] Diese Option ist eigentlich für Fahrgäste mit Halbtax-Abo (Vergünstigungskarte der SBB) gedacht, wird aber auch als unkomplizierte Lösung für FIP 50 Fahrkarten akzeptiert. Des Halbtaxpreis ist in der Regel am Automat vorausgewählt.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Unter anderem in städtischen Gebieten kann eine Fahrkarte mit Halbtax Rabatt auch Verkehrsmittel von Betreibern enthalten, die kein FIP akzeptieren (z. B. Straßenbahnen oder Busse). Diese Abschnitte können mit FIP nicht genutzt werden und das erworbene Ticket ist dort ohne Halbtax-Abo nicht gültig.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 [^1]: [SBB Community](https://community.sbb.ch/d/2251-kann-man-als-fip-beg%C3%BCnstigter-tickets-weiterhin-online-mittels-halbtax-kaufen)

--- a/content/booking/sbb-ticket-machine/index.en.md
+++ b/content/booking/sbb-ticket-machine/index.en.md
@@ -16,9 +16,9 @@ aliases:
 
 At SBB ticket machines, FIP 50 Tickets can be purchased with the "50% Half Fare" discount, provided it is not a saver ticket, saver day pass, or a special ticket.[^1] This option is actually intended for passengers with a Half Fare subscription (SBB discount card), but is also accepted as a straightforward solution for FIP 50 Tickets. The Half Fare price is usually preselected at the machine.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In urban areas, a ticket with Half Fare discount may also include transport operated by companies that do not accept FIP (e.g., trams or buses). These sections cannot be used with FIP, and the purchased ticket is not valid there without a Half Fare subscription.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 [^1]: [SBB Community](https://community.sbb.ch/d/2251-kann-man-als-fip-beg%C3%BCnstigter-tickets-weiterhin-online-mittels-halbtax-kaufen)

--- a/content/booking/sbb-ticket-machine/index.fr.md
+++ b/content/booking/sbb-ticket-machine/index.fr.md
@@ -16,9 +16,9 @@ aliases:
 
 Aux distributeurs automatiques des CFF, les Billets FIP 50 peuvent être achetés en sélectionnant la réduction « Demi-tarif 50 % », à condition qu’il ne s’agisse pas d’un billet dégriffé, d’un abonnement journalier dégriffé ou d’un billet spécial.[^1] Cette option est à l’origine prévue pour les détenteurs d’un abonnement demi-tarif (carte de réduction CFF), mais elle est également acceptée comme solution simple pour les Billets FIP 50. Le tarif demi-tarif est généralement présélectionné sur les distributeurs.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Dans les zones urbaines, un billet avec réduction demi-tarif peut inclure des trajets opérés par des entreprises ne participant pas au FIP (ex. : trams ou bus). Ces parties ne peuvent pas être utilisées avec un Billet FIP, et le billet n’est pas valable pour ces sections sans abonnement demi-tarif.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 [^1]: [SBB Community](https://community.sbb.ch/d/2251-kann-man-als-fip-beg%C3%BCnstigter-tickets-weiterhin-online-mittels-halbtax-kaufen)

--- a/content/booking/sbb-website/index.de.md
+++ b/content/booking/sbb-website/index.de.md
@@ -23,9 +23,9 @@ Die SBB bietet auch eine [App](https://www.sbb.ch/de/reiseinformationen/apps/sbb
 
 Bei der SBB dürfen für FIP 50 Tickets online mit "50% Halbtax" Rabatt gekauft werden, sofern es sich nicht um ein Sparbillett, eine Spar-Tageskarte oder ein spezielles Billett handelt.[^1] Diese Option ist eigentlich für Fahrgäste mit Halbtax-Abo (Vergünstigungskarte der SBB) gedacht, wird aber auch als unkomplizierte Lösung für FIP 50 Fahrkarten akzeptiert. Der Halbtaxpreis ist in der Regel auf der Website / App der SBB standardmäßig vorausgewählt.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Unter anderem in städtischen Gebieten kann eine Fahrkarte mit Halbtax Rabatt auch Verkehrsmittel von Betreibern enthalten, die kein FIP akzeptieren (z. B. Straßenbahnen oder Busse). Diese Abschnitte können mit FIP nicht genutzt werden und das erworbene Ticket ist dort ohne Halbtax-Abo nicht gültig.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/sbb-website/index.en.md
+++ b/content/booking/sbb-website/index.en.md
@@ -23,9 +23,9 @@ SBB also offers an [app](https://www.sbb.ch/en/travel-information/apps/sbb-mobil
 
 On the SBB website and app, FIP 50 Tickets can be purchased with the "50% Half Fare" discount, provided they are not a saver ticket, saver day pass, or a special ticket.[^1] This option is actually intended for passengers with a Half Fare subscription (SBB discount card), but is also accepted as a straightforward solution for FIP 50 Tickets. The Half Fare price is usually preselected by default on the SBB website and app.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In urban areas, a ticket with Half Fare discount may also include transport operated by companies that do not accept FIP (e.g., trams or buses). These sections cannot be used with FIP, and the purchased ticket is not valid there without a Half Fare subscription.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/sbb-website/index.fr.md
+++ b/content/booking/sbb-website/index.fr.md
@@ -24,9 +24,9 @@ La CFF propose également une [application](https://www.sbb.ch/fr/informations-v
 
 Sur le site des CFF et dans l'application, les Billets FIP 50 peuvent être achetés en sélectionnant la réduction « Demi-tarif 50 % », à condition qu’il ne s’agisse pas d’un billet dégriffé, d’un abonnement journalier dégriffé ou d’un billet spécial.[^1] Cette option est à l’origine prévue pour les détenteurs d’un abonnement demi-tarif, mais elle est également acceptée comme solution simple pour les Billets FIP 50. Le tarif demi-tarif est généralement présélectionné par défaut sur le site des CFF et dans l'application.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Dans les zones urbaines, un billet avec réduction demi-tarif peut inclure des transports exploités par des compagnies non participantes au FIP (par exemple : trams ou bus). Ces sections ne sont pas valables avec un Billet FIP, sauf si vous avez un abonnement demi-tarif.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% booking-section "reservations" %}}

--- a/content/booking/sncf-phone/index.de.md
+++ b/content/booking/sncf-phone/index.de.md
@@ -31,7 +31,7 @@ Eine zusätzliche Buchungsgebühr fällt bei FIP Tickets nicht an.
 
 Sobald die Fahrkarten oder Reservierungen bestätigt sind, werden eine PNR (Buchungsbestätigung) sowie das eTicket per E-Mail versendet. Bei der Zugreise muss das eTicket zusammen mit dem FIP Freifahrtschein oder dem FIP Ausweis vorgelegt werden.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Um Wartezeiten zu vermeiden, kann auf der [Website der SNCF](https://www.tgvinoui.sncf/services/mieux-vous-accompagner/prise-de-rendez-vous) ein Rückruftermin vereinbart werden. Dabei kann der Name und die E-Mail-Adresse bereits vorab angegeben werden und muss nicht mehr am Telefon diktiert werden. Außerdem kann im Freitextfeld die gewünschte Verbindung angegeben und der FIP Ermäßigung angegeben werden.
 
 Der Rückrufservice funktioniert nur mit französischen Telefonnummern oder ausländischen Festnetznummern. Ausländische Mobilfunknummern funktionieren nicht.
@@ -39,7 +39,7 @@ Der Rückrufservice funktioniert nur mit französischen Telefonnummern oder ausl
 Die SNCF kennt die FIP Ermäßigungen teilweise auch unter den Namen: \
 _FIP cheminot étranger_ = 50% FIP Ermäßigung \
 _FIP permis (ayant droit SNCF)_ = 100% / FIP Freifahrtschein SNCF
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% booking-section "fip_50" %}}
 

--- a/content/booking/sncf-phone/index.en.md
+++ b/content/booking/sncf-phone/index.en.md
@@ -31,7 +31,7 @@ No additional booking fee applies for FIP tickets.
 
 Once tickets or reservations are confirmed, a PNR (booking confirmation) and the eTicket will be sent by email. When traveling by train, you must present the eTicket together with the FIP Coupon or FIP Card.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 To avoid waiting times, you can schedule a callback appointment on the [SNCF website](https://www.tgvinoui.sncf/services/mieux-vous-accompagner/prise-de-rendez-vous). You can provide your name and email address in advance, so you do not need to spell them over the phone. You can also specify your desired connection and indicate the FIP discount in the free text field.
 
 The callback service only works with French phone numbers or foreign landline numbers. Foreign mobile numbers do not work.
@@ -39,7 +39,7 @@ The callback service only works with French phone numbers or foreign landline nu
 SNCF sometimes refers to FIP discounts as: \
 _FIP cheminot étranger_ = 50% FIP discount \
 _FIP permis (ayant droit SNCF)_ = 100% / FIP Coupon SNCF
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% booking-section "fip_50" %}}
 

--- a/content/booking/sncf-phone/index.fr.md
+++ b/content/booking/sncf-phone/index.fr.md
@@ -31,7 +31,7 @@ Aucun frais de réservation supplémentaire n’est appliqué pour les Billets F
 
 Une fois les billets ou réservations confirmés, une PNR (confirmation de réservation) ainsi que le eTicket sont envoyés par e-mail. Lors du voyage en train, il faut présenter le eTicket avec le Coupon FIP ou la Carte FIP.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Pour éviter les temps d’attente, il est possible de prendre un rendez-vous de rappel sur le [site web de la SNCF](https://www.tgvinoui.sncf/services/mieux-vous-accompagner/prise-de-rendez-vous). Le nom et l’adresse e-mail peuvent être indiqués à l’avance, il n’est donc plus nécessaire de les dicter au téléphone. Il est également possible d’indiquer la liaison souhaitée et la réduction FIP dans la case de texte libre.
 
 Le service de rappel ne fonctionne qu’avec des numéros de téléphone français ou des numéros fixes étrangers. Les numéros de portables étrangers ne fonctionnent pas.
@@ -39,7 +39,7 @@ Le service de rappel ne fonctionne qu’avec des numéros de téléphone frança
 La SNCF connaît parfois les billets FIP sous les noms suivants : \
 _FIP cheminot étranger_ = 50 % de réduction FIP \
 _FIP permis (ayant droit SNCF)_ = 100 % / Coupon FIP SNCF
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% booking-section "fip_50" %}}
 

--- a/content/booking/stena-line-bv-email/index.de.md
+++ b/content/booking/stena-line-bv-email/index.de.md
@@ -25,9 +25,9 @@ In der Mail sind folgende Daten anzugeben:
 Von Stena Line erhält man in der Regel zwei Antwortmails. In der ersten Mail wird die Buchungsanfrage bestätigt. In der zweiten Mail erhält man eine Bezahloption über pay per link. Hier sind dann die Kreditkartendaten zu hinterlegen.
 Nach Bezahlung bekommst du eine Mail mit der Resevierungsbestätigung, die auch als Ticket gilt - die FIP Fahrkarten sind natürlich mitzuführen.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die Bezahlung über pay per link ist nur am selben Tag möglich, an dem die entsprechende Mail zur Zahlungsaufforderung erhalten wurde. Der Link verliert um Mitternacht seine Gültigkeit. Sollte dem so sein, ist erneut Kontakt zu Stena Line aufzunehmen.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% booking-section "fip_50" %}}
 
@@ -42,7 +42,7 @@ FIP 50 Tickets können gebucht werden.
 
 Kabinenreservierungen sind erhältlich und bei Übernachtfahrten obligatorisch.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Für Reservierungen ist außerdem die Nummer des Stena Line BV FIP Freifahrtscheins erforderlich, der bei der Fahrt genutzt werden soll. Eine Buchung ist daher erst möglich, sobald der FIP Freifahrtschein vorliegt.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/stena-line-bv-email/index.en.md
+++ b/content/booking/stena-line-bv-email/index.en.md
@@ -25,9 +25,9 @@ The email must contain the following information:
 You will usually receive two reply emails from Stena Line. The first email confirms your booking request. The second email provides you with a payment option via pay per link. You will then need to enter your credit card details.
 After payment, you will receive an email with your booking confirmation, which also serves as your ticket – you must of course bring your FIP tickets with you.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Payment via pay per link is only possible on the same day that the corresponding payment request email is received. The link expires at midnight. If this is the case, please contact Stena Line again.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% booking-section "fip_50" %}}
 
@@ -42,7 +42,7 @@ FIP 50 Tickets can be booked.
 
 Cabin reservations are available and mandatory for overnight journeys.
 
-{{% highlight important %}}
+{{< highlight important >}}
 For reservations, the number of the Stena Line BV FIP Coupon to be used for the journey is also required. Booking is therefore only possible once the FIP Coupon is available.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/stena-line-bv-email/index.fr.md
+++ b/content/booking/stena-line-bv-email/index.fr.md
@@ -25,9 +25,9 @@ Les informations suivantes doivent être indiquées dans l’e-mail:
 En règle générale, Stena Line vous envoie deux e-mails de réponse. Le premier e-mail confirme la demande de réservation. Le deuxième e-mail vous propose une option de paiement via pay per link. Vous devez alors saisir les données de votre carte de crédit.
 Une fois le paiement effectué, vous recevez un e-mail avec la confirmation de réservation, qui fait également office de billet. Vous devez bien sûr emporter avec vous les billets FIP.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Le paiement via pay per link n’est possible que le jour même où l’e-mail correspondant à la demande de paiement a été reçu. Le lien expire à minuit. Si tel est le cas, veuillez recontacter Stena Line.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% booking-section "fip_50" %}}
 
@@ -42,7 +42,7 @@ Les billets FIP 50 peuvent être réservés.
 
 Les réservations de cabine sont disponibles et obligatoires pour les traversées de nuit.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Pour les réservations, le numéro du Coupon FIP Stena Line BV qui doit être utilisé pour le voyage est également requis. Une réservation n’est donc possible que lorsque le Coupon FIP est disponible.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/stena-line-bv-phone/index.de.md
+++ b/content/booking/stena-line-bv-phone/index.de.md
@@ -38,9 +38,9 @@ FIP 50 Tickets können gebucht werden.
 
 Kabinenreservierungen sind erhältlich und bei Übernachtfahrten obligatorisch.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Für Reservierungen ist außerdem die Nummer des Stena Line BV FIP Freifahrtscheins erforderlich, der bei der Fahrt genutzt werden soll. Eine Buchung ist daher erst möglich, sobal der FIP Freifahrtschein vorliegt.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% satellite /%}}

--- a/content/booking/stena-line-bv-phone/index.en.md
+++ b/content/booking/stena-line-bv-phone/index.en.md
@@ -38,9 +38,9 @@ FIP 50 Tickets can be booked.
 
 Cabin reservations are available and mandatory for overnight journeys.
 
-{{% highlight important %}}
+{{< highlight important >}}
 For reservations, the number of the Stena Line BV FIP Coupon to be used for the journey is also required. Booking is therefore only possible once the FIP Coupon is available.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% satellite /%}}

--- a/content/booking/stena-line-bv-phone/index.fr.md
+++ b/content/booking/stena-line-bv-phone/index.fr.md
@@ -39,9 +39,9 @@ Les billets FIP 50 peuvent être réservés.
 
 Les réservations de cabine sont disponibles et obligatoires pour les traversées de nuit.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Pour les réservations, le numéro du Coupon FIP Stena Line BV qui doit être utilisé pour le voyage est également requis. Une réservation n’est donc possible que lorsque le Coupon FIP est disponible.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}
 
 {{% satellite /%}}

--- a/content/booking/traivelling-website/index.de.md
+++ b/content/booking/traivelling-website/index.de.md
@@ -57,7 +57,7 @@ In Schritt 3 suchst du nach den Verbindungen. Die Ermäßigungskarte wird automa
 Nach Auswahl der Verbindung prüfe unbedingt, ob als Tarif "FIP Leisure" hinterlegt ist. Ist das nicht der Fall, handelt es sich um einen öffentlichen Tarif mit den entsprechenden Stornierungsbedingungen.
 {{% /float-image %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 Wenn die Reise in Deutschland startet oder endet, wird keine Buchungsgebühr erhoben. In allen anderen Fällen wird eine Buchungsgebühr von 8 % erhoben.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/traivelling-website/index.en.md
+++ b/content/booking/traivelling-website/index.en.md
@@ -57,7 +57,7 @@ In step 3, search for connections. The discount card is automatically taken into
 After selecting the connection, make sure that "FIP Leisure" is listed as the fare. If this is not the case, it is a public fare with the corresponding cancellation conditions.
 {{% /float-image %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 If the journey starts or ends in Germany, no booking fee is charged. In all other cases, a booking fee of 8 % is charged.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/booking/traivelling-website/index.fr.md
+++ b/content/booking/traivelling-website/index.fr.md
@@ -57,7 +57,7 @@ Traivelling vend des Billets FIP pour Eurostar Blue et Eurostar Red sur son site
 Après avoir sélectionné la connexion, vérifiez impérativement que le tarif indiqué est « FIP Leisure ». Si ce n'est pas le cas, il s'agit d'un tarif public avec les conditions d'annulation correspondantes.
 {{% /float-image %}}
 
-{{% highlight "important" %}}
+{{< highlight "important" >}}
 Si le trajet commence ou se termine en Allemagne, aucun frais de réservation n'est appliqué. Dans tous les autres cas, des frais de réservation de 8 % sont facturés.
-{{% /highlight %}}
+{{< /highlight >}}
 {{% /booking-section %}}

--- a/content/operator/bdz/index.fr.md
+++ b/content/operator/bdz/index.fr.md
@@ -109,23 +109,6 @@ Trains régionaux en trafic intérieur desservant la plupart des gares, circulan
 
 {{% /train-category %}}
 
-{{% train-category
-    id="night-train"
-    title="Train de nuit"
-    type="sleeper"
-    fip_accepted=true
-    reservation_required=true
-    reservation_possible=true
-%}}
-
-Trains circulant de nuit et nécessitant une réservation.
-
-{{% highlight important %}}
-Les prix de réservation pour les couchettes ou voitures-lits sont plus élevés que pour les réservations classiques.
-{{% /highlight %}}
-
-{{% /train-category %}}
-
 ## Achat de billets et réservations
 
 ### En gare

--- a/content/operator/cd/index.de.md
+++ b/content/operator/cd/index.de.md
@@ -50,9 +50,9 @@ Die SuperCity Züge bieten die schnellsten Verbindungen auf der Strecke Prag –
 
 In der 1. Klasse erhalten Fahrgäste eine kleine Erfrischung, in der 2. Klasse gibt es eine Flasche Wasser. In beiden Klassen stehen außerdem Tageszeitungen gratis zur Verfügung. Während der Fahrt steht ein Bord-Entertainment- und Informationsportal zur Verfügung, über das man Speisen und Getränke direkt an den Platz bestellen, Bücher lesen, Musik hören, Spiele spielen oder Filme schauen kann.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die Züge sind auf einigen Verbindungen zuschlagspflichtig (siehe [ČD kommerzielle Verbindungen](#čd-kommerzielle-verbindungen-zuschlagspflichtig)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -82,9 +82,9 @@ Es gibt meist drei Wagenklassen:
 
 Die Züge verfügen über modernes Wagenmaterial im Stil der ÖBB-Railjets, allerdings mit blauer Außengestaltung. Fahrräder, Kinderwagen und anderes Sperrgepäck können mitgenommen werden. Speisen und Getränke sind im Bordrestaurant oder per Am-Platz-Service erhältlich. In der 1. Klasse erhalten Fahrgäste kostenlos eine Flasche Wasser und eine Tageszeitung, in der Business Class zusätzlich ein Begrüßungsgetränk sowie einen Gutschein im Wert von 50 CZK für das Restaurantangebot (nur innerhalb Tschechiens). Für Kinder gibt es ein eigenes Kinderkino mit speziellen Programmen.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Nicht zu verwechseln mit Zügen von RegioJet, die teilweise ebenfalls mit `RJ` gekennzeichnet sind. Dieser private Betreiber akzeptiert keine FIP Fahrscheine.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -104,9 +104,9 @@ Sitzplatzreservierungen sind möglich, in der Business Class sogar verpflichtend
 
 Internationale Fernverkehrszüge im Taktverkehr mit hohem Komfort. Die klimatisierten Wagen stammen von verschiedenen Bahnverwaltungen und verfügen oft über einen Speisewagen, der sich internationaler Beliebtheit erfreut.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die Züge sind auf einigen Verbindungen zuschlagspflichtig (siehe [ČD kommerzielle Verbindungen](#čd-kommerzielle-verbindungen-zuschlagspflichtig)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -122,9 +122,9 @@ Die Züge sind auf einigen Verbindungen zuschlagspflichtig (siehe [ČD kommerzie
 
 Fernverkehrszüge mit hohem Komfort und Halten nur an wichtigeren Bahnhöfen. Teilweise sind sie mit einem Bordrestaurant oder einer Minibar ausgestattet.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die Züge sind auf einigen Verbindungen zuschlagspflichtig (siehe [ČD kommerzielle Verbindungen](#čd-kommerzielle-verbindungen-zuschlagspflichtig)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -158,9 +158,9 @@ Schnellzüge im innertschechischen Verkehr sowie zwischen Praha und Žilina oder
 
 Schnellzüge im Regional- und Fernverkehr mit häufigeren Halten als Express-Züge. Sie verwenden teilweise älteres Wagenmaterial und verbinden u. a. Prag mit Urlaubsgebieten im Riesen- und Isergebirge sowie Kurorten in Mähren und Westböhmen.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die Züge sind auf einigen Verbindungen zuschlagspflichtig (siehe [ČD kommerzielle Verbindungen](#čd-kommerzielle-verbindungen-zuschlagspflichtig)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -176,13 +176,13 @@ Die Züge sind auf einigen Verbindungen zuschlagspflichtig (siehe [ČD kommerzie
 
 Eilzüge im Nahverkehr, die häufig nur über die 2. Klasse verfügen.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In einigen Regionen (z.B. um Pilsen und Brno) gelten keine FIP Vergünstigungen (siehe [Verbindungen der ČD ohne FIP](#verbindungen-der-čd-ohne-fip)).
-{{% /highlight %}}
+{{< /highlight >}}
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die Züge sind auf einigen Verbindungen zuschlagspflichtig (siehe [ČD kommerzielle Verbindungen](#čd-kommerzielle-verbindungen-zuschlagspflichtig)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -198,13 +198,13 @@ Die Züge sind auf einigen Verbindungen zuschlagspflichtig (siehe [ČD kommerzie
 
 Nahverkehrszüge mit Halt an allen Bahnhöfen, die häufig nur über die 2. Klasse verfügen.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In einigen Regionen (z.B. um Pilsen und Brno) gelten keine FIP Vergünstigungen (siehe [Verbindungen der ČD ohne FIP](#verbindungen-der-čd-ohne-fip)).
-{{% /highlight %}}
+{{< /highlight >}}
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die Züge sind auf einigen Verbindungen zuschlagspflichtig (siehe [ČD kommerzielle Verbindungen](#čd-kommerzielle-verbindungen-zuschlagspflichtig)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -222,9 +222,9 @@ Nachtzüge verbinden Tschechien mit Deutschland, Östereich, Polen, der Schweiz,
 
 Für Nightjet Züge können Reservierungen/Aufpreise für Schlaf- und Liegewagen gebucht werden. Dafür ist ein FIP Freifahrtschein für die Länder/Bahngesellschaften erforderlich, die auf der Reise durchfahren werden. Wenn kein FIP Freifahrtschein genutzt wird, kann ein Ticket zum FIP Globalpreis für die gesamte Strecke erworben werden.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Nationale Freifahrten für Mitarbeitende der Deutschen Bahn werden in Deutschland nicht anerkannt. Liegt ein Teil der Nightjet Fahrt also in Deutschland (Start, Ende oder Durchreise) müssen Mitarbeiter der Deutschen Bahn für die gesamte Strecke ein Ticket zum FIP Globalpreis erwerben. Für Fahrten außerhalb Deutschlands mit FIP Freifahrtschein ist eine Reservierung/Aufpreis für Schlaf- und Liegewagen erforderlich. Die einzige Ausnahme besteht, wenn auf dem deutschen Abschnitt der Zug zusätzlich als IC oder EC verkehrt, dann dieser Teil mit Freifahrten der DB nutzbar.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 

--- a/content/operator/cd/index.en.md
+++ b/content/operator/cd/index.en.md
@@ -50,9 +50,9 @@ SuperCity trains offer the fastest connections on the Prague – Pardubice – O
 
 In 1st class, passengers receive a small refreshment; in 2nd class, a bottle of water. Free newspapers are available in both classes. During the journey, an on-board entertainment and information portal is available, allowing passengers to order food and drinks to their seat, read books, listen to music, play games, or watch movies.
 
-{{% highlight important %}}
+{{< highlight important >}}
 The trains require a surcharge on some services (see [ČD commercial services](#čd-commercial-services-surcharge-required)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -82,9 +82,9 @@ There are usually three classes:
 
 The trains feature modern rolling stock in the ÖBB Railjet style, but with blue exterior. Bicycles, prams, and other bulky luggage can be taken on board. Food and drinks are available in the restaurant car or via at-seat service. In 1st class, passengers receive a free bottle of water and a newspaper; in Business Class, additionally a welcome drink and a 50 CZK voucher for the restaurant (within Czechia only). For children, there is a dedicated children's cinema.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Not to be confused with RegioJet trains, which are sometimes also marked as `RJ`. This private operator does not accept FIP Tickets.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -104,9 +104,9 @@ Seat reservations are possible, and mandatory in Business Class.
 
 International long-distance trains with high comfort and regular-interval service. The air-conditioned coaches come from various railway companies and often include a popular restaurant car.
 
-{{% highlight important %}}
+{{< highlight important >}}
 The trains require a surcharge on some services (see [ČD commercial services](#čd-commercial-services-surcharge-required)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -122,9 +122,9 @@ The trains require a surcharge on some services (see [ČD commercial services](#
 
 Long-distance trains with high comfort, stopping only at major stations. Some are equipped with a restaurant car or minibar.
 
-{{% highlight important %}}
+{{< highlight important >}}
 The trains require a surcharge on some services (see [ČD commercial services](#čd-commercial-services-surcharge-required)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -158,9 +158,9 @@ Fast trains in domestic traffic and between Prague and Žilina or Košice. They 
 
 Fast trains in regional and long-distance traffic with more frequent stops than Express trains. They sometimes use older rolling stock and connect Prague with holiday regions in the Giant and Jizera Mountains as well as spa towns in Moravia and West Bohemia.
 
-{{% highlight important %}}
+{{< highlight important >}}
 The trains require a surcharge on some services (see [ČD commercial services](#čd-commercial-services-surcharge-required)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -176,13 +176,13 @@ The trains require a surcharge on some services (see [ČD commercial services](#
 
 Semi-fast trains in local traffic, often only with 2nd class.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In some regions (e.g. around Pilsen and Brno), FIP benefits are not valid (see [ČD services without FIP](#čd-services-without-fip)).
-{{% /highlight %}}
+{{< /highlight >}}
 
-{{% highlight important %}}
+{{< highlight important >}}
 The trains require a surcharge on some services (see [ČD commercial services](#čd-commercial-services-surcharge-required)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -198,13 +198,13 @@ The trains require a surcharge on some services (see [ČD commercial services](#
 
 Local trains stopping at all stations, often only with 2nd class.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In some regions (e.g. around Pilsen and Brno), FIP benefits are not valid (see [ČD services without FIP](#čd-services-without-fip)).
-{{% /highlight %}}
+{{< /highlight >}}
 
-{{% highlight important %}}
+{{< highlight important >}}
 The trains require a surcharge on some services (see [ČD commercial services](#čd-commercial-services-surcharge-required)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -222,9 +222,9 @@ Night trains connect Czechia with Germany, Austria, Poland, Switzerland, Slovaki
 
 For Nightjet trains, reservations/supplements for sleeping and couchette cars can be booked. For this, an FIP Coupon for the countries/railways being travelled through is required. If no FIP Coupon is used, a ticket at the FIP Global Fare for the entire route can be purchased.
 
-{{% highlight important %}}
+{{< highlight important >}}
 National free travel for Deutsche Bahn employees is not recognized in Germany. If any part of the Nightjet journey is in Germany (start, end, or transit), DB employees must purchase a ticket at the FIP Global Fare for the entire route. For journeys outside Germany with an FIP Coupon, a reservation/supplement for sleeping and couchette cars is required. The only exception is if the train also operates as an IC or EC on the German section, then this part can be used with DB free travel.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 

--- a/content/operator/cd/index.fr.md
+++ b/content/operator/cd/index.fr.md
@@ -50,9 +50,9 @@ Les trains SuperCity offrent les liaisons les plus rapides sur la ligne Prague �
 
 En 1ère classe, les passagers reçoivent une petite collation ; en 2ᵉ classe, une bouteille d’eau. Des journaux gratuits sont disponibles dans les deux classes. Pendant le trajet, un portail d’information et de divertissement à bord permet de commander des repas et boissons à la place, lire, écouter de la musique, jouer ou regarder des films.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les trains nécessitent un supplément sur certaines liaisons (voir [Liaisons commerciales ČD](#liaisons-commerciales-čd-supplément-obligatoire)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -82,9 +82,9 @@ Il existe généralement trois classes :
 
 Les trains disposent de matériel moderne de type ÖBB Railjet, mais avec une livrée bleue. Les vélos, poussettes et bagages encombrants sont acceptés. Restauration disponible au wagon-restaurant ou service à la place. En 1ère classe, une bouteille d’eau et un journal sont offerts ; en Business, une boisson de bienvenue et un bon de 50 CZK pour le restaurant (valable uniquement en Tchéquie). Un cinéma pour enfants est disponible.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 À ne pas confondre avec les trains RegioJet, parfois aussi notés `RJ`, qui n’acceptent pas les Billets FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -104,9 +104,9 @@ La réservation de siège est possible, et obligatoire en Business Class.
 
 Trains internationaux longue distance avec un haut niveau de confort et des horaires cadencés. Les voitures climatisées proviennent de différentes compagnies et incluent souvent un wagon-restaurant.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les trains nécessitent un supplément sur certaines liaisons (voir [Liaisons commerciales ČD](#liaisons-commerciales-čd-supplément-obligatoire)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -122,9 +122,9 @@ Les trains nécessitent un supplément sur certaines liaisons (voir [Liaisons co
 
 Trains longue distance confortables, ne s’arrêtant qu’aux principales gares. Certains sont équipés d’un wagon-restaurant ou d’un minibar.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les trains nécessitent un supplément sur certaines liaisons (voir [Liaisons commerciales ČD](#liaisons-commerciales-čd-supplément-obligatoire)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -158,9 +158,9 @@ Trains rapides en trafic intérieur et entre Prague et Žilina ou Košice. Ils d
 
 Trains rapides en trafic régional et longue distance, avec plus d’arrêts que les trains Express. Ils utilisent parfois du matériel plus ancien et relient Prague à des régions touristiques ou thermales.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les trains nécessitent un supplément sur certaines liaisons (voir [Liaisons commerciales ČD](#liaisons-commerciales-čd-supplément-obligatoire)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -176,13 +176,13 @@ Les trains nécessitent un supplément sur certaines liaisons (voir [Liaisons co
 
 Trains semi-rapides en trafic local, souvent uniquement en 2ᵉ classe.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Dans certaines régions (par ex. autour de Pilsen et Brno), les avantages FIP ne sont pas valables (voir [Services ČD sans FIP](#services-čd-sans-fip)).
-{{% /highlight %}}
+{{< /highlight >}}
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les trains nécessitent un supplément sur certaines liaisons (voir [Liaisons commerciales ČD](#liaisons-commerciales-čd-supplément-obligatoire)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -198,13 +198,13 @@ Les trains nécessitent un supplément sur certaines liaisons (voir [Liaisons co
 
 Trains locaux desservant toutes les gares, souvent uniquement en 2ᵉ classe.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Dans certaines régions (par ex. autour de Pilsen et Brno), les avantages FIP ne sont pas valables (voir [Services ČD sans FIP](#services-čd-sans-fip)).
-{{% /highlight %}}
+{{< /highlight >}}
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les trains nécessitent un supplément sur certaines liaisons (voir [Liaisons commerciales ČD](#liaisons-commerciales-čd-supplément-obligatoire)).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -222,9 +222,9 @@ Les trains de nuit relient la Tchéquie à l’Allemagne, l’Autriche, la Polog
 
 Pour les Nightjet, les réservations/suppléments pour voitures-lits et couchettes sont obligatoires. Un Coupon FIP pour chaque pays/compagnie traversé est nécessaire. Sans Coupon FIP, un billet au Tarif Global FIP pour tout le trajet peut être acheté.
 
-{{% highlight important %}}
+{{< highlight important >}}
 La gratuité nationale pour les employés de la Deutsche Bahn n’est pas reconnue en Allemagne. Si une partie du trajet Nightjet se trouve en Allemagne (départ, arrivée ou transit), les employés DB doivent acheter un billet au Tarif Global FIP pour tout le trajet. Pour les trajets hors Allemagne avec un Coupon FIP, une réservation/supplément pour voitures-lits/couchettes est nécessaire. Exception : si le train circule aussi comme IC ou EC en Allemagne, ce tronçon peut être utilisé avec la gratuité DB.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 

--- a/content/operator/cfl/index.de.md
+++ b/content/operator/cfl/index.de.md
@@ -23,9 +23,9 @@ Die CFL (Société nationale des chemins de fer luxembourgeois) ist die luxembur
 
 {{< fip-validity type="fip-reduced-ticket" status="valid" subtitle="FIP 50" >}}
 
-{{< highlight important >}}
+{{% highlight important %}}
 Luxemburg bietet kostenlosen öffentlichen Nahverkehr für Inlandsfahrten unabhängig von FIP an. Dies umfasst alle Zugverbindungen (außer TGV), Straßenbahnen und Busse. Die Fahrt mit der CFL ist somit in der zweiten Klasse kostenlos und es muss kein zusätzliches Ticket erworben werden. Die Fahrt in der ersten Klasse erfordert einen FIP Freifahrtschein oder FIP 50 Ticket der ersten Klasse. Für Fahrten über Luxemburg hinaus z. B. Richtung Deutschland oder Belgien wird eine Fahrkarte ab dem Grenztarifpunkt benötigt. Das bedeutet, dass beispielsweise ein durchgehendes Ticket, ein gültiger Freifahrtschein oder eine nationale Fahrvergünstigung bei Fahrten nach Deutschland nötig sind, um bis ins Nachbarland zu fahren. Eine Fahrkarte ab dem ersten Bahnhof nach der Grenze ist nicht ausreichend.
-{{< /highlight >}}
+{{% /highlight %}}
 
 Mitarbeitende der [SNCB / NMBS](/operator/sncb) und [NS](/operator/ns) können einen _Unlimited Pass_ erhalten, mit dem sie das gesamte Jahr die Züge der CFL in Luxemburg nutzen können. Dieser ist für Mitarbeitende der NS jedoch kostenpflichtig. [^2]
 

--- a/content/operator/cfl/index.en.md
+++ b/content/operator/cfl/index.en.md
@@ -23,9 +23,9 @@ CFL (Société nationale des chemins de fer luxembourgeois) is the Luxembourgish
 
 {{< fip-validity type="fip-reduced-ticket" status="valid" subtitle="FIP 50" >}}
 
-{{< highlight important >}}
+{{% highlight important %}}
 Luxembourg offers free public transport for domestic journeys regardless of FIP. This includes all train services (except TGV), trams, and buses. Travel with CFL is therefore free of charge in second class and no additional ticket is required. Travel in first class requires a FIP Coupon or FIP 50 Ticket for first class. For journeys beyond Luxembourg, e.g. towards Germany or Belgium, a ticket from the border point is required. This means that, for example, a through ticket, a valid FIP Coupon, or a national travel concession is needed for journeys to Germany to travel into the neighboring country. A ticket from the first station after the border is not sufficient.
-{{< /highlight >}}
+{{% /highlight %}}
 
 Employees of [SNCB / NMBS](/operator/sncb) and [NS](/operator/ns) can get an _Unlimited Pass_, which allows them to use CFL trains in Luxembourg for the entire year. However, this pass is subject to a charge for NS employees. [^2]
 

--- a/content/operator/cfl/index.fr.md
+++ b/content/operator/cfl/index.fr.md
@@ -23,9 +23,9 @@ La CFL (Société nationale des chemins de fer luxembourgeois) est la compagnie 
 
 {{< fip-validity type="fip-reduced-ticket" status="valid" subtitle="FIP 50" >}}
 
-{{< highlight important >}}
+{{% highlight important %}}
 Le Luxembourg offre la gratuité des transports publics pour les trajets intérieurs, indépendamment du FIP. Cela inclut tous les trains (sauf TGV), les tramways et les bus. Le voyage avec la CFL est donc gratuit en deuxième classe et aucun billet supplémentaire n’est requis. Le voyage en première classe nécessite un Coupon FIP ou un Billet FIP 50 de première classe. Pour les trajets au-delà du Luxembourg, par exemple vers l’Allemagne ou la Belgique, un billet est nécessaire à partir du point frontière tarifaire. Cela signifie, par exemple, qu’un billet direct, un coupon FIP valide ou une réduction nationale est requis pour voyager jusqu’au pays voisin. Un billet à partir de la première gare après la frontière n’est pas suffisant.
-{{< /highlight >}}
+{{% /highlight %}}
 Les agents de [SNCB / NMBS](/operator/sncb) et de [NS](/operator/ns) peuvent obtenir un _Unlimited Pass_ leur permettant d’utiliser les trains CFL au Luxembourg toute l’année. Cependant, ce pass est payant pour les agents de NS. [^2]
 
 ## Catégories de trains et réservations

--- a/content/operator/cfr/index.de.md
+++ b/content/operator/cfr/index.de.md
@@ -39,9 +39,9 @@ Die Zugkategorien werden teilweise auch von anderen Betreibern in Rumänien genu
 
 Nationale Fernverkehrszüge mit wenige Zwischenhalten und einem vergleichsweise höherem Komfort. Sie fahren hauptsächlich von Bukarest aus in die verschiedenen Richtungen des Landes.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die `IC` Züge werden teilweise auch von anderen Betreibern in Rumänien betrieben. Für die FIP-Nutzung ist es wichtig zu beachten, dass der Betreiber die CFR Călători ist.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -62,9 +62,9 @@ Eine Sitzplatzreservierung ist verpflichtend. Ist der Zug ausgebucht, kann die R
 
 Vergleichsweise schnelle Züge, die größere Städte des Landes mit wenig Zwischenhalten verbinden. Teilweise verkehren sie auch grenzüberschreitend, insbesondere nach Ungarn.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die `IR` Züge werden teilweise auch von anderen Betreibern in Rumänien betrieben. Für die FIP-Nutzung ist es wichtig zu beachten, dass der Betreiber die CFR Călători ist.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -87,9 +87,9 @@ Meist internationale Züge, die über Nacht verkehren. Sie werden in der Verbind
 
 Bei den Zügen sind meist auch Liege- oder Schlafwagen eingereiht, die mit einer entsprechenden Reservierung genutzt werden können.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die `IRN` Züge werden teilweise auch von anderen Betreibern in Rumänien betrieben. Für die FIP-Nutzung ist es wichtig zu beachten, dass der Betreiber die CFR Călători ist.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -114,9 +114,9 @@ Internationale Züge nach Bulgarien, Moldau und der Ukraine verkehren ohne eigen
 
 Bei den Zügen sind oft auch Liege- oder Schlafwagen eingereiht, die mit einer entsprechenden Reservierung genutzt werden können.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die Züge werden teilweise auch von anderen Betreibern in Rumänien betrieben. Für die FIP-Nutzung ist es wichtig zu beachten, dass der Betreiber die CFR Călători ist.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -139,9 +139,9 @@ Für Liege- und Schlafwagen gelten folgende Preise auf nationalen Relationen: [P
 
 Regionalzüge, die auch kleinere Orte mit anbinden. Dabei haben die verschiedenen Züge auf einer Strecke oft kein festes Halteschema, d. h. die kleineren Halte werden nur von manchen `R` Zügen angefahren.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die `R` Züge werden teilweise auch von anderen Betreibern in Rumänien betrieben. Für die FIP-Nutzung ist es wichtig zu beachten, dass der Betreiber die CFR Călători ist.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 

--- a/content/operator/cfr/index.en.md
+++ b/content/operator/cfr/index.en.md
@@ -39,9 +39,9 @@ The train categories are partially used by other operators in Romania as well. F
 
 National long-distance trains with few intermediate stops and comparatively higher comfort. They mainly run from Bucharest in various directions across the country.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `IC` trains are partially operated by other operators in Romania as well. For FIP usage, it is important to verify that the operator is CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -62,9 +62,9 @@ A seat reservation is mandatory. If the train is fully booked, a standing reserv
 
 Comparatively fast trains connecting major cities with few intermediate stops. Some also run cross-border, particularly to Hungary.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `IR` trains are partially operated by other operators in Romania as well. For FIP usage, it is important to verify that the operator is CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -87,9 +87,9 @@ Mostly international trains running overnight. They are also partially listed as
 
 These trains usually include couchette or sleeper cars, which can be used with a corresponding reservation.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `IRN` trains are partially operated by other operators in Romania as well. For FIP usage, it is important to verify that the operator is CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -114,9 +114,9 @@ International trains to Bulgaria, Moldova and Ukraine run without a specific tra
 
 These trains often include couchette or sleeper cars, which can be used with a corresponding reservation.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 These trains are partially operated by other operators in Romania as well. For FIP usage, it is important to verify that the operator is CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -139,9 +139,9 @@ For couchette and sleeper cars, the following prices apply on national routes: [
 
 Regional trains that also serve smaller towns. The various trains on a route often do not have a fixed stopping pattern, meaning smaller stops are only served by some `R` trains.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `R` trains are partially operated by other operators in Romania as well. For FIP usage, it is important to verify that the operator is CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 

--- a/content/operator/cfr/index.fr.md
+++ b/content/operator/cfr/index.fr.md
@@ -39,9 +39,9 @@ Les catégories de trains sont en partie également utilisées par d’autres op
 
 Trains nationaux longue distance avec peu d’arrêts intermédiaires et un confort comparativement plus élevé. Ils circulent principalement au départ de Bucarest dans les différentes directions du pays.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains `IC` sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -62,9 +62,9 @@ Une réservation de place assise est obligatoire. Si le train est complet, une r
 
 Trains relativement rapides reliant les grandes villes du pays avec peu d’arrêts intermédiaires. Certains circulent également en transfrontalier, notamment vers la Hongrie.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains `IR` sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -87,9 +87,9 @@ Trains principalement internationaux circulant de nuit. Ils sont aussi parfois r
 
 Ces trains comprennent généralement des voitures-couchettes ou voitures-lits, qui peuvent être utilisées avec une réservation correspondante.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains `IRN` sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -114,9 +114,9 @@ Les trains internationaux vers la Bulgarie, la Moldavie et l’Ukraine circulent
 
 Ces trains comprennent souvent des voitures-couchettes ou voitures-lits, qui peuvent être utilisées avec une réservation correspondante.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Ces trains sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -139,9 +139,9 @@ Pour les voitures-couchettes et voitures-lits, les tarifs suivants s’appliquen
 
 Trains régionaux desservant également les petites localités. Les différents trains sur une même ligne n’ont souvent pas de schéma d’arrêt fixe, ce qui signifie que les petits arrêts ne sont desservis que par certains trains `R`.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains `R` sont en partie également exploités par d’autres opérateurs en Roumanie. Pour l’utilisation de la FIP, il est important de vérifier que l’opérateur est CFR Călători.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 

--- a/content/operator/cie/index.de.md
+++ b/content/operator/cie/index.de.md
@@ -39,9 +39,9 @@ Auf ihrer Website bietet Irish Rail eine [Übersichtskarte der Strecken](https:/
 
 InterCity-Züge verbinden die wichtigsten Städte Irlands, darunter Dublin, Cork, Galway und Limerick. FIP wird auf allen InterCity-Verbindungen akzeptiert. Zudem wird der Enterprise Service zwischen Dublin und Belfast von InterCity-Zügen bedient. Mehr Informationen zum Enterprise sind auf der [Irland-Seite](/country/ireland#vereinigtes-königreich) zu finden.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die First Class zwischen Dublin und Cork darf nicht mit FIP genutzt werden. Mehr Informationen zu den Klassenkategorien sind [weiter unten](#klassenkategorien) zu finden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 

--- a/content/operator/cie/index.en.md
+++ b/content/operator/cie/index.en.md
@@ -39,9 +39,9 @@ On its website, Irish Rail provides an [overview map of the routes](https://www.
 
 InterCity trains connect the major cities of Ireland, including Dublin, Cork, Galway and Limerick. FIP is accepted on all InterCity services. The Enterprise Service between Dublin and Belfast is also operated by InterCity trains. More information about the Enterprise can be found on the [Ireland page](/country/ireland#united-kingdom).
 
-{{% highlight important %}}
+{{< highlight important >}}
 First Class between Dublin and Cork may not be used with FIP. More information about class categories can be found [below](#class-categories).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 

--- a/content/operator/cie/index.fr.md
+++ b/content/operator/cie/index.fr.md
@@ -39,9 +39,9 @@ Sur son site web, Irish Rail propose une [carte d’ensemble des lignes](https:/
 
 Les trains InterCity relient les principales villes d’Irlande, notamment Dublin, Cork, Galway et Limerick. Le FIP est accepté sur toutes les liaisons InterCity. Le service Enterprise entre Dublin et Belfast est également assuré par des trains InterCity. Plus d’informations sur l’Enterprise sont disponibles sur la [page Irlande](/country/ireland#royaume-uni).
 
-{{% highlight important %}}
+{{< highlight important >}}
 La First Class entre Dublin et Cork ne peut pas être utilisée avec le FIP. Plus d’informations sur les catégories de classes sont disponibles [ci-dessous](#catégories-de-classes).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 

--- a/content/operator/cp/index.de.md
+++ b/content/operator/cp/index.de.md
@@ -108,12 +108,12 @@ Das [Liniennetz](https://www.cp.pt/info/documents/d/cp/ligacao-cp-metro-lisboa-b
 - Cascais-Linie
 - Sado-Linie
 
-{{% highlight important %}}
+{{< highlight important >}}
 Der Zugang zur Sintra-Linie und Cascais-Linie erfolgt über Ticketschranken.
 
 - Fahrgäste mit ermäßigten Tickets müssen ein Viva Viagem-Ticket für 0,50€ kaufen, um die Ticketschranke passieren zu können.
 - Fahrgäste mit FIP Freifahrtschein müssen am Zugangspunkt (zwischen 6:00 und 22:00 Uhr) die Hilfe-Taste drücken. Der Anruf wird von einem Mitarbeitenden entgegengenommen, der den Zugang freigibt.
-  {{% /highlight %}}
+  {{< /highlight >}}
 
 **Porto:** \
 Das [Liniennetz](https://www.cp.pt/info/documents/d/cp/mapa-comboios-urbanos-porto) umfasst fünf Linien:

--- a/content/operator/cp/index.en.md
+++ b/content/operator/cp/index.en.md
@@ -108,12 +108,12 @@ The [network](https://www.cp.pt/info/documents/d/cp/ligacao-cp-metro-lisboa-baix
 - Cascais Line
 - Sado Line
 
-{{% highlight important %}}
+{{< highlight important >}}
 Access to the Sintra Line and Cascais Line is via ticket gates.
 
 - Passengers with reduced tickets must purchase a Viva Viagem ticket for €0.50 to pass the gate.
 - Passengers holding an FIP Coupon must press the assistance button at the gate (between 06:00 and 22:00). Staff will grant access.
-  {{% /highlight %}}
+  {{< /highlight >}}
 
 **Porto:** \
 The [network](https://www.cp.pt/info/documents/d/cp/mapa-comboios-urbanos-porto) includes five lines:

--- a/content/operator/cp/index.fr.md
+++ b/content/operator/cp/index.fr.md
@@ -108,12 +108,12 @@ Le [réseau](https://www.cp.pt/info/documents/d/cp/ligacao-cp-metro-lisboa-baixa
 - Ligne de Cascais
 - Ligne du Sado
 
-{{% highlight important %}}
+{{< highlight important >}}
 L’accès à la ligne de Sintra et à la ligne de Cascais se fait par des portiques.
 
 - Les voyageurs titulaires d’un billet réduit doivent acheter un ticket Viva Viagem pour 0,50€ afin de franchir le portique.
 - Les titulaires d’un Coupon FIP doivent appuyer sur le bouton d’assistance au point d’accès (entre 06:00 et 22:00). Le personnel accordera l’accès.
-  {{% /highlight %}}
+  {{< /highlight >}}
 
 **Porto :** \
 Le [réseau](https://www.cp.pt/info/documents/d/cp/mapa-comboios-urbanos-porto) comprend cinq lignes :

--- a/content/operator/db/index.de.md
+++ b/content/operator/db/index.de.md
@@ -130,14 +130,14 @@ Einige [Nightjet](#nj)-Verbindungen werden mit `IC`-Sitzwagen geführt. Diese Si
 
 Ein internationaler Expresszug zwischen Frankfurt und Mailand sowie zwischen München und Zürich. Seit Dezember 2025 wird die Zugkategorie auch für weitere Verkehre zwischen der Schweiz und Deutschland sowie Zügen auf der Route Hamburg – Kopenhagen genutzt.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die Züge Richtung Italien sind ab der italienischen Grenze aufschlags- und reservierungspflichtig. Günstiger ist die Fahrt Richtung Italien mit Umstieg in Chiasso ([siehe Anreise Italien](/country/switzerland#italien "Anreise Italien")). Der Zuschlag kann am DB oder SBB Ticketschalter oder im Zug erworben werden.
 
 **Aufschlag/Reservierung Italien:**
 
 - 1\. Klasse: 13 €
 - 2\. Klasse: 11 €
-  {{% /highlight %}}
+  {{< /highlight >}}
 
 #### Reservierungen
 
@@ -174,9 +174,9 @@ Für grenzüberschreitende Fahrten in den Sommermonaten nach Tschechien gab es i
 
 Nachtzüge der ÖBB in Kooperation mit der DB in verschiedene europäische Länder. Die Züge bieten Schlaf- und Liegewagen sowie Sitzwagen an und werden im Ausland in Kooperation mit anderen Bahngesellschaften betrieben.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Nationale Freifahrten für Mitarbeiter der Deutschen Bahn werden in Deutschland nicht anerkannt. Liegt ein Teil der Nightjet Fahrt also in Deutschland (Start, Ende oder Durchreise) müssen Mitarbeiter der Deutschen Bahn für die gesamte Strecke ein Ticket zum FIP Globalpreis erwerben. Für Fahrten außerhalb Deutschlands mit FIP Freifahrtschein ist eine Reservierung/Aufpreis erforderlich.
-{{% /highlight %}}
+{{< /highlight >}}
 
 **FIP Globalpreis:** ja \
 _Tipp:_ Für Fahrten von Deutschland nach Italien, die nationalen Freifahrten bis Salzburg nutzen und dort in den Nightjet steigen, um den FIP Globalpreis zu vermeiden.
@@ -210,9 +210,9 @@ Eine Orientierung bieten [Übersichtskarten](https://www.schienennahverkehr.de/v
 
 Regionalexpresszüge verbinden Orte und Städte mit Halten an den wichtigsten Stationen. Teilweise verkehren die Züge auch überregional über längere Strecken.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die Züge der Kategorie `RE` werden oftmals auch von anderen Betreibern betrieben.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -227,9 +227,9 @@ Die Züge der Kategorie `RE` werden oftmals auch von anderen Betreibern betriebe
 
 Regionalbahnzüge verbinden Orte und Städte mit Halten an fast allen Stationen.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die Züge der Kategorie `RB` werden oftmals auch von anderen Betreibern betrieben.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -244,9 +244,9 @@ Die Züge der Kategorie `RB` werden oftmals auch von anderen Betreibern betriebe
 
 Nahverkehrszüge in großen Städten und Metropolregionen mit Halt an allen Stationen.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die Züge der Kategorie `S` werden oftmals auch von anderen Betreibern betrieben.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/db/index.en.md
+++ b/content/operator/db/index.en.md
@@ -130,14 +130,14 @@ Some [Nightjet](#nj) services are operated using `IC` coaches. These coaches may
 
 An international express train between Frankfurt and Milan as well as between Munich and Zurich. Since December 2025, the train category is also used for further services between Switzerland and Germany and trains on the Hamburg – Copenhagen route.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Trains to Italy require a surcharge and reservation from the Italian border. It is cheaper to travel to Italy by changing trains in Chiasso ([see Arrival Italy](/country/switzerland#italien "Arrival Italy")). The surcharge can be purchased at DB or SBB ticket offices or on the train.
 
 **Surcharge/Reservation Italy:**
 
 - 1st class: € 13
 - 2nd class: € 11
-  {{% /highlight %}}
+  {{< /highlight >}}
 
 #### Reservations
 
@@ -174,9 +174,9 @@ In the past, there was a reservation requirement for cross-border journeys in su
 
 Night trains of ÖBB in cooperation with DB to various European countries. The trains offer sleeper, couchette, and seating cars and are operated abroad in cooperation with other railway companies.
 
-{{% highlight important %}}
+{{< highlight important >}}
 National free travel for DB employees is not recognized in Germany. If part of the Nightjet journey is in Germany (start, end, or transit), DB employees must purchase a ticket at the FIP Global Fare for the entire route. For journeys outside Germany with FIP Coupon, a reservation/surcharge is required.
-{{% /highlight %}}
+{{< /highlight >}}
 
 **FIP Global Fare:** yes \
 _Tip:_ For journeys from Germany to Italy, use national free travel to Salzburg and board the Nightjet there to avoid the FIP Global Fare.
@@ -210,9 +210,9 @@ Local trains are often operated by other companies that do not accept FIP. In th
 
 Regional express trains connect towns and cities with stops at the main stations. Sometimes the trains also run long-distance routes.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Trains of the `RE` category are often operated by other companies.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -227,9 +227,9 @@ Trains of the `RE` category are often operated by other companies.
 
 Regional trains connect towns and cities with stops at almost all stations.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Trains of the `RB` category are often operated by other companies.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -244,9 +244,9 @@ Trains of the `RB` category are often operated by other companies.
 
 Local trains in large cities and metropolitan regions with stops at all stations.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Trains of the `S` category are often operated by other companies.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/db/index.fr.md
+++ b/content/operator/db/index.fr.md
@@ -130,14 +130,14 @@ Certains [services Nightjet](#nj) utilisent des voitures Intercity (IC). Ces voi
 
 Train express international entre Francfort et Milan ainsi qu’entre Munich et Zurich. Depuis décembre 2025, la catégorie est aussi utilisée pour d’autres liaisons entre la Suisse et l’Allemagne ainsi que sur de trains sur la route Hambourg – Copenhague.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les trains vers l’Italie sont soumis à supplément et réservation obligatoire à partir de la frontière italienne. Il est plus avantageux de voyager vers l’Italie avec un changement à Chiasso ([voir Arrivée Italie](/country/switzerland#italien "Arrivée Italie")). Le supplément peut être acheté au guichet DB ou SBB ou à bord.
 
 **Supplément/Réservation Italie :**
 
 - 1ʳᵉ classe : 13€
 - 2ᵉ classe : 11€
-  {{% /highlight %}}
+  {{< /highlight >}}
 
 #### Réservations
 
@@ -174,9 +174,9 @@ Pour les trajets transfrontaliers en été vers la République tchèque, une obl
 
 Trains de nuit de l’ÖBB en coopération avec la DB vers différents pays européens. Les trains proposent des voitures-lits, couchettes et places assises et sont exploités à l’étranger avec d’autres compagnies.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les trajets nationaux gratuits pour les employés de la Deutsche Bahn ne sont pas reconnus en Allemagne. Si une partie du trajet Nightjet est en Allemagne (départ, arrivée ou transit), les employés de la DB doivent acheter un billet au Tarif Global FIP pour tout le trajet. Pour les trajets hors d’Allemagne avec FIP Coupon, une réservation/supplément est nécessaire.
-{{% /highlight %}}
+{{< /highlight >}}
 
 **Tarif Global FIP :** oui \
 _Astuce :_ Pour les trajets Allemagne - Italie, utiliser les trajets nationaux gratuits jusqu’à Salzbourg puis prendre le Nightjet pour éviter le Tarif Global FIP.
@@ -210,9 +210,9 @@ Une orientation est fournie par les [cartes d’aperçu](https://www.schienennah
 
 Les trains Regionalexpress relient des villes avec des arrêts dans les principales gares. Certains circulent aussi sur de longues distances.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains de la catégorie `RE` sont souvent exploités par d’autres opérateurs.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -227,9 +227,9 @@ Les trains de la catégorie `RE` sont souvent exploités par d’autres opérate
 
 Les trains Regionalbahn relient des villes avec des arrêts dans presque toutes les gares.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains de la catégorie `RB` sont souvent exploités par d’autres opérateurs.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -244,9 +244,9 @@ Les trains de la catégorie `RB` sont souvent exploités par d’autres opérate
 
 Trains de proximité dans les grandes villes et régions métropolitaines avec arrêt à toutes les gares.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains de la catégorie `S` sont souvent exploités par d’autres opérateurs.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/dsb/index.de.md
+++ b/content/operator/dsb/index.de.md
@@ -102,11 +102,11 @@ Eine Reservierung ist bei einer grenzüberschreitenden Fahrt empfehlenswert, in 
 
 Regional-Züge stellen den Nahverkehr zwischen verschiedenen Orten sicher. Sie halten außerhalb des S-Bahn-Netzes in Kopenhagen an allen Stationen und sind daher eher langsam.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Auch Züge von anderen Anbietern werden als `R` angezeigt, daher unbedingt vorher schauen, ob der Betreiber des Zuges die DSB ist. \
 Züge, die als `RA` gekennzeichnet sind, werden nicht von der DSB betrieben und sind daher nicht mit FIP nutzbar. \
 Züge, die als `RE` gekennzeichnet sind, werden in der Regel von der DSB betrieben.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/dsb/index.en.md
+++ b/content/operator/dsb/index.en.md
@@ -102,11 +102,11 @@ A reservation is recommended for cross-border journeys and usually mandatory in 
 
 Regional trains provide local connections between various locations. Outside the S-train network in Copenhagen, they stop at all stations and are therefore slower.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Trains from other operators are also displayed as `R`, so always check beforehand if the operator is DSB. \
 Trains marked as `RA` are not operated by DSB and therefore not included in FIP. \
 Trains marked as `RE` are usually DSB operated trains.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/dsb/index.fr.md
+++ b/content/operator/dsb/index.fr.md
@@ -102,11 +102,11 @@ Une réservation est recommandée pour les trajets transfrontaliers et général
 
 Trains régionaux desservant toutes les gares hors du réseau S-tog de Copenhague.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 D’autres opérateurs utilisent aussi la catégorie `R` — vérifiez toujours que le train est bien exploité par DSB. \
 Les trains marqués `RA` ne sont pas exploités par DSB et ne sont donc pas inclus dans FIP. \
 Les trains marqués `RE` sont généralement exploités par DSB.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/fs/index.de.md
+++ b/content/operator/fs/index.de.md
@@ -45,9 +45,9 @@ Im Fernverkehr besteht eine Reservierungspflicht inkl. Aufschlägen.
 
 Höchste italienische Zuggattung im Fernverkehr mit Hochgeschwindigkeitszügen. Zusätzlich wird der Frecciarossa 1000 als Zug mit besonders hoher Geschwindigkeit und Service im Fahrplan gekennzeichnet.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Züge des privaten Anbieters Italo werden auch als AV gekennzeichnet, können jedoch nicht mit FIP genutzt werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 Preise [siehe Ticket- und Reservierungskauf](#ticket--und-reservierungskauf)
 
@@ -68,9 +68,9 @@ Der variable Reservierungspreis enthält immer einen Aufschlag bei Nutzung mit F
 
 Hochgeschwindigkeitszüge mit Neigetechnik.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Züge des privaten Anbieters Italo werden auch als AV gekennzeichnet, können jedoch nicht mit FIP genutzt werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 Preise [siehe Ticket- und Reservierungskauf](#ticket--und-reservierungskauf)
 
@@ -189,9 +189,9 @@ Der Reservierungspreis enthält immer einen Aufschlag bei Nutzung mit FIP Freifa
 
 Internationale Nachtzüge nach Deutschland, Österreich und in die Schweiz.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Nationale Freifahrten für Mitarbeitende der Deutschen Bahn werden in Deutschland nicht anerkannt. Liegt ein Teil der Nightjet Fahrt also in Deutschland (Start, Ende oder Durchreise) müssen Mitarbeitende der Deutschen Bahn für die gesamte Strecke ein Ticket zum FIP Globalpreis erwerben. Für Fahrten außerhalb Deutschlands mit FIP Freifahrtschein ist eine Reservierung/Aufpreis erforderlich.
-{{% /highlight %}}
+{{< /highlight >}}
 
 _Tipp:_ Für Fahrten von Deutschland nach Italien die nationalen Freifahrten bis Salzburg nutzen und dort in den Nightjet steigen, um den FIP Globalpreis zu vermeiden.
 
@@ -214,9 +214,9 @@ Der variable Reservierungspreis enthält immer einen Aufschlag bei Nutzung mit F
 
 Schnelle Regionalzüge mit Halt an den wichtigsten Stationen.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Tickets für Regionalzüge sind teilweise zuggebunden. Weitere Informationen siehe [Zugbindung im Nahverkehr](#zugbindung-im-nahverkehr)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -231,9 +231,9 @@ Tickets für Regionalzüge sind teilweise zuggebunden. Weitere Informationen sie
 
 Regionalzüge mit Halt an den meisten Stationen.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Tickets für Regionalzüge sind teilweise zuggebunden. Weitere Informationen siehe [Zugbindung im Nahverkehr](#zugbindung-im-nahverkehr)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -248,9 +248,9 @@ Tickets für Regionalzüge sind teilweise zuggebunden. Weitere Informationen sie
 
 S-Bahnsysteme im Großraum Neapel `M` und Großraum Turin `sfm`.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 U-Bahnen sind teilweise auch mit `M` gekennzeichnet und können nicht mit FIP genutzt werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/fs/index.en.md
+++ b/content/operator/fs/index.en.md
@@ -45,9 +45,9 @@ Reservations (with surcharges) are mandatory on long-distance trains.
 
 Highest Italian train category for long-distance high-speed trains. Frecciarossa 1000 is marked for higher speed and service.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Trains of the private operator Italo are also marked as AV but cannot be used with FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 Prices [see Ticket and Reservation Purchase](#ticket-and-reservation-purchase)
 
@@ -68,9 +68,9 @@ The variable reservation price always includes a surcharge when using a FIP Coup
 
 High-speed tilting trains.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Trains of the private operator Italo are also marked as AV but cannot be used with FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 Prices [see Ticket and Reservation Purchase](#ticket-and-reservation-purchase)
 
@@ -189,9 +189,9 @@ The reservation price always includes a surcharge when using a FIP Coupon.
 
 International night trains to Germany, Austria, and Switzerland.
 
-{{% highlight important %}}
+{{< highlight important >}}
 National free travel for Deutsche Bahn staff is not recognized in Germany. If any part of the Nightjet journey is in Germany, DB staff must buy a ticket at the FIP global fare for the entire route. For journeys outside Germany with a FIP Coupon, a reservation/supplement is required.
-{{% /highlight %}}
+{{< /highlight >}}
 
 _Tip:_ For trips from Germany to Italy, use national free travel to Salzburg and board the Nightjet there to avoid the FIP global fare.
 
@@ -214,9 +214,9 @@ The variable reservation price always includes a surcharge when using a FIP Coup
 
 Fast regional trains stopping at main stations.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Tickets for regional trains may be train-bound. See [Train binding in regional trains](#train-binding-in-regional-trains)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -231,9 +231,9 @@ Tickets for regional trains may be train-bound. See [Train binding in regional t
 
 Regional trains stopping at most stations.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Tickets for regional trains may be train-bound. See [Train binding in regional trains](#train-binding-in-regional-trains)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -248,9 +248,9 @@ Tickets for regional trains may be train-bound. See [Train binding in regional t
 
 Suburban rail systems in Naples (`M`) and Turin (`sfm`).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Metro lines are sometimes also marked as `M` and cannot be used with FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/fs/index.fr.md
+++ b/content/operator/fs/index.fr.md
@@ -45,9 +45,9 @@ La réservation (avec supplément) est obligatoire dans les trains longue distan
 
 Catégorie la plus élevée pour les trains à grande vitesse longue distance. Le Frecciarossa 1000 est signalé pour sa vitesse et son service supérieurs.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains du transporteur privé Italo sont aussi marqués AV mais ne sont pas accessibles avec FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 Voir les prix sous [Achat de billets et réservations](#achat-de-billets-et-réservations)
 
@@ -68,9 +68,9 @@ Le prix de la réservation inclut toujours un supplément avec un Coupon FIP.
 
 Trains à grande vitesse à pendulation.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains du transporteur privé Italo sont aussi marqués AV mais ne sont pas accessibles avec FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 Voir les prix sous [Achat de billets et réservations](#achat-de-billets-et-réservations)
 
@@ -191,9 +191,9 @@ Le prix de la réservation inclut toujours un supplément lors de l’utilisatio
 
 Trains de nuit internationaux vers l’Allemagne, l’Autriche et la Suisse.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les voyages gratuits nationaux pour les employés de la Deutsche Bahn ne sont pas reconnus en Allemagne. Si une partie du trajet Nightjet est en Allemagne, les employés DB doivent acheter un billet au Tarif Global FIP pour tout le trajet. Pour les trajets hors Allemagne avec un Coupon FIP, une réservation/supplément est nécessaire.
-{{% /highlight %}}
+{{< /highlight >}}
 
 _Astuce :_ Pour les trajets Allemagne–Italie, utilisez le voyage gratuit national jusqu’à Salzbourg puis prenez le Nightjet pour éviter le Tarif Global FIP.
 
@@ -216,9 +216,9 @@ Le prix de la réservation inclut toujours un supplément avec un Coupon FIP.
 
 Trains régionaux rapides desservant les principales gares.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les billets pour les trains régionaux peuvent être liés à un train spécifique. Voir [Billets liés à un train dans les trains régionaux](#billets-liés-à-un-train-dans-les-trains-régionaux)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -233,9 +233,9 @@ Les billets pour les trains régionaux peuvent être liés à un train spécifiq
 
 Trains régionaux desservant la plupart des gares.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les billets pour les trains régionaux peuvent être liés à un train spécifique. Voir [Billets liés à un train dans les trains régionaux](#billets-liés-à-un-train-dans-les-trains-régionaux)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -250,9 +250,9 @@ Les billets pour les trains régionaux peuvent être liés à un train spécifiq
 
 Réseaux suburbains à Naples (`M`) et Turin (`sfm`).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les lignes de métro sont parfois aussi marquées `M` et ne sont pas accessibles avec FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/gb/index.de.md
+++ b/content/operator/gb/index.de.md
@@ -127,9 +127,9 @@ Die Elizabeth Line bietet durchgehende S-Bahn-Verbindungen von Ost- nach West-Lo
 
 Es gibt keine Ticketschalter zwischen Abbey Wood und Canary Wharf, bei denen FIP 50 Tickets erworben werden können.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Von den Stationen der Elizabeth Line verkehren teilweise auch Linien der London Underground. Die Ticketschranken sind an diesen Stationen oftmals mit TfL-Personal besetzt. Um Verwirrungen vorzubeugen, sollte beim Vorzeigen des Freifahrtscheins die Nutzung der Elizabeth Line erwähnt werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -206,9 +206,9 @@ GWR betreibt auch einen Nachtzug von London nach Penzance – den reservierungsp
 
 Eine Reservierung für den Zug kann nicht online vorgenommen werden.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Im Night Riviera Sleeper besteht Reservierungspflicht.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/gb/index.en.md
+++ b/content/operator/gb/index.en.md
@@ -127,9 +127,9 @@ The Elizabeth Line offers continuous suburban connections from east to west Lond
 
 There are no ticket counters between Abbey Wood and Canary Wharf where FIP 50 Tickets can be purchased.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Some Elizabeth Line stations are also served by London Underground lines. Ticket barriers at these stations are often staffed by TfL personnel. To avoid confusion, mention the use of the Elizabeth Line when showing your FIP Coupon.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -206,9 +206,9 @@ GWR also operates a night train from London to Penzance – the Night Riviera Sl
 
 Reservations for this train cannot be made online.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Reservations are required for the Night Riviera Sleeper.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/gb/index.fr.md
+++ b/content/operator/gb/index.fr.md
@@ -127,9 +127,9 @@ La Elizabeth Line propose des liaisons suburbaines continues d’est en ouest à
 
 Il n’y a pas de guichets entre Abbey Wood et Canary Wharf où les Billets FIP 50 peuvent être achetés.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Certaines stations de la Elizabeth Line sont aussi desservies par le métro londonien. Les portiques de ces stations sont souvent surveillés par du personnel TfL. Pour éviter toute confusion, il convient de préciser l’utilisation de la Elizabeth Line lors de la présentation du Coupon FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -206,9 +206,9 @@ GWR exploite aussi un train de nuit de Londres à Penzance – le Night Riviera 
 
 La réservation pour ce train ne peut pas se faire en ligne.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Réservation obligatoire pour le Night Riviera Sleeper.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -494,9 +494,9 @@ Elle peut servir d’orientation ; toutefois, les offres individuelles doivent �
 | THAMES ROVER 7 DAYS         | TR7        | I367 | 60.50  | X      |
 | Waterside Wander Ranger     | WRR        | I437 | 6.75   | X      |
 
-{{% highlight important %}}
+{{< highlight important >}}
 FOSW ROVER 8 IN 15 DAYS est plus cher avec FIP 75.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /expander %}}
 

--- a/content/operator/gysev/index.de.md
+++ b/content/operator/gysev/index.de.md
@@ -50,9 +50,9 @@ Folgende Linien sind mit dem FIP Freifahrtschein der GySEV in Österreich in den
 
 Die GySEV betreibt Scarbantia `IC` Züge zwischen Sopron und Budapest.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 In Ungarn verkehren auch InterCity Züge der ungarischen Staatsbahn [MÁV](/operator/mav#ic).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -71,9 +71,9 @@ Reservierungen sind nur zwischen Győr und Budapest verpflichtend. Bei Fahrten z
 
 Schneller Nahverkehrszug mit weniger Halten und modernem Wagenmaterial.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regionalexpress-Züge werden teilweise auch von der ÖBB betrieben, bei denen FIP Fahrtkarten der GySEV nicht anerkannt werden. Im Zweifelsfall kann der Beförderer über die jeweilige Anbieterwebsite oder über [bahn.de](https://www.bahn.de) geklärt werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -88,9 +88,9 @@ Regionalexpress-Züge werden teilweise auch von der ÖBB betrieben, bei denen FI
 
 Nahverkehrszug mit Halten an den meisten Stationen.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regionalzüge werden teilweise auch von der ÖBB betrieben, bei denen FIP Fahrkarten der GySEV nicht anerkannt werden. Im Zweifelsfall kann der Beförderer über die jeweilige Anbieterwebsite oder über [bahn.de](https://www.bahn.de) geklärt werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -105,9 +105,9 @@ Regionalzüge werden teilweise auch von der ÖBB betrieben, bei denen FIP Fahrka
 
 Nahverkehrszug mit Halten an den meisten Stationen.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Személyvonat werden teilweise auch von der [MÁV](/operator/mav#sz) betrieben, bei denen FIP Fahrtkarten der GySEV nicht anerkannt werden. Im Zweifelsfall kann der Beförderer über die jeweilige Anbieterwebsite oder über [bahn.de](https://www.bahn.de) geklärt werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/gysev/index.en.md
+++ b/content/operator/gysev/index.en.md
@@ -50,9 +50,9 @@ The following lines can be used with the GySEV FIP Coupon in Austria in the spec
 
 GySEV operates Scarbantia IC trains between Sopron and Budapest.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 In Hungary, InterCity trains are also operated by MÁV, the Hungarian state railway.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -71,9 +71,9 @@ Reservations are only mandatory between Győr and Budapest. For journeys between
 
 Fast local train with fewer stops and modern rolling stock.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regionalexpress trains are sometimes also operated by ÖBB where GySEV FIP Tickets are not accepted. If in doubt, check the operator via the provider's website or [bahn.de](https://int.bahn.de/en).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -88,9 +88,9 @@ Regionalexpress trains are sometimes also operated by ÖBB where GySEV FIP Ticke
 
 Local train stopping at most stations.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regional trains are sometimes also operated by ÖBB where GySEV FIP Tickets are not accepted. If in doubt, check the operator via the provider's website or [bahn.de](https://int.bahn.de/en).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -105,9 +105,9 @@ Regional trains are sometimes also operated by ÖBB where GySEV FIP Tickets are 
 
 Local train stopping at most stations.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Személyvonat trains are sometimes also operated by [MÁV](/operator/mav#sz) where GySEV FIP Tickets are not accepted. If in doubt, check the operator via the provider's website or [bahn.de](https://int.bahn.de/en).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/gysev/index.fr.md
+++ b/content/operator/gysev/index.fr.md
@@ -50,9 +50,9 @@ Les lignes suivantes peuvent être utilisées avec le Coupon FIP GySEV en Autric
 
 GySEV exploite des trains Scarbantia `IC` entre Sopron et Budapest.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 En Hongrie, des trains InterCity de la compagnie ferroviaire d’État hongroise MÁV circulent également.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -71,9 +71,9 @@ Les réservations ne sont obligatoires qu’entre Győr et Budapest. Pour les tr
 
 Train régional rapide avec moins d’arrêts et matériel roulant moderne.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Certains trains Regionalexpress sont également exploités par les ÖBB où les Billets FIP GySEV ne sont pas acceptés. En cas de doute, vérifier le transporteur sur le site de l’opérateur ou sur [bahn.de](https://int.bahn.de/fr/).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -88,9 +88,9 @@ Certains trains Regionalexpress sont également exploités par les ÖBB où les 
 
 Train régional avec arrêts dans la plupart des gares.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Certains trains régionaux sont également exploités par les ÖBB où les Billets FIP GySEV ne sont pas acceptés. En cas de doute, vérifier le transporteur sur le site de l’opérateur ou sur [bahn.de](https://int.bahn.de/fr/).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -105,9 +105,9 @@ Certains trains régionaux sont également exploités par les ÖBB où les Bille
 
 Train régional avec arrêts dans la plupart des gares.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Certains trains Személyvonat sont également exploités par [MÁV](/operator/mav#sz) où les Billets FIP GySEV ne sont pas acceptés. En cas de doute, vérifier le transporteur sur le site de l’opérateur ou sur [bahn.de](https://int.bahn.de/fr/).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/ht/index.de.md
+++ b/content/operator/ht/index.de.md
@@ -39,12 +39,12 @@ Diese Züge verbinden Athen (Αθήνα) und Thessaloniki (Θεσσαλονίκ�
 
 Reservierungen sind vorab zwingend zu erwerben. Sie können online oder vor Ort gekauft werden.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Die IC-Züge sind häufiger einige Tage vorher ausgebucht. Es empfiehlt sich, sich rechtzeitig um eine Reservierung zu kümmern.
 
 Trick für Reisende mit FIP Freifahrtschein:
 Da online keine einzelnen Reservierungen verfügbar sind, buche zunächst ein FIP 50 Ticket. Dieses ist kostenfrei stornierbar. Vor Ort kannst du prüfen, ob noch Reservierungen verfügbar sind. Falls ja, storniere das FIP 50 Ticket, sonst fahre mit dem FIP 50 Ticket.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -61,9 +61,9 @@ Regionalzüge verbinden Städte und Regionen außerhalb der Hauptachse.
 
 Teilweise werden die Züge als Proastiakos oder Suburban Railway bezeichnet, was vergleichbar mit einer S-Bahn ist. In der Verbindungsauskunft erscheinen diese Verbindungen allerdings ebenfalls als Regionalzüge `REG`.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Touristische Verbindungen wie der Pelion-Train werden in der Verbindung ebenfalls als `REG` gekennzeichnet, allerdings gilt hier kein FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/ht/index.en.md
+++ b/content/operator/ht/index.en.md
@@ -39,12 +39,12 @@ These trains connect Athens (Αθήνα) and Thessaloniki (Θεσσαλονίκ�
 
 Reservations must be obtained in advance. They can be purchased online or on site.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 IC trains are frequently sold out a few days in advance. It is advisable to arrange a reservation in good time.
 
 Tip for travellers with an FIP Coupon:
 Since individual reservations are not available online, first book an FIP 50 Ticket. This can be cancelled free of charge. On site, you can check whether reservations are still available. If so, cancel the FIP 50 Ticket; otherwise, travel with the FIP 50 Ticket.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -61,9 +61,9 @@ Regional trains connect cities and regions outside the main axis.
 
 Some trains are referred to as Proastiakos or Suburban Railway, which is comparable to an S-Bahn. In the journey planner, these services also appear as regional trains `REG`.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Tourist services such as the Pelion Train are also shown as `REG` in the journey planner, but FIP is not valid on these.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/ht/index.fr.md
+++ b/content/operator/ht/index.fr.md
@@ -39,12 +39,12 @@ Ces trains relient Athènes (Αθήνα) et Thessalonique (Θεσσαλονίκ�
 
 Les réservations doivent être obtenues à l’avance. Elles peuvent être achetées en ligne ou en gare.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Les trains IC sont souvent complets quelques jours à l’avance. Il est conseillé de s’occuper de la réservation suffisamment tôt.
 
 Astuce pour les voyageurs avec un Coupon FIP :
 Comme les réservations individuelles ne sont pas disponibles en ligne, réservez d’abord un Billet FIP 50. Celui-ci peut être annulé gratuitement. Sur place, vous pouvez vérifier si des réservations sont encore disponibles. Si oui, annulez le Billet FIP 50 ; sinon, voyagez avec le Billet FIP 50.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -61,9 +61,9 @@ Les trains régionaux relient les villes et régions en dehors de l’axe princi
 
 Certains trains sont désignés sous le nom de Proastiakos ou Suburban Railway, ce qui est comparable à un S-Bahn. Dans le planificateur de voyage, ces services apparaissent également comme trains régionaux `REG`.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les services touristiques comme le Pelion Train sont également indiqués comme `REG` dans le planificateur de voyage, mais le FIP n’y est pas valable.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/mav/index.de.md
+++ b/content/operator/mav/index.de.md
@@ -41,9 +41,9 @@ Internationale Fernverkehrszüge in Kooperation mit ÖBB und weiteren Partnerbah
 
 Die Business Class ist für nationale Fahrten in Ungarn nicht verfügbar. Bei internationalen Fahrten kann die Business Class mit einem FIP Freifahrtschein oder FIP 50 Ticket der 1. Klasse genutzt werden. Es ist ein Aufschlag von 22 € zu zahlen.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `RJ` kann auch für RegioJet stehen. In RegioJet-Zügen gelten keine MÁV-FIP-Fahrkarten.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -62,9 +62,9 @@ Im Inlandsverkehr ist die Sitzplatzreservierung verpflichtend, im internationale
 
 Nationale Schnellzüge mit Reisezugwagen der zweiten Klasse, teilweise auch mit Wagen der ersten Klasse und der Premiumklasse 1+. Teilweise werden [Restaurant-Wagen](https://www.mavcsoport.hu/en/mav-szemelyszallitas/domestic-travels/utasellato-dining-cars) und/oder [Bistro-Wagen](https://www.mavcsoport.hu/en/mav-szemelyszallitas/domestic-travels/utasellato-bistro-cars) mitgeführt.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `IC` Züge in Ungarn werden teilweise auch von [GySEV](/operator/gysev#ic) betrieben.
-{{% /highlight %}}
+{{< /highlight >}}
 
 Es gibt teilweise bis zu drei Wagenklassen:
 
@@ -175,9 +175,9 @@ In Verbindungsauskunftsystemen außerhalb der MÁV werden die Züge ggf. als `IC
 
 Klassische Regionalzüge, die an allen Unterwegsbahnhöfen halten.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `SZ` Züge in Ungarn werden teilweise auch von [GySEV](/operator/gysev#sz) betrieben.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/mav/index.en.md
+++ b/content/operator/mav/index.en.md
@@ -41,9 +41,9 @@ International long-distance trains in cooperation with ÖBB and other partner ra
 
 Business Class is not available for domestic journeys within Hungary. For international journeys, Business Class can be used with a 1st-class FIP Coupon pass or FIP 50 ticket; a supplement of € 22 applies.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `RJ` can also stand for RegioJet. FIP tickets for MÁV are not valid on RegioJet trains.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -62,9 +62,9 @@ Seat reservations are mandatory for domestic traffic, optional for international
 
 National express trains with 2nd class passenger cars, some also with 1st class and premium class 1+ cars. Occasionally [restaurant cars](https://www.mavcsoport.hu/en/mav-szemelyszallitas/domestic-travels/utasellato-dining-cars) and/or [bistro cars](https://www.mavcsoport.hu/en/mav-szemelyszallitas/domestic-travels/utasellato-bistro-cars) are carried.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `IC` trains in Hungary are sometimes also operated by [GySEV](/operator/gysev#ic).
-{{% /highlight %}}
+{{< /highlight >}}
 
 There are sometimes up to three car classes:
 
@@ -175,9 +175,9 @@ In connection information systems outside of MÁV, the trains may be listed as `
 
 Classic regional trains that stop at all intermediate stations.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `SZ` trains in Hungary are sometimes also operated by [GySEV](/operator/gysev#sz).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/mav/index.fr.md
+++ b/content/operator/mav/index.fr.md
@@ -41,9 +41,9 @@ Trains internationaux longue distance en coopération avec ÖBB et d'autres chem
 
 La classe affaires n'est pas disponible pour les vols intérieurs en Hongrie. Pour les vols internationaux, elle peut être réservée avec un coupon FIP 1re classe ou un billet FIP 50 ; un supplément de 22 € est appliqué.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `RJ` peut aussi signifier RegioJet. Les billets FIP pour MÁV ne sont pas valables sur les trains RegioJet.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -62,9 +62,9 @@ Les réservations de places sont obligatoires pour le trafic intérieur, faculta
 
 Trains rapides nationaux avec voitures de voyageurs de 2e classe, certaines aussi avec voitures de 1ère classe et classe premium 1+. Occasionnellement, des [voitures restaurant](https://www.mavcsoport.hu/en/mav-szemelyszallitas/domestic-travels/utasellato-dining-cars) et/ou des [voitures bistro](https://www.mavcsoport.hu/en/mav-szemelyszallitas/domestic-travels/utasellato-bistro-cars) sont transportées.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains `IC` en Hongrie sont parfois aussi exploités par [GySEV](/operator/gysev#ic).
-{{% /highlight %}}
+{{< /highlight >}}
 
 Il y a parfois jusqu'à trois catégories de voitures :
 
@@ -175,9 +175,9 @@ Dans les systèmes d'information de connexion en dehors de MÁV, les trains peuv
 
 Trains régionaux classiques qui s'arrêtent à toutes les gares intermédiaires.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains `SZ` en Hongrie sont parfois aussi exploités par [GySEV](/operator/gysev#sz).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/ns/index.de.md
+++ b/content/operator/ns/index.de.md
@@ -47,11 +47,11 @@ Zuschläge müssen teilweise für Eurocity Direct und Intercity Direct Züge gez
 
 Hochgeschwindigkeitszüge der Deutschen Bahn, die in den Niederlanden von der NS übernommen werden. Sie verkehren zwischen Amsterdam und Deutschland (Köln / Frankfurt am Main bzw. Hannover / Berlin), können jedoch auch innerhalb der Niederlande zwischen Amsterdam und Arnhem bzw. Hengelo mit FIP Freifahrtschein ohne Aufschlag genutzt werden. Bei FIP 50 Tickets ist jedoch ein Zuschlag erforderlich.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Bei der Nutzung von FIP 50 Tickets im niederländischen Binnenverkehr muss ein [ICE Aufschlag](https://www.ns.nl/en/tickets/ice-supplement) in Höhe von 3 € pro Fahrt gezahlt werden. Bei Nutzung der FIP Freifahrt ist der Zuschlag nicht erforderlich.
 
 Der Aufschlag kann [Online](https://www.ns.nl/en/tickets/ice-supplement) bzw. in der NS-App oder vor Ort am Automaten bzw. Schalter gekauft werden. Vor Ort kann der Aufschlag auf eine OV-Chipkarte geladen werden. Ohne OV-Chipkarte wird eine zusätzliche Gebühr von 1,50 € für ein Einmalticket erhoben.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -161,9 +161,9 @@ Anders als in anderen Ländern keine wirklichen Fernzüge, sondern eher schnelle
 
 Regionalzüge mit mehr Halten als beim Intercity, aber trotzdem nur an wichtigeren Stationen.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die Züge der Kategorie Sneltrein / Regional-Express `RE`, unter anderem die Verbindungen Venlo – Hamm (Deutschland), Maastricht – Aachen (Deutschland) und Arnhem – Düsseldorf (Deutschland) sowie andere RE-Verbindungen werden nicht von der NS betrieben und sind mit FIP nicht nutzbar.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/ns/index.en.md
+++ b/content/operator/ns/index.en.md
@@ -47,11 +47,11 @@ Supplements must partly be paid for Eurocity Direct and Intercity Direct trains.
 
 High-speed trains of Deutsche Bahn, operated by NS in the Netherlands. They run between Amsterdam and Germany (Cologne / Frankfurt am Main or Hanover / Berlin), but can also be used within the Netherlands between Amsterdam and Arnhem or Hengelo with an FIP Coupon without a supplement. However, with FIP 50 Tickets, a supplement is required.
 
-{{% highlight important %}}
+{{< highlight important >}}
 When using FIP 50 Tickets for domestic travel within the Netherlands, an [ICE supplement](https://www.ns.nl/en/tickets/ice-supplement) of € 3 per journey must be paid. No supplement is required with FIP Coupons.
 
 The supplement can be purchased [online](https://www.ns.nl/en/tickets/ice-supplement), in the NS app, or at ticket machines/counters. On site, the supplement can be loaded onto an OV-chipkaart. Without an OV-chipkaart, an additional fee of € 1.50 is charged for a single-use ticket.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -161,9 +161,9 @@ Unlike in other countries, these are not true long-distance trains, but rather f
 
 Regional trains with more stops than Intercity, but still only at important stations.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Trains of the Sneltrein / Regional-Express `RE` category, including the connections Venlo – Hamm (Germany), Maastricht – Aachen (Germany), and Arnhem – Düsseldorf (Germany), as well as other RE connections, are not operated by NS and cannot be used with FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/ns/index.fr.md
+++ b/content/operator/ns/index.fr.md
@@ -47,11 +47,11 @@ Un supplément est partiellement nécessaire pour les trains Eurocity Direct et 
 
 Trains à grande vitesse de la Deutsche Bahn, exploités aux Pays-Bas par NS. Ils circulent entre Amsterdam et l’Allemagne (Cologne / Francfort-sur-le-Main ou Hanovre / Berlin), mais peuvent également être utilisés à l’intérieur des Pays-Bas entre Amsterdam et Arnhem ou Hengelo avec un Coupon FIP sans supplément. Avec un Billet FIP 50, un supplément est toutefois requis.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Lors de l’utilisation de Billets FIP 50 pour des trajets nationaux aux Pays-Bas, un [supplément ICE](https://www.ns.nl/en/tickets/ice-supplement) de 3 € par trajet doit être payé. Aucun supplément n’est requis avec un Coupon FIP.
 
 Le supplément peut être acheté [en ligne](https://www.ns.nl/en/tickets/ice-supplement), via l’application NS ou sur place au guichet ou au distributeur. Sur place, il peut être chargé sur une carte OV-chipkaart. Sans carte OV-chipkaart, des frais supplémentaires de 1,50 € s’appliquent pour un billet unique.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -161,9 +161,9 @@ Contrairement à d’autres pays, il ne s’agit pas de véritables trains longu
 
 Trains régionaux avec plus d’arrêts que les Intercity, mais uniquement dans les gares principales.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains de la catégorie Sneltrein / Regional-Express `RE`, notamment les liaisons Venlo – Hamm (Allemagne), Maastricht – Aix-la-Chapelle (Allemagne) et Arnhem – Düsseldorf (Allemagne), ainsi que d’autres liaisons RE, ne sont pas exploités par NS et ne sont pas accessibles avec FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/oebb/index.de.md
+++ b/content/operator/oebb/index.de.md
@@ -62,9 +62,9 @@ Nationale und internationale Schnellzüge der höchsten Kategorie der ÖBB. Die 
 
 Für Railjets nach Italien ist ab der italienischen Grenze ein Zuschlag zu zahlen. Siehe [Tarifliche Besonderheiten](#verkehr-nach-italien).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `RJ` ist gleichzeitig auch die Abkürzung für RegioJet, dort gelten keinerlei FIP-Farscheine.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -79,9 +79,9 @@ Für Railjets nach Italien ist ab der italienischen Grenze ein Zuschlag zu zahle
 
 Die meisten `IC` Züge auf den Hauptstrecken wurden nach und nach durch Railjets ersetzt. `IC` Züge verkehren weiterhin auf Nebenstrecken wie Graz – Linz, Graz – Salzburg, Graz – Innsbruck, Klagenfurt – Salzburg, Wien – Gmunden – Stainach-Irdning sowie ergänzend zu Railjets auf der Verbindung Wien–Lienz (Osttirol). Zudem gibt es `IC` Züge und `ICE` Züge auf einigen internationalen Strecken nach Deutschland in Zusammenarbeit mit der Deutschen Bahn, wobei der österreichische Abschnitt von der ÖBB betrieben wird.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Teilweise werden auch Regiojet Züge innerhalb von Österreich als `IC` gekennzeichnet, in diesen Züge sind FIP Tickets nicht gültig.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -128,9 +128,9 @@ Für Eurocitys nach Italien ist ab der italienischen Grenze ein Zuschlag zu zahl
 
 Nachtzüge der ÖBB in verschiedene europäische Länder. Die Züge bieten Schlaf- und Liegewagen sowie Sitzwagen an und werden im Ausland in Kooperation mit anderen Bahngesellschaften betrieben.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Nationale Freifahrten für Mitarbeitende der Deutschen Bahn werden in Deutschland nicht anerkannt. Liegt ein Teil der Nightjet Fahrt also in Deutschland (Start, Ende oder Durchreise) müssen Mitarbeiter der Deutschen Bahn für die gesamte Strecke ein Ticket zum FIP Globalpreis erwerben. Für Fahrten außerhalb Deutschlands mit FIP Freifahrtschein ist eine Reservierung/Aufpreis erforderlich.
-{{% /highlight %}}
+{{< /highlight >}}
 
 **FIP Globalpreis:** ja \
 _Tipp:_ Für Fahrten von Deutschland nach Italien, die nationalen Freifahrten bis Salzburg nutzen und dort in den Nightjet steigen, um den FIP Globalpreis zu vermeiden.
@@ -169,9 +169,9 @@ Für Nightjet Züge können Reservierungen/Aufpreise für Schlaf- und Liegewagen
 
 Schneller Nahverkehrszug mit weniger Halten und modernem Wagenmaterial.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regionalexpress-Züge werden teilweise auch von anderen privaten Bahngesellschaften betrieben bei denen FIP Fahrtkarten der ÖBB nicht anerkannt werden. Im Zweifelsfall kann der Beförderer über die jeweilige Anbieterwebsite oder über [bahn.de](https://www.bahn.de) geklärt werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -186,11 +186,11 @@ Regionalexpress-Züge werden teilweise auch von anderen privaten Bahngesellschaf
 
 Nahverkehrszug mit Halten an den meisten Stationen.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regionalzüge werden teilweise auch von anderen privaten Bahngesellschaften betrieben bei denen FIP Fahrtkarten der ÖBB nicht anerkannt werden. Im Zweifelsfall kann der Beförderer über die jeweilige Anbieterwebsite oder über [bahn.de](https://www.bahn.de) geklärt werden.
 
 Die Bezeichnung `R` Regionalzug wird in der Fahrplanauskunft der ÖBB auch für rein touristische Verkehre verwendet, bei denen keine FIP Fahrkarten gültig sind. Diese sind mit Fußnoten mit dem Hinweis „Sondertarif“ gekennzeichnet.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -205,7 +205,7 @@ Die Bezeichnung `R` Regionalzug wird in der Fahrplanauskunft der ÖBB auch für 
 
 Nahverkehrszug mindestens im Stundentakt mit Halt an allen Stationen. Vergleichbar mit einer S-Bahn.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Schnellbahnen werden teilweise auch von anderen privaten Bahngesellschaften betrieben, bei denen FIP Fahrtkarten der ÖBB nicht anerkannt werden. Im Zweifelsfall kann der Beförderer über die jeweilige Anbieterwebsite oder über [bahn.de](https://www.bahn.de) geklärt werden.
 
 Dazu gehören unter anderem:
@@ -214,7 +214,7 @@ Dazu gehören unter anderem:
 - S-Bahn Salzburg: S1 Salzburg – Lamprechtshausen, S11 Salzburg – Ostermiething (Salzburger Lokalbahn)
 - S-Bahn Steiermark: S11 Graz – Übelbach (Steiermarkbahn)
 - S6, S61 Graz – Wies-Eibiswald, S7 Graz – Köflach (Graz-Köflacher Eisenbahn)
-  {{% /highlight %}}
+  {{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/oebb/index.en.md
+++ b/content/operator/oebb/index.en.md
@@ -62,9 +62,9 @@ There are three classes:
 
 For Railjets to Italy, a supplement is payable from the Italian border. See [Special Tariff Conditions](#traffic-to-italy).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `RJ` is also the abbreviation for RegioJet, where no FIP Tickets are valid.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -79,9 +79,9 @@ For Railjets to Italy, a supplement is payable from the Italian border. See [Spe
 
 Most `IC` trains on main routes have gradually been replaced by Railjets. `IC` trains still operate on secondary routes such as Graz – Linz, Graz – Salzburg, Graz – Innsbruck, Klagenfurt – Salzburg, Vienna – Gmunden – Stainach-Irdning, and as supplements to Railjets on Vienna–Lienz (East Tyrol). There are also `IC` and `ICE` trains on some international routes to Germany in cooperation with Deutsche Bahn, with the Austrian section operated by ÖBB.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Some Regiojet trains within Austria are labeled as `IC`; FIP Tickets are not valid on these trains.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -128,9 +128,9 @@ For Eurocity trains to Italy, a supplement is payable from the Italian border. S
 
 ÖBB night trains to various European countries. They offer sleeper, couchette, and seating cars and are operated abroad in cooperation with other railways.
 
-{{% highlight important %}}
+{{< highlight important >}}
 National free travel for Deutsche Bahn staff is not recognized in Germany. If any part of the Nightjet journey is in Germany (start, end, or transit), DB staff must buy a ticket at the FIP Global Fare for the entire route. For journeys outside Germany with a FIP Coupon, a reservation/surcharge for sleeper/couchette cars is required.
-{{% /highlight %}}
+{{< /highlight >}}
 
 **FIP Global Fare:** yes \
 _Tip:_ For trips from Germany to Italy, use national free travel to Salzburg and board the Nightjet there to avoid the FIP Global Fare.
@@ -169,9 +169,9 @@ For Nightjet trains, reservations/surcharges for sleeper and couchette cars can 
 
 Fast local train with fewer stops and modern rolling stock.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regionalexpress trains are sometimes operated by other private railways where ÖBB FIP Tickets are not accepted. If in doubt, check the operator via the provider’s website or [bahn.de](https://int.bahn.de/en).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -186,11 +186,11 @@ Regionalexpress trains are sometimes operated by other private railways where Ö
 
 Local train stopping at most stations.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regional trains are sometimes operated by other private railways where ÖBB FIP Tickets are not accepted. If in doubt, check the operator via the provider’s website or [bahn.de](https://int.bahn.de/en).
 
 The designation `R` Regionalzug is also used in ÖBB’s journey planner for purely tourist services where FIP Tickets are not valid. These are marked with footnotes indicating “special fare.”
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -205,7 +205,7 @@ The designation `R` Regionalzug is also used in ÖBB’s journey planner for pur
 
 Local train at least hourly, stopping at all stations. Comparable to an S-Bahn.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 S-Bahn services are sometimes operated by other private railways where ÖBB FIP Tickets are not accepted. If in doubt, check the operator via the provider’s website or [bahn.de](https://int.bahn.de/en).
 
 Including:
@@ -214,7 +214,7 @@ Including:
 - S-Bahn Salzburg: S1 Salzburg – Lamprechtshausen, S11 Salzburg – Ostermiething (Salzburger Lokalbahn)
 - S-Bahn Styria: S11 Graz – Übelbach (Steiermarkbahn)
 - S6, S61 Graz – Wies-Eibiswald, S7 Graz – Köflach (Graz-Köflacher Eisenbahn)
-  {{% /highlight %}}
+  {{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/oebb/index.fr.md
+++ b/content/operator/oebb/index.fr.md
@@ -62,9 +62,9 @@ Il existe trois classes de voitures :
 
 Pour les Railjet vers l’Italie, un supplément est à payer à partir de la frontière italienne. Voir [Conditions spéciales](#conditions-tarifaires-spéciales).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `RJ` est aussi l’abréviation de RegioJet, où les Billets FIP ne sont pas valables.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -79,9 +79,9 @@ Pour les Railjet vers l’Italie, un supplément est à payer à partir de la fr
 
 La plupart des trains `IC` sur les axes principaux ont été progressivement remplacés par les Railjet. Les `IC` circulent encore sur des lignes secondaires comme Graz – Linz, Graz – Salzburg, Graz – Innsbruck, Klagenfurt – Salzburg, Vienne – Gmunden – Stainach-Irdning, ainsi qu’en complément des Railjet sur la liaison Vienne–Lienz (Tyrol oriental). Il existe aussi des trains `IC` et `ICE` sur certaines liaisons internationales vers l’Allemagne en coopération avec la Deutsche Bahn, la section autrichienne étant exploitée par ÖBB.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Certains trains Regiojet sont désignés comme `IC` en Autriche, mais les Billets FIP n’y sont pas valables.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -128,9 +128,9 @@ Pour les Eurocity vers l’Italie, un supplément est à payer à partir de la f
 
 Trains de nuit ÖBB vers plusieurs pays européens. Wagons couchettes, wagons-lits et places assises, exploités à l’étranger en coopération avec d’autres compagnies.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les Coupons FIP nationaux pour les employés de la Deutsche Bahn ne sont pas acceptés en Allemagne. Si une partie du trajet Nightjet est en Allemagne (départ, arrivée ou transit), les employés DB doivent acheter un billet au Tarif Global FIP pour l’ensemble du trajet. Pour les trajets hors Allemagne avec Coupon FIP, une réservation/supplément pour les couchettes ou wagons-lits est nécessaire.
-{{% /highlight %}}
+{{< /highlight >}}
 
 **Tarif Global FIP :** oui \
 _Astuce :_ Pour les trajets Allemagne–Italie, utiliser les Coupons FIP nationaux jusqu’à Salzbourg puis prendre le Nightjet pour éviter le Tarif Global FIP.
@@ -169,9 +169,9 @@ Les trains `D` sont principalement utilisés comme trains de renfort lors des p�
 
 Train régional rapide avec moins d’arrêts et matériel moderne.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Certains Regionalexpress sont exploités par des compagnies privées où les Billets FIP ÖBB ne sont pas acceptés. En cas de doute, vérifier le transporteur sur le site de l’opérateur ou sur [bahn.de](https://int.bahn.de/fr/).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -186,11 +186,11 @@ Certains Regionalexpress sont exploités par des compagnies privées où les Bil
 
 Train régional avec arrêts dans la plupart des gares.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Certains trains régionaux sont exploités par des compagnies privées où les Billets FIP ÖBB ne sont pas acceptés. En cas de doute, vérifier le transporteur sur le site de l’opérateur ou sur [bahn.de](https://int.bahn.de/fr/).
 
 La désignation `R` est aussi utilisée dans les horaires ÖBB pour des trains touristiques où les Billets FIP ne sont pas valables. Ceux-ci sont signalés par une note « tarif spécial ».
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -205,7 +205,7 @@ La désignation `R` est aussi utilisée dans les horaires ÖBB pour des trains t
 
 Train régional au moins toutes les heures, arrêt à toutes les gares. Comparable à un S-Bahn.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Certaines Schnellbahn sont exploitées par des compagnies privées où les Billets FIP ÖBB ne sont pas acceptés. En cas de doute, vérifier le transporteur sur le site de l’opérateur ou sur [bahn.de](https://int.bahn.de/fr/).
 
 Exemples :
@@ -214,7 +214,7 @@ Exemples :
 - S-Bahn Salzbourg : S1 Salzburg – Lamprechtshausen, S11 Salzburg – Ostermiething (Salzburger Lokalbahn)
 - S-Bahn Styrie : S11 Graz – Übelbach (Steiermarkbahn)
 - S6, S61 Graz – Wies-Eibiswald, S7 Graz – Köflach (Graz-Köflacher Eisenbahn)
-  {{% /highlight %}}
+  {{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/pkp/index.de.md
+++ b/content/operator/pkp/index.de.md
@@ -179,9 +179,9 @@ Abweichende Preise für internationale Verbindungen. [Weitere Informationen](htt
 
 Regionalzugverbindungen mit Halten an den meisten Bahnhöfen, die von Polregio betrieben werden. Diese Züge haben keine 1. Klasse.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regionalzüge werden in Polen teilweise auch von anderen Bahngesellschaften als Polregio betrieben. Diese haben teilweise ihre eigenen FIP-Ermäßigungen ([siehe Polen](/country/poland "Polen")).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/pkp/index.en.md
+++ b/content/operator/pkp/index.en.md
@@ -179,9 +179,9 @@ Different prices for international connections. [More information](https://www.i
 
 Regional train connections stopping at most stations, operated by Polregio. These trains do not have 1st class.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Regional trains in Poland are sometimes also operated by railway companies other than Polregio. These sometimes have their own FIP discounts. [See Poland](/country/poland "Poland")
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/pkp/index.fr.md
+++ b/content/operator/pkp/index.fr.md
@@ -176,9 +176,9 @@ Prix différents pour les connexions internationales. [Plus d’informations](ht
 
 Connexions de trains régionaux s’arrêtant à la plupart des gares, exploitées par Polregio. Ces trains n’ont pas de 1ère classe.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Les trains régionaux en Pologne sont parfois aussi exploités par d’autres compagnies ferroviaires que Polregio. Celles-ci ont parfois leurs propres réductions FIP. [Voir Pologne](/country/poland "Pologne")
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/sbb/index.de.md
+++ b/content/operator/sbb/index.de.md
@@ -128,9 +128,9 @@ Panoramazüge der SBB über die Gotthardbergstrecke von Mitte April bis Mitte Ok
 
 Eine besondere Reservierung für 24 CHF ist erforderlich.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Die Züge führen nur Wagen der 1. Klasse. Zu einem Freifahrschein der 2. Klasse ist daher ein Klassenübergang notwendig. Mit einem FIP-Ausweis der 2. Klasse gibt es keine Ermäßigung.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/sbb/index.en.md
+++ b/content/operator/sbb/index.en.md
@@ -128,9 +128,9 @@ SBB Panoramic trains via the classic Gotthard route running mid-April to mid-Oct
 
 A special reservation for 24 CHF is required.
 
-{{% highlight important %}}
+{{< highlight important >}}
 These trains are 1st class only. With a 2nd class coupon a 1st class upgrade is necessary. With a 2nd class FIP card there is no discount.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/sbb/index.fr.md
+++ b/content/operator/sbb/index.fr.md
@@ -128,9 +128,9 @@ Train panoramique des CFF prenant la ligne du Gothard classique de mi-avril à m
 
 Une réservation spéciale pour 24 CHF est requise.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Les trains ne sont composés que des voitures 1ère classe. Avec un permis FIP en 2ᵉ un surclassement est nécessaire. Avec une carte FIP en 2ᵉ aucune réduction est disponible.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/sncb/index.en.md
+++ b/content/operator/sncb/index.en.md
@@ -75,9 +75,9 @@ Unlike in other countries, these are not real long-distance trains, but rather f
 
 International train between Lelystad, Amsterdam and Brussels with stops in Almere, Schiphol, Rotterdam and Antwerp.
 
-{{% highlight important %}}
+{{< highlight important >}}
 For journeys within the Netherlands, special regulations apply, see [NS ECD](/operator/ns#ecd)
-{{% /highlight %}}
+{{< /highlight >}}
 
 ![Eurocity (Direct) Network](eurocity-map.en.svg)
 

--- a/content/operator/sncb/index.fr.md
+++ b/content/operator/sncb/index.fr.md
@@ -75,9 +75,9 @@ Contrairement à d’autres pays, il ne s’agit pas de véritables trains longu
 
 Train international entre Lelystad, Amsterdam et Bruxelles avec arrêts à Almere, Schiphol, Rotterdam et Anvers.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Pour les trajets aux Pays-Bas, des règles spéciales s’appliquent, voir [NS ECD](/operator/ns#ecd)
-{{% /highlight %}}
+{{< /highlight >}}
 
 ![Réseau Eurocity (Direct)](eurocity-map.fr.svg)
 

--- a/content/operator/sncf/index.de.md
+++ b/content/operator/sncf/index.de.md
@@ -54,13 +54,13 @@ Es gilt eine Reservierungspflicht in allen `TGV`, fast allen `IC` Zügen sowie e
 
 Der `TGV` inOui ist der Hochgeschwindigkeitszug von SNCF Voyageurs und verbindet zahlreiche Städte in Frankreich sowie internationale Ziele (z. B. München, Frankfurt am Main, Barcelona, Luxemburg, Brüssel, Mailand). Zusätzlich fahren `TGV` Lyria Züge von Frankreich in die Schweiz (Basel, Zürich, Lausanne, Genf).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die SNCF betreibt auch Low-Cost-Fernzüge unter dem Namen OUIGO, diese sind jedoch nicht mit FIP nutzbar.
-{{% /highlight %}}
+{{< /highlight >}}
 
-{{% highlight important %}}
+{{< highlight important >}}
 Es gelten Besonderheiten für grenzüberschreitende Verbindungen, siehe [Grenzüberschreitende TGV inOui / ICE Züge](#grenzüberschreitende-tgv-inoui--ice-züge).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -84,9 +84,9 @@ Die Reservierungspreise unterscheiden sich zwischen Zügen zur Hauptverkehrszeit
 
 Der OUIGO (Grand Vitesse) ist der Low-Cost-Hochgeschwindigkeitszug der SNCF und verbindet zahlreiche Städte in Frankreich sowie internationale Ziele. Zusätzlich gibt es OUIGO Classique Züge, die aus herkömmlichen Reisezugwagen bestehen.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Die SNCF betreibt auch `TGV` Züge unter dem Namen inOui, welche mit FIP nutzbar sind.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -101,9 +101,9 @@ Die SNCF betreibt auch `TGV` Züge unter dem Namen inOui, welche mit FIP nutzbar
 
 Internationale Hochgeschwindigkeitszüge der SNCF in Kooperation mit der Deutschen Bahn, die zwischen Frankreich (Paris Est, Straßburg) und Deutschland (Karlsruhe, Mannheim, Frankfurt am Main, Erfurt, Halle (Saale) und Berlin bzw. Stuttgart und München) verkehren. Im Juli und August gibt es samstags zudem [Direktzüge zwischen Frankfurt (Main) und Bordeaux](https://www.bahn.de/angebot/urlaub/bahnreisen/summerrail/bordeaux).
 
-{{% highlight important %}}
+{{< highlight important >}}
 Es gelten Besonderheiten für grenzüberschreitende Verbindungen, siehe [Grenzüberschreitende TGV inOui / ICE Züge](#grenzüberschreitende-tgv-inoui--ice-züge).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 
@@ -172,9 +172,9 @@ Kosten abhängig von Strecke und Auslastung.
 Der `TER` ist ein Regionalzug, der verschiedene Städte in Frankreich verbindet.
 Auf einigen Linien von Paris aus gibt es eine Reservierungspflicht, siehe [Reservierungspflicht im Regionalverkehr](#reservierungspflicht-im-regionalverkehr).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Auf der Strecke Marseille – Nice betreibt Transdev die Züge, weshalb FIP nicht akzeptiert wird. Auf der Strecke Marseille – Toulon werden jedoch auch Züge der SNCF eingesetzt, bei denen FIP akzeptiert wird. Eine vorige Prüfung des Betreibers ist hier zwingend notwendig.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -189,9 +189,9 @@ Auf der Strecke Marseille – Nice betreibt Transdev die Züge, weshalb FIP nich
 
 Der RER ist ein S-Bahn ähnlicher Zug der SNCF, der in Île de France (Großraum Paris) und umliegenden Städten verkehrt.
 
-{{% highlight important %}}
+{{< highlight important >}}
 FIP gilt nur eingeschränkt in `RER` Zügen, siehe [Züge im Großraum Paris](#züge-im-großraum-paris)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/sncf/index.en.md
+++ b/content/operator/sncf/index.en.md
@@ -54,13 +54,13 @@ Reservations are mandatory on all `TGV`, almost all `IC` trains, and some region
 
 The `TGV` inOui is SNCF Voyageurs's high-speed train, connecting many cities in France and international destinations (e.g. Munich, Frankfurt am Main, Barcelona, Luxembourg, Brussels, Milan). Additionally, `TGV` Lyria trains run from France to Switzerland (Basel, Zurich, Lausanne, Geneva).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 SNCF also operates low-cost long-distance trains under the OUIGO brand, but these are not valid with FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
-{{% highlight important %}}
+{{< highlight important >}}
 Special conditions apply for international connections, see [International TGV inOui / ICE trains](#international-tgv-inoui--ice-trains).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -84,9 +84,9 @@ Prices differ between peak and off-peak trains for national journeys. The classi
 
 OUIGO (Grande Vitesse) is SNCF's low-cost high-speed train connecting numerous cities in France and some international destinations. There are also OUIGO Classique trains composed of conventional coaching stock.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 SNCF also operates `TGV` trains under the inOui brand, which are valid with FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -101,9 +101,9 @@ SNCF also operates `TGV` trains under the inOui brand, which are valid with FIP.
 
 International high-speed trains operated by SNCF in cooperation with Deutsche Bahn, running between France (Paris Est, Strasbourg) and Germany (Karlsruhe, Mannheim, Frankfurt am Main, Erfurt, Halle (Saale) and Berlin or Stuttgart and Munich). In July and August, there are also [direct trains between Frankfurt (Main) and Bordeaux on Saturdays](https://www.bahn.de/angebot/urlaub/bahnreisen/summerrail/bordeaux).
 
-{{% highlight important %}}
+{{< highlight important >}}
 Special conditions apply for international connections, see [International TGV inOui / ICE trains](#international-tgv-inoui--ice-trains).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 
@@ -172,9 +172,9 @@ Cost depends on route and occupancy.
 `TER` is SNCF's regional train, connecting various cities in France.
 Some lines from Paris require reservations, see [Reservation requirement in regional trains](#reservation-requirement-in-regional-trains).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 On the Marseille – Nice route, Transdev operates the trains, so FIP is not accepted. However, on the Marseille – Toulon route, SNCF trains are also used, where FIP is accepted. Prior verification of the operator is essential here.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -189,9 +189,9 @@ On the Marseille – Nice route, Transdev operates the trains, so FIP is not acc
 
 RER is a suburban train operated by SNCF in Île de France (Greater Paris) and surrounding cities.
 
-{{% highlight important %}}
+{{< highlight important >}}
 FIP is only valid on certain RER lines, see [Trains in Greater Paris](#trains-in-greater-paris)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/sncf/index.fr.md
+++ b/content/operator/sncf/index.fr.md
@@ -54,13 +54,13 @@ La réservation est obligatoire dans tous les `TGV`, presque tous les trains `IC
 
 Le `TGV` inOui est le train à grande vitesse des SNCF Voyageurs, reliant de nombreuses villes françaises et des destinations internationales (ex. Munich, Francfort, Barcelone, Luxembourg, Bruxelles, Milan). Des trains `TGV` Lyria relient également la France à la Suisse (Bâle, Zurich, Lausanne, Genève).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 La SNCF exploite aussi des trains longue distance low-cost sous la marque OUIGO, mais ceux-ci ne sont pas valables avec FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
-{{% highlight important %}}
+{{< highlight important >}}
 Des conditions particulières s’appliquent pour les liaisons internationales, voir [Trains TGV inOui / ICE internationaux](#trains-tgv-inoui--ice-internationaux).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -84,9 +84,9 @@ Les prix de réservation diffèrent entre les trains en période de pointe (Peak
 
 OUIGO (Grande Vitesse) est le service grande vitesse low-cost de la SNCF, reliant de nombreuses villes en France et quelques destinations internationales. Il existe également des OUIGO Classique composés de matériel conventionnel.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 La SNCF exploite aussi des `TGV` sous la marque inOui, qui sont valables avec le FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -101,9 +101,9 @@ La SNCF exploite aussi des `TGV` sous la marque inOui, qui sont valables avec le
 
 Trains à grande vitesse internationaux exploités par la SNCF en coopération avec la Deutsche Bahn, entre la France (Paris Est, Strasbourg) et l’Allemagne (Karlsruhe, Mannheim, Francfort-sur-le-Main, Erfurt, Halle-sur-Saale et Berlin ou Stuttgart et Munich). En juillet et août, il existe également des [trains directs entre Francfort (Main) et Bordeaux les samedis](https://www.bahn.de/angebot/urlaub/bahnreisen/summerrail/bordeaux).
 
-{{% highlight important %}}
+{{< highlight important >}}
 Des conditions particulières s’appliquent pour les liaisons internationales, voir [Trains TGV inOui / ICE internationaux](#trains-tgv-inoui--ice-internationaux).
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 
@@ -174,9 +174,9 @@ Coût selon la ligne et l’affluence.
 Le `TER` est le train régional reliant différentes villes françaises.
 Certaines lignes au départ de Paris sont à réservation obligatoire, voir [Réservation obligatoire en TER](#réservation-obligatoire-en-ter).
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 Sur la ligne Marseille – Nice, Transdev exploite les trains, c’est pourquoi FIP n’est pas accepté. Cependant, sur la ligne Marseille – Toulon, des trains de la SNCF sont également utilisés, où FIP est accepté. Une vérification préalable de l’exploitant est donc indispensable ici.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -191,9 +191,9 @@ Sur la ligne Marseille – Nice, Transdev exploite les trains, c’est pourquoi 
 
 Le RER est un train de banlieue exploité par la SNCF en Île-de-France (région parisienne) et villes alentours.
 
-{{% highlight important %}}
+{{< highlight important >}}
 FIP n’est valable que sur certains tronçons du RER, voir [Trains en Île-de-France](#trains-en-île-de-france)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/sp/index.de.md
+++ b/content/operator/sp/index.de.md
@@ -150,9 +150,9 @@ Die Ferrovie autolinee regionali ticinesi (FART) betreibt neben einigen Buslinie
 
 Auch wenn die Centovallibahn nach Italien führt, sind FIP-Tickets der SP auf der kompletten Strecke gültig, da der italienische Abschnitt von der SSIF, ebenfalls SP FIP-Mitglied, betrieben wird.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In einigen Zügen ist ein Panoramaaufschlag in Höhe von 1,50 € zu zahlen. Die betroffenen Zugverbindungen sind nur [Online auf der Centovalli Website](https://www.vigezzinacentovalli.com/de/informationen/zuege-mit-zuschlag/) und nicht über die Verbindungsauskunft einsehbar. Der Zuschlag kann [online](https://www.vigezzinacentovalli.com/de/informationen/zuege-mit-zuschlag/) oder vor Ort im Zug erworben werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 Außerdem werden von FART zwei Kleinseilbahnen betrieben. Bei diesen ist nicht bekannt, ob hier FIP anerkannt wird.
 
@@ -251,9 +251,9 @@ Auf folgenden Routen werden keine FIP Vergünstigungen gewährt:
 - Seilbahn Mürren – Allmendhubel (SMA)
 - Luftseilbahn Stechelberg – Mürren – Schilthorn (LSMS)
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 Uns wurde berichtet, dass die Mitnahme von Wintersportausrüstung (Ski, Snowboard) bei den Jungfraubahnen bei der Nutzung von FIP nicht möglich ist.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -503,9 +503,9 @@ Eine Reservierung ist erforderlich für den Glacier Express, siehe [eigener Absc
 
 Die Schweizerische Südostbahn betreibt Linienverkehr sowohl auf eigenen als auch einigen Strecken der SBB. In Kooperation mit der SBB werden auch die überregional bekannten Züge Voralpen-Express/Treno Gottardo, Alpenrhein-Express und der Aare Linth durch die SOB betrieben.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Bei FIP-Vergünstigungen ist zu beachten, dass die Freifahrtscheine für SP nicht auf Strecken gelten, auf denen die SOB in Kooperation mit der SBB verkehrt, so zum Beispiel zwischen Basel SBB und Arth-Goldau. Auf diesen Routen gelten stattdessen nur FIP Freifahrtscheine der SBB. Durchgehende FIP 50 Tickets sind dagegen möglich.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Strecken ohne SBB Kooperation (Freifahrtschein SP erforderlich)
 
@@ -531,9 +531,9 @@ Die Società Subalpina di Imprese Ferroviarie betreibt den italienischen Abschni
 
 FIP-Tickets der SP sind auf der kompletten Strecke gültig, auch auf dem Schweizer Abschnitt, da dieser durch die FART betrieben wird, die ebenfalls Teil von SP ist.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In einigen Zügen ist ein Panoramaaufschlag in Höhe von 1,50 € zu zahlen. Die betroffenen Zugverbindungen sind nur [Online auf der Centovalli Website](https://www.vigezzinacentovalli.com/de/informationen/zuege-mit-zuschlag/) und nicht über die Verbindungsauskunft einsehbar. Der Zuschlag kann [online](https://www.vigezzinacentovalli.com/de/informationen/zuege-mit-zuschlag/) oder vor Ort im Zug erworben werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 

--- a/content/operator/sp/index.en.md
+++ b/content/operator/sp/index.en.md
@@ -150,9 +150,9 @@ The Ferrovie Autolinee Regionali Ticinesi (FART) operates, in addition to severa
 
 Even though the Centovallibahn leads to Italy, FIP tickets from SP are valid for the entire route, as the Italian section is operated by SSIF, which is also a member of SP FIP.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In some trains, a panorama surcharge of €1.50 must be paid. The affected train connections can only be viewed [online on the Centovalli website](https://www.vigezzinacentovalli.com/en/information/trains-with-supplement/) and not through the connection information. The surcharge can be purchased [online](https://www.vigezzinacentovalli.com/en/information/trains-with-supplement/) or on-site in the train.
-{{% /highlight %}}
+{{< /highlight >}}
 
 Additionally, FART operates two small cable cars. It is not known whether FIP is accepted here.
 
@@ -251,9 +251,9 @@ No FIP discounts are granted on the following routes:
 - Mürren – Allmendhubel funicular (SMA)
 - Stechelberg – Mürren – Schilthorn aerial cableway (LSMS)
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 It has been reported to us that the transport of winter sports equipment (skis, snowboards) on the Jungfrau Railways is not possible when using FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -503,9 +503,9 @@ A reservation is required for the Glacier Express; see the [dedicated section](#
 
 The Schweizerische Südostbahn (SOB) operates scheduled services on both its own lines and some SBB routes. In cooperation with SBB, SOB also operates the internationally known trains Voralpen-Express/Treno Gottardo, Alpenrhein-Express, and the Aare Linth.
 
-{{% highlight important %}}
+{{< highlight important >}}
 When using FIP discounts, note that SP Coupons are not valid on routes where SOB operates in cooperation with SBB, for example between Basel SBB and Arth-Goldau. On these routes, only SBB FIP Coupons are valid instead. However, continuous FIP 50 Tickets are possible.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Routes without SBB cooperation (SP Coupon required)
 
@@ -531,9 +531,9 @@ Società Subalpina di Imprese Ferroviarie operates the Italian section of the Ce
 
 SP FIP tickets are valid on the entire route, including the Swiss section, as this is operated by FART, which is also part of SP.
 
-{{% highlight important %}}
+{{< highlight important >}}
 In some trains, a panorama surcharge of €1.50 must be paid. The affected train connections can only be viewed [online on the Centovalli website](https://www.vigezzinacentovalli.com/en/information/trains-with-supplement/) and not through the connection information. The surcharge can be purchased [online](https://www.vigezzinacentovalli.com/en/information/trains-with-supplement/) or on-site in the train.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 

--- a/content/operator/sp/index.fr.md
+++ b/content/operator/sp/index.fr.md
@@ -150,9 +150,9 @@ Ferrovie Autolinee Regionali Ticinesi (FART) exploite, outre quelques lignes d�
 
 Bien que la Centovallibahn mène en Italie, les billets FIP de SP sont valables sur l’ensemble de la ligne, car la section italienne est exploitée par la SSIF, également membre SP du FIP.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Dans certains trains, un supplément de panorama de 1,50 € doit être payé. Les liaisons de train concernées ne sont visibles que [en ligne sur le site de Centovalli](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) et non via le service d’information sur les connexions. Le supplément peut être acheté [en ligne](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) ou sur place dans le train.
-{{% /highlight %}}
+{{< /highlight >}}
 
 FART exploite également deux petits téléphériques. Il n’est pas connu si le FIP est reconnu sur ceux-ci.
 
@@ -251,9 +251,9 @@ Aucune réduction FIP n’est accordée sur les lignes suivantes :
 - Funiculaire Mürren – Allmendhubel (SMA)
 - Téléphérique Stechelberg – Mürren – Schilthorn (LSMS)
 
-{{% highlight inofficial %}}
+{{< highlight inofficial >}}
 Il nous a été signalé que le transport d'équipements de sports d'hiver (ski, snowboard) sur les Jungfraubahn n'est pas possible lors de l'utilisation du FIP.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -503,9 +503,9 @@ Pour le Glacier Express, des réservations payantes doivent être achetées à l
 
 La Schweizerische Südostbahn (SOB) exploite des services réguliers à la fois sur ses propres lignes et sur certaines lignes de la CFF. En coopération avec la CFF, les trains régionaux connus tels que le Voralpen-Express/Treno Gottardo, l’Alpenrhein-Express et l’Aare Linth sont également exploités par la SOB.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Il est à noter que les Coupons FIP ne sont pas valables sur les lignes où la SOB opère en coopération avec la CFF, par exemple entre Bâle CFF et Arth-Goldau. Sur ces itinéraires, seuls les Coupons FIP de la CFF sont valables. En revanche, les billets FIP 50 sont possibles.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Lignes sans coopération CFF (Coupon FIP SP requis)
 
@@ -531,9 +531,9 @@ La Società Subalpina di Imprese Ferroviarie exploite la section italienne de la
 
 Les billets FIP SP sont valables sur l’ensemble de la ligne, y compris la section suisse, car celle-ci est exploitée par la FART, également membre de SP.
 
-{{% highlight important %}}
+{{< highlight important >}}
 Dans certains trains, un supplément de panorama de 1,50 € doit être payé. Les liaisons de train concernées ne sont visibles que [en ligne sur le site de Centovalli](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) et non via le service d’information sur les connexions. Le supplément peut être acheté [en ligne](https://www.vigezzinacentovalli.com/fr/informations/trains-avec-supplement/) ou sur place dans le train.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 

--- a/content/operator/vy/index.de.md
+++ b/content/operator/vy/index.de.md
@@ -74,12 +74,12 @@ Auf den Linien F4, F5, F6 und F7 ist eine Reservierung erforderlich:
 | PlusNight {{< icon "bedtime" >}}                                                             | 500 kr (F5, F6) <br> 680 kr (F4)                 | 0 kr                  |
 | Sleeper {{< icon "bedtime" >}} <br><small>Reservierung ist für zwei Personen gültig.</small> | 1000 kr (F5) <br> 1250 kr (F6) <br> 1350 kr (F4) | 0 kr                  |
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 **Nachtzug: Aufenthalt, Dusche und Früstück**
 
 Die Bahngesellschaften betreiben Kooperationen mit lokalen Hotels.
 Mit einem Ticket für den Nachtzug kann man die Zeit bis zur Abfahrt in der Hotel-Lobby verbringen. Nach Ankunft des Zuges kann zu einem guten Preis-Leistungs-Verhältnis im Hotel gefrühstückt und/oder geduscht werden.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -101,9 +101,9 @@ Der Regionekspress verbindet Orte und Städte mit Halten an den wichtigsten Stat
 - RE20: Oslo S – Halden – (Göteborg – Malmö)
 - RE30: Oslo S – Nittedal – Jaren/Gjøvik (Gjøvikbanen)
 
-{{% highlight important %}}
+{{< highlight important >}}
 Auf dem RE20 wird FIP nur zwischen Oslo S und Halden anerkannt, aber nicht bei der grenzüberschreitenden Fahrt.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -182,9 +182,9 @@ Züge, welche mit X markiert sind, halten nicht an allen Stationen (z. B. L2x).
 
 Flytoget ist der Flughafenexpress zwischen Oslo Airport und Oslo S. FIP-Vergünstigungen können hier nicht genutzt werden.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Alternativ können jedoch die Regionalzuglinien R10, R11 und R12 für die Fahrt zum Flughafen mit FIP genutzt werden. Weitere Informationen im Abschnitt [Oslo Airport](#oslo-airport)
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/vy/index.en.md
+++ b/content/operator/vy/index.en.md
@@ -74,12 +74,12 @@ Reservations are compulsory on lines F4, F5, F6 and F7:
 | PlusNight {{< icon "bedtime" >}}                                                           | 500 kr (F5, F6) <br> 680 kr (F4)                 | 0 kr               |
 | Sleeper {{< icon "bedtime" >}} <br><small>The reservation is valid for two people.</small> | 1000 kr (F5) <br> 1250 kr (F6) <br> 1350 kr (F4) | 0 kr               |
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 **Night train: stay, shower and breakfast**
 
 The railway companies cooperate with local hotels.
 With a ticket for the night train, you can spend the time until departure in the hotel lobby. After the train arrives, breakfast and/or a shower can be booked at the hotel at a good price-performance ratio.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -101,9 +101,9 @@ Regionekspress connects towns and cities with stops at the main stations. Some t
 - RE20: Oslo S – Halden – (Gothenburg – Malmö)
 - RE30: Oslo S – Nittedal – Jaren/Gjøvik (Gjøvik Line)
 
-{{% highlight important %}}
+{{< highlight important >}}
 On RE20, FIP is recognized only between Oslo S and Halden, but not on the cross-border journey.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -182,9 +182,9 @@ Trains marked with X do not stop at all stations (for example L2x).
 
 Flytoget is the airport express between Oslo Airport and Oslo S. FIP Discounts cannot be used here.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 Alternatively, regional train lines R10, R11 and R12 can be used with FIP for the journey to the airport. More information in the [Oslo Airport](#oslo-airport) section.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/vy/index.fr.md
+++ b/content/operator/vy/index.fr.md
@@ -74,12 +74,12 @@ Les réservations sont obligatoires sur les lignes F4, F5, F6 et F7 :
 | PlusNight {{< icon "bedtime" >}}                                                                  | 500 kr (F5, F6) <br> 680 kr (F4)                 | 0 kr                 |
 | Sleeper {{< icon "bedtime" >}} <br><small>La réservation est valable pour deux personnes.</small> | 1000 kr (F5) <br> 1250 kr (F6) <br> 1350 kr (F4) | 0 kr                 |
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 **Train de nuit : séjour, douche et petit-déjeuner**
 
 Les compagnies ferroviaires coopèrent avec des hôtels locaux.
 Avec un billet pour le train de nuit, il est possible de passer le temps jusqu’au départ dans le hall de l’hôtel. Après l’arrivée du train, il est possible de prendre un petit-déjeuner et/ou une douche à l’hôtel avec un bon rapport qualité-prix.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -101,9 +101,9 @@ Le Regionekspress relie des localités et des villes avec des arrêts dans les p
 - RE20 : Oslo S – Halden – (Göteborg – Malmö)
 - RE30 : Oslo S – Nittedal – Jaren/Gjøvik (ligne de Gjøvik)
 
-{{% highlight important %}}
+{{< highlight important >}}
 Sur le RE20, le FIP n’est reconnu qu’entre Oslo S et Halden, mais pas pour le trajet transfrontalier.
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 
@@ -182,9 +182,9 @@ Les trains marqués d’un X ne s’arrêtent pas dans toutes les gares (par exe
 
 Flytoget est l’express aéroportuaire entre Oslo Airport et Oslo S. Les Réductions FIP ne peuvent pas y être utilisées.
 
-{{% highlight tip %}}
+{{< highlight tip >}}
 En alternative, les lignes de trains régionaux R10, R11 et R12 peuvent être utilisées avec FIP pour se rendre à l’aéroport. Plus d’informations dans la section [Aéroport d’Oslo](#aéroport-doslo).
-{{% /highlight %}}
+{{< /highlight >}}
 
 {{% /train-category %}}
 

--- a/content/operator/zssk/index.de.md
+++ b/content/operator/zssk/index.de.md
@@ -80,9 +80,9 @@ Grenzüberschreitende Fernzüge, die eigenwirtschaftlich von der ZSSK und CD erb
 
 Grenzüberschreitende Züge zwischen der Slowakei und Tschechien, Österreich oder Ungarn. Sie verkehren oft mit wenigen Halten und im Vergleich relativ hoher Durchschnittsgeschwindigkeit. Die `RJ` Züge sind Railjet-Züge der Österreichischen Bundesbahn, die auf slowakischem Abschnitt auch mit ZSSK-Freifahrtscheinen genutzt werden können.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `RJ` ist gleichzeitig auch die Abkürzung für RegioJet, dort gelten keinerlei FIP-Farscheine.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservierungen
 

--- a/content/operator/zssk/index.en.md
+++ b/content/operator/zssk/index.en.md
@@ -80,9 +80,9 @@ Cross-border long-distance trains operated commercially by ZSSK and CD, usually 
 
 Cross-border trains between Slovakia and the Czech Republic, Austria, or Hungary. They often run with few stops and relatively high average speed. `RJ` trains are Railjet trains of the Austrian Federal Railways, which can also be used with ZSSK Coupons on the Slovak section.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `RJ` is also the abbreviation for RegioJet, where no FIP Tickets are valid.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Reservations
 

--- a/content/operator/zssk/index.fr.md
+++ b/content/operator/zssk/index.fr.md
@@ -80,9 +80,9 @@ Trains longue distance transfrontaliers exploités commercialement par ZSSK et C
 
 Trains transfrontaliers entre la Slovaquie et la République tchèque, l’Autriche ou la Hongrie. Ils circulent souvent avec peu d’arrêts et une vitesse moyenne relativement élevée. Les trains `RJ` sont des Railjet des chemins de fer autrichiens, utilisables avec les coupons ZSSK sur la section slovaque.
 
-{{% highlight confusion %}}
+{{< highlight confusion >}}
 `RJ` est aussi l’abréviation de RegioJet, où les Billets FIP ne sont pas valables.
-{{% /highlight %}}
+{{< /highlight >}}
 
 #### Réservations
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -263,7 +263,7 @@ collections:
         i18n: true
         editor_components:
           - "image"
-          - "highlight"
+          - "highlight-raw"
           - "expander"
           - "booking-section"
           - "button"

--- a/static/admin/shortcodes.js
+++ b/static/admin/shortcodes.js
@@ -176,6 +176,22 @@
     }),
   });
 
+  CMS.registerEditorComponent({
+    id: "highlight-raw",
+    label: "Highlight",
+    fields: highlightFields,
+    pattern: shortcodePattern("highlight"),
+    fromBlock: function (match) {
+      return { type: match[1].trim(), body: match[2].trim() };
+    },
+    toBlock: makeToBlock("highlight", {
+      bracket: "<",
+      fields: highlightFields,
+      bodyMode: "required",
+      bodySeparator: "\n",
+    }),
+  });
+
   var expanderFields = [
     {
       name: "title",
@@ -195,7 +211,7 @@
       name: "body",
       label: "Content",
       widget: "markdown",
-      editor_components: ["button", "float-image", "highlight", "image"],
+      editor_components: ["button", "float-image", "highlight-raw", "image"],
     },
   ];
 
@@ -371,7 +387,7 @@
       name: "body",
       label: "Description",
       widget: "markdown",
-      editor_components: ["button", "float-image", "highlight", "image"],
+      editor_components: ["button", "float-image", "highlight-raw", "image"],
     },
   ];
 
@@ -508,7 +524,7 @@
       label: "Additional info",
       widget: "markdown",
       required: false,
-      editor_components: ["button", "float-image", "highlight", "image"],
+      editor_components: ["button", "float-image", "image"],
     },
   ];
 
@@ -554,7 +570,7 @@
       name: "body",
       label: "Content",
       widget: "markdown",
-      editor_components: ["button", "float-image", "highlight", "image"],
+      editor_components: ["button", "float-image", "highlight-raw", "image"],
     },
   ];
 
@@ -672,7 +688,7 @@
       label: "Additional info",
       widget: "markdown",
       required: false,
-      editor_components: ["button", "float-image", "highlight", "image"],
+      editor_components: ["button", "float-image", "image"],
     },
   ];
 


### PR DESCRIPTION
If a highlight is rendered in a context that will be parsed by another Markdown parser in the sounding content, for example in the train category content or in booking expanders, the Markdown is double-parsed when using `{{% highlight %}}`. While this is usually no issue, there are certain cases where it breaks the layout. So far, we handled it manually.

With Decap, we can automatically derive the context and use the correct formatting without the need to think about it. For consistency, I updated all highlight brackets to match the best option for the corresponding context.

PS: Found an outdates FR page of BDZ with an "Train de nuit" expander. I removed it in this PR.