### PR TITLE
fix: oebb inconsistencies

### DIFF
--- a/content/operator/oebb/index.en.md
+++ b/content/operator/oebb/index.en.md
@@ -230,16 +230,6 @@ FIP Tickets are not valid on ÖBB Postbus. On rail replacement buses, FIP discou
 
 {{% /train-category %}}
 
-## Class Categories
-
-Railjet(Xpress) trains have special class categories:
-
-**Economy**: Comparable to 2nd class. \
-**First Class**: Comparable to 1st class. A FIP Coupon for 1st class is required. \
-**Business**: 1st class with welcome drink and private compartments. Not usable with FIP Coupon (even with supplement).
-
-[Detailed overview of ÖBB classes](https://www.oebb.at/en/reiseplanung-services/im-zug/abteile-komfortklassen)
-
 ## Ticket and Reservation Purchase
 
 ### Online

--- a/content/operator/oebb/index.fr.md
+++ b/content/operator/oebb/index.fr.md
@@ -230,16 +230,6 @@ Les Billets FIP ne sont pas valables sur ÖBB Postbus. Dans les bus de remplacem
 
 {{% /train-category %}}
 
-## Catégories de classes
-
-Dans les Railjet(Xpress) :
-
-- **Economy** = 2ᵉ classe
-- **First Class** = 1ʳᵉ classe (nécessite un Coupon FIP 1ʳᵉ)
-- **Business** = classe 1ʳᵉ premium avec boisson de bienvenue — non valable avec FIP
-
-[Détails des classes ÖBB](https://www.oebb.at/en/reiseplanung-services/im-zug/abteile-komfortklassen)
-
 ## Achat de billets et réservations
 
 ### En ligne


### PR DESCRIPTION
We already remove the class categories on the german page, but not on the english and french one. The description of the class categories can be found in the RailJet section because it's only valid for this train category.